### PR TITLE
Make `compositor_pipeline::event` public

### DIFF
--- a/compositor_pipeline/src/lib.rs
+++ b/compositor_pipeline/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod audio_mixer;
 pub mod error;
-pub(crate) mod event;
+pub mod event;
 pub mod pipeline;
 pub mod queue;
 


### PR DESCRIPTION
Forgot about it in https://github.com/software-mansion/live-compositor/pull/800

subscribing is useless if you can't match the event type