### PR TITLE
Develop benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ target/
 
 # Assets
 **/*.mp4
+**/*.yuv
 
 # Generated MP4s
 **/*.mp4\.old\.*

--- a/integration_tests/src/bin/benchmark/args.rs
+++ b/integration_tests/src/bin/benchmark/args.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, time::Duration};
 
 use compositor_pipeline::pipeline::{self, encoder::ffmpeg_h264};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Argument {
     IterateExp,
     Maximize,
@@ -99,6 +99,104 @@ impl From<EncoderPreset> for ffmpeg_h264::EncoderPreset {
     }
 }
 
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum ResolutionPreset {
+    UHD,
+    QHD,
+    FHD,
+    HD,
+    SD,
+}
+
+impl std::str::FromStr for ResolutionPreset {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "uhd" => Ok(ResolutionPreset::UHD),
+            "qhd" => Ok(ResolutionPreset::QHD),
+            "fhd" => Ok(ResolutionPreset::FHD),
+            "hd" => Ok(ResolutionPreset::HD),
+            "sd" => Ok(ResolutionPreset::SD),
+            _ => Err(
+                "invalid resolution preset, available options: sd, hd, fhd, qhd, uhd".to_string(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ResolutionArgument {
+    Preset(ResolutionPreset),
+    Value(u32, u32),
+}
+
+impl std::str::FromStr for ResolutionArgument {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.as_bytes()
+            .get(0)
+            .ok_or("error while parsing resolution argument".to_string())?
+            .is_ascii_digit()
+        {
+            let (width, height) = s
+                .split_once("x")
+                .ok_or("invalid resolution value, should look like eg. `1920x1080`")?;
+            return Ok(ResolutionArgument::Value(
+                width.parse::<u32>().map_err(|e| format!("{e}"))?,
+                height.parse::<u32>().map_err(|e| format!("{e}"))?,
+            ));
+        } else {
+            let preset = s.parse::<ResolutionPreset>().map_err(|e| format!("{e}"))?;
+            return Ok(ResolutionArgument::Preset(preset));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Resolution {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl From<ResolutionArgument> for Resolution {
+    fn from(value: ResolutionArgument) -> Self {
+        match value {
+            ResolutionArgument::Value(width, height) => Resolution { width, height },
+            ResolutionArgument::Preset(preset) => preset.into(),
+        }
+    }
+}
+
+impl From<ResolutionPreset> for Resolution {
+    fn from(value: ResolutionPreset) -> Self {
+        match value {
+            ResolutionPreset::UHD => Resolution {
+                width: 3840,
+                height: 2160,
+            },
+            ResolutionPreset::QHD => Resolution {
+                width: 2560,
+                height: 1440,
+            },
+            ResolutionPreset::FHD => Resolution {
+                width: 1920,
+                height: 1080,
+            },
+            ResolutionPreset::HD => Resolution {
+                width: 1280,
+                height: 720,
+            },
+            ResolutionPreset::SD => Resolution {
+                width: 640,
+                height: 480,
+            },
+        }
+    }
+}
+
 /// Only one option can be set to "maximize"
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -113,11 +211,9 @@ pub struct Args {
     #[arg(long)]
     pub file_path: PathBuf,
 
+    /// [possible values: uhd, qhd, fhd, hd, sd or `<width>x<height>`]
     #[arg(long)]
-    pub output_width: u32,
-
-    #[arg(long)]
-    pub output_height: u32,
+    pub output_resolution: ResolutionArgument,
 
     #[arg(long)]
     pub encoder_preset: EncoderPreset,
@@ -150,8 +246,7 @@ impl Args {
             decoder_count: arguments[1].as_constant().unwrap(),
 
             file_path: self.file_path.clone(),
-            output_width: self.output_width,
-            output_height: self.output_height,
+            output_resolution: self.output_resolution.into(),
             warm_up_time: self.warm_up_time.0,
             measured_time: self.measured_time.0,
             video_decoder: self.video_decoder.into(),
@@ -161,12 +256,12 @@ impl Args {
     }
 }
 
+#[derive(Debug)]
 pub struct SingleBenchConfig {
     pub decoder_count: u64,
     pub framerate: u64,
     pub file_path: PathBuf,
-    pub output_width: u32,
-    pub output_height: u32,
+    pub output_resolution: Resolution,
     pub output_encoder_preset: ffmpeg_h264::EncoderPreset,
     pub warm_up_time: Duration,
     pub measured_time: Duration,
@@ -176,6 +271,7 @@ pub struct SingleBenchConfig {
 
 impl SingleBenchConfig {
     pub fn log_running_config(&self) {
+        tracing::info!("config: {:?}", self);
         tracing::info!(
             "checking configuration: framerate: {}, decoder count: {}",
             self.framerate,
@@ -186,8 +282,7 @@ impl SingleBenchConfig {
     pub fn log_as_report(&self) {
         print!("{}\t", self.decoder_count);
         print!("{}\t", self.framerate);
-        print!("{}\t", self.output_width);
-        print!("{}\t", self.output_height);
+        print!("{:?}\t", self.output_resolution);
         print!("{:?}\t", self.output_encoder_preset);
         print!("{:?}\t", self.warm_up_time);
         print!("{:?}\t", self.measured_time);

--- a/integration_tests/src/bin/benchmark/args.rs
+++ b/integration_tests/src/bin/benchmark/args.rs
@@ -262,6 +262,10 @@ pub struct Args {
     #[arg(long)]
     pub decoder_count: Argument,
 
+    /// [possible values: iterate_exp, maximize or a number]
+    #[arg(long)]
+    pub encoder_count: Argument,
+
     #[arg(long)]
     pub file_path: PathBuf,
 
@@ -291,13 +295,14 @@ pub struct Args {
 
 impl Args {
     pub fn arguments(&self) -> Box<[Argument]> {
-        vec![self.framerate, self.decoder_count].into_boxed_slice()
+        vec![self.framerate, self.decoder_count, self.encoder_count].into_boxed_slice()
     }
 
     pub fn with_arguments(&self, arguments: &[Argument]) -> SingleBenchConfig {
         SingleBenchConfig {
             framerate: arguments[0].as_constant().unwrap(),
             decoder_count: arguments[1].as_constant().unwrap(),
+            encoder_count: arguments[2].as_constant().unwrap(),
 
             file_path: self.file_path.clone(),
             output_resolution: self.output_resolution.into(),
@@ -313,6 +318,7 @@ impl Args {
 #[derive(Debug)]
 pub struct SingleBenchConfig {
     pub decoder_count: u64,
+    pub encoder_count: u64,
     pub framerate: u64,
     pub file_path: PathBuf,
     pub output_resolution: Resolution,
@@ -327,14 +333,16 @@ impl SingleBenchConfig {
     pub fn log_running_config(&self) {
         tracing::info!("config: {:?}", self);
         tracing::info!(
-            "checking configuration: framerate: {}, decoder count: {}",
+            "checking configuration: framerate: {}, decoder count: {}, encoder count: {}",
             self.framerate,
-            self.decoder_count
+            self.decoder_count,
+            self.encoder_count
         );
     }
 
     pub fn log_as_report(&self) {
         print!("{}\t", self.decoder_count);
+        print!("{}\t", self.encoder_count);
         print!("{}\t", self.framerate);
         print!("{:?}\t", self.output_resolution);
         print!("{:?}\t", self.output_encoder_preset);

--- a/integration_tests/src/bin/benchmark/args.rs
+++ b/integration_tests/src/bin/benchmark/args.rs
@@ -224,44 +224,49 @@ impl From<ResolutionPreset> for Resolution {
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
     /// [possible values: iterate_exp, maximize or a number]
-    #[arg(long)]
+    #[arg(long, default_value("24"))]
     pub framerate: Argument,
 
     /// [possible values: iterate_exp, maximize or a number]
-    #[arg(long)]
+    #[arg(long, default_value("maximize"))]
     pub input_count: Argument,
 
     /// [possible values: iterate_exp, maximize or a number]
-    #[arg(long)]
+    #[arg(long, default_value("1"))]
     pub output_count: Argument,
 
     #[arg(long)]
     pub file_path: PathBuf,
 
-    /// [possible values: uhd, qhd, fhd, hd, sd or `<width>x<height>`]
-    #[arg(long)]
+    /// [possible values: 4320p, 2160p, 1440p, 1080p, 720p, 480p, 360p, 240p, 144p or `<width>x<height>`]
+    #[arg(long, default_value("1080p"))]
     pub output_resolution: ResolutionConstant,
 
-    #[arg(long)]
+    #[arg(long, default_value("false"))]
     pub disable_encoder: bool,
 
-    #[arg(long, required_unless_present("disable_encoder"))]
+    #[arg(
+        long,
+        default_value("ultrafast"),
+        required_unless_present("disable_encoder")
+    )]
     pub encoder_preset: Option<EncoderPreset>,
 
     /// warm-up time in seconds
-    #[arg(long)]
+    #[arg(long, default_value("10"))]
     pub warm_up_time: DurationWrapper,
 
     /// measuring time in seconds
-    #[arg(long)]
+    #[arg(long, default_value("10"))]
     pub measured_time: DurationWrapper,
 
-    #[arg(long)]
+    /// [possible values: ffmpegh264, vulkan_video_h264 (if your device supports vulkan)]
+    #[arg(long, default_value("ffmpeg_h264"))]
     pub video_decoder: VideoDecoder,
 
     /// in the end of the benchmark the framerate achieved by the compositor is multiplied by this
     /// number, before comparing to the target framerate
-    #[arg(long)]
+    #[arg(long, default_value("1.05"))]
     pub framerate_tolerance: f64,
 }
 

--- a/integration_tests/src/bin/benchmark/args.rs
+++ b/integration_tests/src/bin/benchmark/args.rs
@@ -23,17 +23,14 @@ impl std::str::FromStr for NumericArgument {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "iterate" {
-            return Ok(NumericArgument::IterateExp);
+        match s {
+            "iterate" => Ok(NumericArgument::IterateExp),
+            "maximize" => Ok(NumericArgument::Maximize),
+            _ => s
+                .parse::<u64>()
+                .map(NumericArgument::Constant)
+                .map_err(|e| e.to_string()),
         }
-
-        if s == "maximize" {
-            return Ok(NumericArgument::Maximize);
-        }
-
-        s.parse::<u64>()
-            .map(NumericArgument::Constant)
-            .map_err(|e| e.to_string())
     }
 }
 
@@ -266,30 +263,28 @@ impl From<ResolutionPreset> for Resolution {
 pub enum ResolutionArgument {
     Maximize,
     Iterate,
-    Constant(ResolutionConstant),
+    Constant(Resolution),
 }
 
 impl FromStr for ResolutionArgument {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "iterate" {
-            return Ok(ResolutionArgument::Iterate);
+        match s {
+            "iterate" => Ok(ResolutionArgument::Iterate),
+            "maximize" => Ok(ResolutionArgument::Maximize),
+            _ => s
+                .parse::<ResolutionConstant>()
+                .map(Resolution::from)
+                .map(ResolutionArgument::Constant),
         }
-
-        if s == "maximize" {
-            return Ok(ResolutionArgument::Maximize);
-        }
-
-        s.parse::<ResolutionConstant>()
-            .map(ResolutionArgument::Constant)
     }
 }
 
 impl ResolutionArgument {
     pub fn as_constant(&self) -> Option<Resolution> {
         if let Self::Constant(v) = self {
-            Some((*v).into())
+            Some(*v)
         } else {
             None
         }

--- a/integration_tests/src/bin/benchmark/main.rs
+++ b/integration_tests/src/bin/benchmark/main.rs
@@ -41,8 +41,8 @@ use tracing::warn;
 mod args;
 
 use args::{
-    Args, Argument, ExpIterator, NumericArgument, ResolutionArgument, ResolutionConstant,
-    ResolutionPreset, SingleBenchConfig,
+    Args, Argument, ExpIterator, NumericArgument, ResolutionArgument, ResolutionPreset,
+    SingleBenchConfig,
 };
 
 trait PipelineReceiver {
@@ -122,9 +122,7 @@ fn run_args_iterate(
             Argument::ResolutionArgument(resolution_argument) => {
                 if matches!(resolution_argument, args::ResolutionArgument::Iterate) {
                     let iterator = ResolutionPreset::iter().map(|v| {
-                        Argument::ResolutionArgument(ResolutionArgument::Constant(
-                            ResolutionConstant::Value(v.into()),
-                        ))
+                        Argument::ResolutionArgument(ResolutionArgument::Constant(v.into()))
                     });
                     return run_fn_iterate(ctx, reports, args, i, arguments, iterator);
                 }
@@ -211,11 +209,8 @@ fn run_args_maximize(
             Argument::ResolutionArgument(resolution_argument)
                 if *resolution_argument == ResolutionArgument::Maximize =>
             {
-                let iterator = ResolutionPreset::iter().map(|v| {
-                    Argument::ResolutionArgument(ResolutionArgument::Constant(
-                        ResolutionConstant::Value(v.into()),
-                    ))
-                });
+                let iterator = ResolutionPreset::iter()
+                    .map(|v| Argument::ResolutionArgument(ResolutionArgument::Constant(v.into())));
                 for preset in iterator {
                     let mut arguments = arguments.clone();
                     arguments[i] = preset.clone();

--- a/integration_tests/src/bin/benchmark/main.rs
+++ b/integration_tests/src/bin/benchmark/main.rs
@@ -41,7 +41,7 @@ use tracing::warn;
 mod args;
 
 use args::{
-    Args, Argument, ExpIterator, NumericArgument, ResolutionArgument, ResolutionPreset,
+    Args, Argument, CsvWriter, ExpIterator, NumericArgument, ResolutionArgument, ResolutionPreset,
     SingleBenchConfig,
 };
 
@@ -78,10 +78,12 @@ fn main() {
         warn!("This benchmark is running in debug mode. Make sure to run in release mode for reliable results.");
     }
 
+    let mut csv_writer = args.csv_path.clone().map(CsvWriter::init);
+
     let reports = run_args(ctx, &args);
-    SingleBenchConfig::log_report_header();
+    SingleBenchConfig::log_report_header(&mut csv_writer);
     for report in reports {
-        report.log_as_report();
+        report.log_as_report(&mut csv_writer);
     }
 }
 


### PR DESCRIPTION
Develop more benchmark options:

- [x] resolution
  - [x] presets 
  - [x] iteration
  - [x] maximize
- [x] outputs
  - [x] iteration
  - [x] maximize
- [x] run without encoder
- [x] run without decoder
- [x] add csv export option
- [x] readable output formatting
- renamed `encoder/decoder_count` to `output/input_count` to be more meaningful

closes #937