### PR TITLE
Fix image autoregister

### DIFF
--- a/ts/smelter-core/src/api.ts
+++ b/ts/smelter-core/src/api.ts
@@ -103,11 +103,14 @@ export class ApiClient {
     });
   }
 
-  public async unregisterImage(imageRef: ImageRef): Promise<object> {
+  public async unregisterImage(
+    imageRef: ImageRef,
+    body: { schedule_time_ms?: number }
+  ): Promise<object> {
     return this.serverManager.sendRequest({
       method: 'POST',
       route: `/api/image/${encodeURIComponent(imageRefIntoRawId(imageRef))}/unregister`,
-      body: {},
+      body,
     });
   }
 

--- a/ts/smelter-core/src/live/compositor.ts
+++ b/ts/smelter-core/src/live/compositor.ts
@@ -119,7 +119,7 @@ export class Smelter {
     this.logger.info({ imageId }, 'Unregister image');
     const imageRef = { type: 'global', id: imageId } as const satisfies ImageRef;
 
-    return this.api.unregisterImage(imageRef);
+    return this.api.unregisterImage(imageRef, {});
   }
 
   public async registerWebRenderer(

--- a/ts/smelter-core/src/live/output.ts
+++ b/ts/smelter-core/src/live/output.ts
@@ -188,11 +188,14 @@ class OutputContext implements SmelterOutputContext {
     });
   }
   public async unregisterImage(imageId: number) {
-    await this.output.api.unregisterImage({
-      type: 'output-specific-image',
-      outputId: this.outputId,
-      id: imageId,
-    });
+    await this.output.api.unregisterImage(
+      {
+        type: 'output-specific-image',
+        outputId: this.outputId,
+        id: imageId,
+      },
+      {}
+    );
   }
 }
 

--- a/ts/smelter-core/src/offline/output.ts
+++ b/ts/smelter-core/src/offline/output.ts
@@ -1,4 +1,4 @@
-import type { RegisterMp4Input } from '@swmansion/smelter';
+import type { RegisterMp4Input, Renderers } from '@swmansion/smelter';
 import { _smelterInternals } from '@swmansion/smelter';
 import type { ReactElement } from 'react';
 import { createElement } from 'react';
@@ -156,7 +156,10 @@ class OutputContext implements SmelterOutputContext {
       await this.output.api.registerInput(inputRef, {
         type: 'mp4',
         offset_ms: offsetMs,
-        ...registerRequest,
+        path: registerRequest.serverPath,
+        url: registerRequest.url,
+        required: registerRequest.required,
+        video_decoder: registerRequest.videoDecoder,
       });
     this.output.internalInputStreamStore.addInput({
       inputId,
@@ -192,7 +195,7 @@ class OutputContext implements SmelterOutputContext {
       { schedule_time_ms: this.timeContext.timestampMs() }
     );
   }
-  public async registerImage(imageId: number, imageSpec: any) {
+  public async registerImage(imageId: number, imageSpec: Renderers.RegisterImage) {
     const imageRef = {
       type: 'output-specific-image',
       outputId: this.outputId,
@@ -201,17 +204,22 @@ class OutputContext implements SmelterOutputContext {
 
     await this.output.api.registerImage(imageRef, {
       url: imageSpec.url,
+      path: imageSpec.serverPath,
       asset_type: imageSpec.assetType,
     });
   }
   public async unregisterImage(imageId: number) {
-    await this.output.api.unregisterImage({
-      type: 'output-specific-image',
-      outputId: this.outputId,
-      id: imageId,
-    });
+    await this.output.api.unregisterImage(
+      {
+        type: 'output-specific-image',
+        outputId: this.outputId,
+        id: imageId,
+      },
+      { schedule_time_ms: this.timeContext.timestampMs() }
+    );
   }
 }
+
 async function waitForBlockingTasks(offlineContext: OfflineTimeContext): Promise<void> {
   while (offlineContext.isBlocked()) {
     await sleep(100);

--- a/ts/smelter/src/components/Image.ts
+++ b/ts/smelter/src/components/Image.ts
@@ -7,6 +7,7 @@ import { newInternalImageId } from '../context/internalImageIdManager.js';
 import { newBlockingTask } from '../hooks.js';
 import { SmelterContext } from '../context/index.js';
 import { isValidImageType } from '../types/utils.js';
+import type { RegisterImage } from '../types/registerRenderer.js';
 
 export type ImageProps = Omit<ComponentBaseProps, 'children'> &
   (
@@ -41,12 +42,10 @@ function Image(props: ImageProps) {
     setIsImageRegistered(false);
 
     const newImageId = newInternalImageId();
-    setInternalImageId(newImageId);
-    const task = newBlockingTask(ctx);
-    const pathOrUrl =
+    const pathOrUrl: Pick<RegisterImage, 'serverPath' | 'url'> =
       props.source?.startsWith('http://') || props.source?.startsWith('https://')
         ? { url: props.source }
-        : { path: props.source };
+        : { serverPath: props.source };
     const extension = props.source?.split('.').pop();
     const assetType = extension && isValidImageType(extension) ? extension : undefined;
 
@@ -56,6 +55,8 @@ function Image(props: ImageProps) {
       throw new Error('Unsupported image type');
     }
 
+    const task = newBlockingTask(ctx);
+    setInternalImageId(newImageId);
     void (async () => {
       try {
         registerPromise = ctx.registerImage(newImageId, {

--- a/ts/smelter/src/components/Mp4.ts
+++ b/ts/smelter/src/components/Mp4.ts
@@ -6,6 +6,7 @@ import { InnerInputStream } from './InputStream.js';
 import { newInternalStreamId } from '../context/internalStreamIdManager.js';
 import type { ComponentBaseProps } from '../component.js';
 import { useTimeLimitedComponent } from '../context/childrenLifetimeContext.js';
+import type { RegisterMp4Input } from '../types/registerInput.js';
 
 export type Mp4Props = Omit<ComponentBaseProps, 'children'> & {
   /**
@@ -31,13 +32,13 @@ function Mp4(props: Mp4Props) {
   useEffect(() => {
     const newInputId = newInternalStreamId();
     setInputId(newInputId);
-    const task = newBlockingTask(ctx);
-    const pathOrUrl =
+    const pathOrUrl: Pick<RegisterMp4Input, 'url' | 'serverPath'> =
       props.source.startsWith('http://') || props.source.startsWith('https://')
         ? { url: props.source }
-        : { path: props.source };
+        : { serverPath: props.source };
     let registerPromise: Promise<any>;
 
+    const task = newBlockingTask(ctx);
     void (async () => {
       try {
         registerPromise = ctx.registerMp4Input(newInputId, {


### PR DESCRIPTION
- The rust server did not support scheduling image unregister which is necessary for the offline cases (or we could skip unregisters entirely)
- path field was not passed through the request
- Types for Mp4 and Image request were incorrect (as a fix I changed values to match, not types)
- Move `newBlocikngTask` just before the try-catch (if an exception would throw on asset type it would block rendering indefinitely

Tested on meetup example