### PR TITLE
[web-wasm] Ensure wasm module is loaded only once

### DIFF
--- a/ts/smelter-browser-render/src/wasm.ts
+++ b/ts/smelter-browser-render/src/wasm.ts
@@ -4,8 +4,17 @@ import init, * as wasm from './generated/smelter/compositor_web';
  * Loads and initializes wasm module required for the smelter to work.
  * @param wasmModuleUrl {string} - An URL for `smelter.wasm` file. The file is located in `dist` folder.
  */
-export async function loadWasmModule(wasmModuleUrl: string) {
-  await init({ module_or_path: wasmModuleUrl });
-}
+export const loadWasmModule = (() => {
+  let loadResult: Promise<wasm.InitOutput> | undefined = undefined;
+  return async (wasmModuleUrl: string) => {
+    if (loadResult) {
+      await loadResult;
+      return;
+    }
+
+    loadResult = init({ module_or_path: wasmModuleUrl });
+    await loadResult;
+  };
+})();
 
 export { wasm };


### PR DESCRIPTION
It's a potential fix for https://github.com/software-mansion/smelter/issues/874

When wasm module is loaded more than once it can override the wasm's internals. I tested it on `wgpu 24.0.1`  MacOS / Linux and it seems to be working