### PR TITLE
[ts-sdk] Recalculate input streams in the same timestamp

### DIFF
--- a/ts/smelter/src/context/inputStreamStore.ts
+++ b/ts/smelter/src/context/inputStreamStore.ts
@@ -153,17 +153,20 @@ type OfflineAddInput<Id> = {
 };
 
 export class OfflineInputStreamStore<Id> {
+  private lastTimestamp: number = 0;
   private context: InstanceContext<Id> = {};
   private inputs: OfflineAddInput<Id>[] = [];
   private onChangeCallbacks: Set<() => void> = new Set();
 
   public addInput(update: OfflineAddInput<Id>) {
     this.inputs.push(update);
+    this.setCurrentTimestamp(this.lastTimestamp);
   }
 
   // TimeContext should call that function. It will always trigger re-render, but there
   // is no point to optimize it right now.
   public setCurrentTimestamp(timestampMs: number) {
+    this.lastTimestamp = timestampMs;
     this.context = Object.fromEntries(
       this.inputs
         .filter(input => timestampMs >= input.offsetMs)


### PR DESCRIPTION
new input lifetime is registered on the next timestamp, so event though mp4 is rendered correctly it's timeout is not reported until next timestamp.