### PR TITLE
Pass framerate to the encoder when it's being created.

### DIFF
--- a/compositor_pipeline/src/pipeline/encoder.rs
+++ b/compositor_pipeline/src/pipeline/encoder.rs
@@ -1,4 +1,4 @@
-use compositor_render::{Frame, OutputId, Resolution};
+use compositor_render::{Frame, Framerate, OutputId, Resolution};
 use crossbeam_channel::{bounded, Receiver, Sender};
 use fdk_aac::AacEncoder;
 use log::error;
@@ -60,6 +60,7 @@ impl Encoder {
     pub fn new(
         output_id: &OutputId,
         options: EncoderOptions,
+        framerate: Framerate,
         sample_rate: u32,
     ) -> Result<(Self, Receiver<EncoderOutputEvent>), EncoderInitError> {
         let (encoded_chunks_sender, encoded_chunks_receiver) = bounded(1);
@@ -68,6 +69,7 @@ impl Encoder {
             Some(video_encoder_options) => Some(VideoEncoder::new(
                 output_id,
                 video_encoder_options,
+                framerate,
                 encoded_chunks_sender.clone(),
             )?),
             None => None,
@@ -135,11 +137,12 @@ impl VideoEncoder {
     pub fn new(
         output_id: &OutputId,
         options: VideoEncoderOptions,
+        framerate: Framerate,
         sender: Sender<EncoderOutputEvent>,
     ) -> Result<Self, EncoderInitError> {
         match options {
             VideoEncoderOptions::H264(options) => Ok(Self::H264(LibavH264Encoder::new(
-                output_id, options, sender,
+                output_id, options, framerate, sender,
             )?)),
         }
     }

--- a/compositor_pipeline/src/pipeline/output.rs
+++ b/compositor_pipeline/src/pipeline/output.rs
@@ -107,8 +107,13 @@ impl OutputOptionsExt<Option<Port>> for OutputOptions {
             audio: self.audio.clone(),
         };
 
-        let (encoder, packets) = Encoder::new(output_id, encoder_opts, ctx.mixing_sample_rate)
-            .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
+        let (encoder, packets) = Encoder::new(
+            output_id,
+            encoder_opts,
+            ctx.output_framerate,
+            ctx.mixing_sample_rate,
+        )
+        .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
 
         match &self.output_protocol {
             OutputProtocolOptions::Rtp(rtp_options) => {
@@ -151,8 +156,13 @@ impl OutputOptionsExt<Receiver<EncoderOutputEvent>> for EncodedDataOutputOptions
             audio: self.audio.clone(),
         };
 
-        let (encoder, packets) = Encoder::new(output_id, encoder_opts, ctx.mixing_sample_rate)
-            .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
+        let (encoder, packets) = Encoder::new(
+            output_id,
+            encoder_opts,
+            ctx.output_framerate,
+            ctx.mixing_sample_rate,
+        )
+        .map_err(|e| RegisterOutputError::EncoderError(output_id.clone(), e))?;
 
         Ok((Output::EncodedData { encoder }, packets))
     }


### PR DESCRIPTION
This removes the annoying ffmpeg warning that usually shows up about MB rate being higher than level limit.