### PR TITLE
[ts-sdk] Make shaders work on web

### DIFF
--- a/compositor_render/src/transformations/shader/validation.rs
+++ b/compositor_render/src/transformations/shader/validation.rs
@@ -10,8 +10,12 @@ use error::{
 };
 
 pub fn shader_header() -> Module {
-    naga::front::wgsl::parse_str(include_str!("./validation/shader_header.wgsl"))
-        .expect("failed to parse the shader header file")
+    let header_code = match cfg!(target_arch = "wasm32") {
+        false => include_str!("./validation/shader_header.wgsl"),
+        true => include_str!("./validation/shader_header_web.wgsl"),
+    };
+
+    naga::front::wgsl::parse_str(header_code).expect("failed to parse the shader header file")
 }
 
 pub(super) fn validate_contains_header(

--- a/compositor_render/src/transformations/shader/validation/shader_header_web.wgsl
+++ b/compositor_render/src/transformations/shader/validation/shader_header_web.wgsl
@@ -1,0 +1,16 @@
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+}
+
+struct BaseShaderParameters {
+    plane_id: i32,
+    time: f32,
+    output_resolution: vec2<u32>,
+    texture_count: u32,
+}
+
+@group(0) @binding(0) var texture: texture_2d<f32>;
+@group(2) @binding(0) var sampler_: sampler;
+
+var<push_constant> base_params: BaseShaderParameters;

--- a/compositor_web/src/wasm/renderer.rs
+++ b/compositor_web/src/wasm/renderer.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use compositor_api::types as api;
 use compositor_render::{
-    image::ImageSpec, InputId, OutputFrameFormat, OutputId, RegistryType, RendererId,
-    RendererOptions, RendererSpec,
+    image::ImageSpec, shader::ShaderSpec, InputId, OutputFrameFormat, OutputId, RegistryType,
+    RendererId, RendererOptions, RendererSpec,
 };
 use glyphon::fontdb::Source;
 use wasm_bindgen::JsValue;
@@ -69,14 +69,13 @@ impl Renderer {
         self.renderer.register_input(InputId(input_id.into()));
     }
 
-    pub async fn register_image(
+    pub async fn register_renderer(
         &mut self,
         renderer_id: String,
-        image_spec: ImageSpec,
+        spec: RendererSpec,
     ) -> Result<(), JsValue> {
-        let renderer_spec = RendererSpec::Image(image_spec);
         self.renderer
-            .register_renderer(RendererId(renderer_id.into()), renderer_spec)
+            .register_renderer(RendererId(renderer_id.into()), spec)
             .map_err(types::to_js_error)
     }
 
@@ -96,9 +95,13 @@ impl Renderer {
         self.output_downloader.remove_output(&output_id);
     }
 
-    pub fn unregister_image(&mut self, renderer_id: String) -> Result<(), JsValue> {
+    pub fn unregister_renderer(
+        &mut self,
+        renderer_id: String,
+        registry: RegistryType,
+    ) -> Result<(), JsValue> {
         self.renderer
-            .unregister_renderer(&RendererId(renderer_id.into()), RegistryType::Image)
+            .unregister_renderer(&RendererId(renderer_id.into()), registry)
             .map_err(types::to_js_error)
     }
 }

--- a/compositor_web/src/wasm/types.rs
+++ b/compositor_web/src/wasm/types.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use compositor_render::{web_renderer::WebRendererInitOptions, InputId, Resolution};
+use compositor_render::{
+    error::ErrorStack, web_renderer::WebRendererInitOptions, InputId, Resolution,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
@@ -130,8 +132,9 @@ pub fn from_js_value<T: DeserializeOwned>(value: JsValue) -> Result<T, JsValue> 
     serde_wasm_bindgen::from_value(value).map_err(to_js_error)
 }
 
-pub fn to_js_error(error: impl std::error::Error) -> JsValue {
-    JsValue::from_str(&error.to_string())
+pub fn to_js_error(error: impl std::error::Error + 'static) -> JsValue {
+    let error_stack = ErrorStack::new(&error);
+    JsValue::from_str(&error_stack.into_string())
 }
 
 trait JsValueExt {

--- a/ts/examples/vite-example/src/App.tsx
+++ b/ts/examples/vite-example/src/App.tsx
@@ -12,6 +12,7 @@ import DemoExample from './smelter-examples/Demo';
 import MultipleOutputs from './smelter-examples/MultipleOutputs';
 import MediaStreamInput from './smelter-examples/MediaStreamExample';
 import DynamicExample from './smelter-examples/playground/PlaygroundPage';
+import ShaderExample from './smelter-examples/ShaderExample';
 
 setWasmBundleUrl('/assets/smelter.wasm');
 
@@ -26,6 +27,7 @@ function App() {
     camera: <Camera />,
     screenCapture: <ScreenCapture />,
     mediaStream: <MediaStreamInput />,
+    shader: <ShaderExample />,
     home: <Home />,
     demo: <DemoExample />,
     playground: <DynamicExample />,
@@ -52,6 +54,7 @@ function App() {
         <button onClick={() => setCurrentExample('camera')}>Camera</button>
         <button onClick={() => setCurrentExample('screenCapture')}>Screen Capture</button>
         <button onClick={() => setCurrentExample('mediaStream')}>MediaStream</button>
+        <button onClick={() => setCurrentExample('shader')}>Shader</button>
 
         <h3>Smelter rendering engine examples</h3>
         <button onClick={() => setCurrentExample('counter')}>Counter</button>
@@ -107,6 +110,9 @@ function Home() {
       <li>
         <code>MediaStream</code> - Pass MediaStream object as an input. In this example it will be
         camera.
+      </li>
+      <li>
+        <code>Shader</code> - Render video with a custom shader effect.
       </li>
       <h3>
         <code>@swmansion/smelter-browser-render</code> - Rendering engine from Smelter

--- a/ts/examples/vite-example/src/smelter-examples/ShaderExample.tsx
+++ b/ts/examples/vite-example/src/smelter-examples/ShaderExample.tsx
@@ -1,0 +1,95 @@
+import { Mp4, Shader } from '@swmansion/smelter';
+import SmelterCanvasOutput from '../components/SmelterCanvasOutput';
+import { useEffect } from 'react';
+import { useSmelter } from '../hooks/useSmelter';
+
+const EXAMPLE_SHADER = `
+struct VertexInput {
+    @location(0) position: vec3<f32>,
+    @location(1) tex_coords: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tex_coords: vec2<f32>,
+}
+
+@vertex
+fn vs_main(input: VertexInput) -> VertexOutput {
+    var output: VertexOutput;
+
+    output.position = vec4(input.position, 1.0);
+    output.tex_coords = input.tex_coords;
+
+    return output;
+}
+
+struct BaseShaderParameters {
+    plane_id: i32,
+    time: f32,
+    output_resolution: vec2<u32>,
+    texture_count: u32,
+}
+
+@group(0) @binding(0) var texture: texture_2d<f32>;
+@group(2) @binding(0) var sampler_: sampler;
+
+var<push_constant> base_params: BaseShaderParameters;
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+  // Return transparent frame in case of different input video count
+  if (base_params.texture_count != 1u) {
+      return vec4(0.0, 0.0, 0.0, 0.0);
+  }
+
+  let pi = 3.14159;
+  let effect_radius = abs(sin(base_params.time) / 2.0);
+  let effect_angle = 2.0 * pi * abs(sin(base_params.time) / 2.0);
+
+  let center = vec2(0.5, 0.5);
+  let uv = input.tex_coords - center;
+
+  let len = length(uv);
+  let angle = atan2(uv.y, uv.x) + effect_angle * smoothstep(effect_radius, 0.0, len);
+  let coords = vec2(len * cos(angle), len * sin(angle)) + center;
+
+  return textureSample(texture, sampler_, coords);
+}
+`;
+
+const MP4_URL =
+  'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4';
+
+function ShaderExample() {
+  const smelter = useSmelter();
+  useEffect(() => {
+    if (!smelter) {
+      return;
+    }
+
+    void smelter.registerShader('example_shader', {
+      source: EXAMPLE_SHADER,
+    });
+  }, [smelter]);
+
+  return (
+    <div className="card">
+      {smelter && (
+        <SmelterCanvasOutput smelter={smelter} width={1280} height={720}>
+          <Scene />
+        </SmelterCanvasOutput>
+      )}
+    </div>
+  );
+}
+
+function Scene() {
+  return (
+    <Shader shaderId="example_shader" resolution={{ width: 1280, height: 720 }}>
+      <Mp4 source={MP4_URL} />
+    </Shader>
+  );
+}
+
+export default ShaderExample;

--- a/ts/smelter-browser-render/src/api.ts
+++ b/ts/smelter-browser-render/src/api.ts
@@ -2,6 +2,7 @@ import type { Api } from '@swmansion/smelter';
 
 export type Resolution = Api.Resolution;
 export type ImageSpec = Required<Pick<Api.ImageSpec, 'asset_type' | 'url'>>;
+export type ShaderSpec = Api.ShaderSpec;
 export type Component = Extract<
   Api.Component,
   { type: 'input_stream' | 'view' | 'rescaler' | 'image' | 'text' | 'tiles' }

--- a/ts/smelter-browser-render/src/renderer.ts
+++ b/ts/smelter-browser-render/src/renderer.ts
@@ -63,6 +63,10 @@ export class Renderer {
     await this.renderer.register_image(rendererId, imageSpec);
   }
 
+  public async registerShader(rendererId: Api.RendererId, shaderSpec: Api.ShaderSpec) {
+    await this.renderer.register_shader(rendererId, shaderSpec);
+  }
+
   public async registerFont(fontUrl: string) {
     await this.renderer.register_font(fontUrl);
   }
@@ -73,6 +77,10 @@ export class Renderer {
 
   public unregisterImage(rendererId: Api.RendererId) {
     this.renderer.unregister_image(rendererId);
+  }
+
+  public unregisterShader(rendererId: Api.RendererId) {
+    this.renderer.unregister_shader(rendererId);
   }
 
   public unregisterOutput(outputId: Api.OutputId) {

--- a/ts/smelter-web-wasm/src/compositor/api.ts
+++ b/ts/smelter-web-wasm/src/compositor/api.ts
@@ -3,6 +3,8 @@ import type { Api, Renderers } from '@swmansion/smelter';
 
 export type RegisterImage = Required<Pick<Renderers.RegisterImage, 'assetType' | 'url'>>;
 
+export type RegisterShader = Renderers.RegisterShader;
+
 export type RegisterOutput =
   | {
       type: 'stream';

--- a/ts/smelter-web-wasm/src/compositor/compositor.ts
+++ b/ts/smelter-web-wasm/src/compositor/compositor.ts
@@ -7,6 +7,7 @@ import {
   type RegisterOutput,
   type RegisterInput,
   type RegisterImage,
+  type RegisterShader,
   intoRegisterOutputRequest,
 } from './api';
 import WasmInstance from '../mainContext/instance';
@@ -103,6 +104,11 @@ export default class Smelter {
   public async registerImage(imageId: string, request: RegisterImage): Promise<void> {
     assert(this.coreSmelter);
     await this.coreSmelter.registerImage(imageId, request);
+  }
+
+  public async registerShader(shaderId: string, shaderSpec: RegisterShader): Promise<void> {
+    assert(this.coreSmelter);
+    await this.coreSmelter.registerShader(shaderId, shaderSpec);
   }
 
   public async unregisterImage(imageId: string): Promise<void> {

--- a/ts/smelter-web-wasm/src/workerApi.ts
+++ b/ts/smelter-web-wasm/src/workerApi.ts
@@ -1,5 +1,5 @@
 import type { _smelterInternals, Api } from '@swmansion/smelter';
-import type { ImageSpec, Resolution } from '@swmansion/smelter-browser-render';
+import type { ImageSpec, Resolution, ShaderSpec } from '@swmansion/smelter-browser-render';
 import type { Framerate } from './compositor/compositor';
 
 export type RegisterInput =
@@ -64,6 +64,15 @@ export type WorkerMessage =
   | {
       type: 'unregisterImage';
       imageId: string;
+    }
+  | {
+      type: 'registerShader';
+      shaderId: string;
+      shader: ShaderSpec;
+    }
+  | {
+      type: 'unregisterShader';
+      shaderId: string;
     }
   | {
       type: 'registerFont';

--- a/ts/smelter-web-wasm/src/workerContext/pipeline.ts
+++ b/ts/smelter-web-wasm/src/workerContext/pipeline.ts
@@ -1,4 +1,4 @@
-import type { Component, ImageSpec, Renderer } from '@swmansion/smelter-browser-render';
+import type { Component, ShaderSpec, ImageSpec, Renderer } from '@swmansion/smelter-browser-render';
 import type { Framerate } from '../compositor/compositor';
 import type { Logger } from 'pino';
 import type { Api } from '@swmansion/smelter';
@@ -109,6 +109,14 @@ export class Pipeline {
 
   public unregisterImage(imageId: string) {
     this.renderer.unregisterImage(imageId);
+  }
+
+  public async registerShader(shaderId: string, request: ShaderSpec) {
+    await this.renderer.registerShader(shaderId, request);
+  }
+
+  public unregisterShader(shaderId: string) {
+    this.renderer.unregisterShader(shaderId);
   }
 
   public async registerFont(url: string): Promise<void> {

--- a/ts/smelter-web-wasm/src/workerContext/runWorker.ts
+++ b/ts/smelter-web-wasm/src/workerContext/runWorker.ts
@@ -30,12 +30,16 @@ registerWorkerEntrypoint<WorkerMessage, WorkerResponse>(
       return instance.registerOutput(request.outputId, request.output);
     } else if (request.type === 'registerImage') {
       return await instance.registerImage(request.imageId, request.image);
+    } else if (request.type === 'registerShader') {
+      return await instance.registerShader(request.shaderId, request.shader);
     } else if (request.type === 'unregisterInput') {
       return await instance.unregisterInput(request.inputId);
     } else if (request.type === 'unregisterOutput') {
       return await instance.unregisterOutput(request.outputId);
     } else if (request.type === 'unregisterImage') {
       return instance.unregisterImage(request.imageId);
+    } else if (request.type === 'unregisterShader') {
+      return instance.unregisterShader(request.shaderId);
     } else if (request.type === 'updateScene') {
       return instance.updateScene(request.outputId, request.output);
     } else if (request.type === 'registerFont') {


### PR DESCRIPTION
Shaders on web have to be slightly different from the native version, because we can't use `binding_array` on web.
Due to those limitations, on the web, we'll only allow one texture to be passed to the user shader

Closes: #701 