### PR TITLE
Fix web renderer crashing when multiple Smelter instances are run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix web renderer crashing when multiple Smelter instances are run. ([#1016](https://github.com/software-mansion/smelter/pull/1016) by [@noituri](https://github.com/noituri))
+
 ### 🔧 Others
 
 ## [v0.4.1](https://github.com/software-mansion/live-compositor/releases/tag/v0.4.1)

--- a/compositor_chromium/src/settings.rs
+++ b/compositor_chromium/src/settings.rs
@@ -1,4 +1,4 @@
-use std::{env, os::raw::c_int};
+use std::{env, os::raw::c_int, path::PathBuf};
 
 use chromium_sys::_cef_string_utf16_t;
 
@@ -9,6 +9,8 @@ pub const PROCESS_HELPER_PATH_ENV: &str = "SMELTER_PROCESS_HELPER_PATH";
 /// Main process settings
 #[derive(Default)]
 pub struct Settings {
+    /// Path to root directory of CEF cache. The path should be unique for each running instance.
+    pub root_cache_path: PathBuf,
     /// If set to `true` message loop can run on a separate thread. **Not supported by MacOS**
     pub multi_threaded_message_loop: bool,
     /// If set to `true` it makes it possible to control message pump scheduling.
@@ -38,7 +40,7 @@ impl Settings {
             windowless_rendering_enabled: self.windowless_rendering_enabled as c_int,
             command_line_args_disabled: false as c_int,
             cache_path: CefString::empty_raw(),
-            root_cache_path: CefString::empty_raw(),
+            root_cache_path: CefString::new_raw(self.root_cache_path.display().to_string()),
             persist_session_cookies: false as c_int,
             user_agent: CefString::empty_raw(),
             user_agent_product: CefString::empty_raw(),

--- a/compositor_render/src/transformations/web_renderer.rs
+++ b/compositor_render/src/transformations/web_renderer.rs
@@ -11,6 +11,7 @@ mod renderer;
 mod renderer;
 
 mod tranformation_matrices;
+mod utils;
 
 pub use renderer::*;
 

--- a/compositor_render/src/transformations/web_renderer/chromium_context.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_context.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     event_loop::{EventLoop, EventLoopRunError},
+    transformations::web_renderer::utils,
     types::Framerate,
     utils::random_string,
 };
@@ -54,6 +55,8 @@ impl ChromiumContext {
                 enable_gpu: opts.enable_gpu,
             };
             let settings = cef::Settings {
+                root_cache_path: utils::get_smelter_instance_tmp_path(&instance_id)
+                    .join("cef_cache"),
                 windowless_rendering_enabled: true,
                 log_severity: cef::LogSeverity::Info,
                 ..Default::default()

--- a/compositor_render/src/transformations/web_renderer/chromium_sender_thread.rs
+++ b/compositor_render/src/transformations/web_renderer/chromium_sender_thread.rs
@@ -15,12 +15,12 @@ use crate::transformations::web_renderer::chromium_sender::{
     ChromiumSenderMessage, UpdateSharedMemoryInfo,
 };
 use crate::transformations::web_renderer::shared_memory::{SharedMemory, SharedMemoryError};
-use crate::transformations::web_renderer::{WebRenderer, UNEMBED_SOURCE_FRAMES_MESSAGE};
+use crate::transformations::web_renderer::UNEMBED_SOURCE_FRAMES_MESSAGE;
 use crate::wgpu::texture::utils::pad_to_256;
 use crate::{RendererId, Resolution};
 
 use super::{browser_client::BrowserClient, chromium_context::ChromiumContext};
-use super::{WebRendererSpec, EMBED_SOURCE_FRAMES_MESSAGE, GET_FRAME_POSITIONS_MESSAGE};
+use super::{utils, WebRendererSpec, EMBED_SOURCE_FRAMES_MESSAGE, GET_FRAME_POSITIONS_MESSAGE};
 
 pub(super) struct ChromiumSenderThread {
     chromium_ctx: Arc<ChromiumContext>,
@@ -231,7 +231,7 @@ impl Drop for ThreadState {
 impl ThreadState {
     fn new(browser: cef::Browser, compositor_id: &str, web_renderer_id: &RendererId) -> Self {
         let shared_memory_root_path =
-            WebRenderer::shared_memory_root_path(compositor_id, &web_renderer_id.to_string());
+            utils::get_smelter_instance_tmp_path(compositor_id).join(web_renderer_id.to_string());
         let shared_memory = Vec::new();
 
         Self {

--- a/compositor_render/src/transformations/web_renderer/renderer.rs
+++ b/compositor_render/src/transformations/web_renderer/renderer.rs
@@ -1,8 +1,4 @@
-use std::{
-    env,
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use log::info;
@@ -141,13 +137,6 @@ impl WebRenderer {
 
     pub fn resolution(&self) -> Resolution {
         self.spec.resolution
-    }
-
-    pub fn shared_memory_root_path(compositor_instance_id: &str, web_renderer_id: &str) -> PathBuf {
-        env::temp_dir()
-            .join("smelter")
-            .join(format!("instance_{compositor_instance_id}"))
-            .join(web_renderer_id)
     }
 }
 

--- a/compositor_render/src/transformations/web_renderer/utils.rs
+++ b/compositor_render/src/transformations/web_renderer/utils.rs
@@ -1,0 +1,7 @@
+use std::{env, path::PathBuf};
+
+pub fn get_smelter_instance_tmp_path(compositor_instance_id: &str) -> PathBuf {
+    env::temp_dir()
+        .join("smelter")
+        .join(format!("instance_{compositor_instance_id}"))
+}


### PR DESCRIPTION
When two instances of smelter share the same CEF `root_cache_path`, one instance becomes the main browser window, and the other acts as an opened "tab" in that browser. We don't handle that case at all, hence the crash. Fixed it by giving each instance a unique `root_cache_path` so now each instance works independently. 


Fixes: #1014 