### PR TITLE
Prevent decoder from resetting PTS, add flag `send_eos`

### DIFF
--- a/compositor_pipeline/src/pipeline/decoder/audio.rs
+++ b/compositor_pipeline/src/pipeline/decoder/audio.rs
@@ -118,6 +118,7 @@ pub fn start_audio_decoder_thread(
     chunks_receiver: Receiver<PipelineEvent<EncodedChunk>>,
     samples_sender: Sender<PipelineEvent<InputSamples>>,
     input_id: InputId,
+    send_eos: bool,
 ) -> Result<(), InputInitError> {
     let (init_result_sender, init_result_receiver) = bounded(0);
     std::thread::Builder::new()
@@ -145,7 +146,7 @@ pub fn start_audio_decoder_thread(
                 init_result_sender,
             );
 
-            if samples_sender.send(PipelineEvent::EOS).is_err() {
+            if send_eos && samples_sender.send(PipelineEvent::EOS).is_err() {
                 debug!("Failed to send EOS message.")
             }
         })

--- a/compositor_pipeline/src/pipeline/decoder/video.rs
+++ b/compositor_pipeline/src/pipeline/decoder/video.rs
@@ -20,6 +20,7 @@ pub fn start_video_decoder_thread(
     chunks_receiver: Receiver<PipelineEvent<EncodedChunk>>,
     frame_sender: Sender<PipelineEvent<Frame>>,
     input_id: InputId,
+    send_eos: bool,
 ) -> Result<(), InputInitError> {
     match options.decoder {
         VideoDecoder::FFmpegH264 => ffmpeg_h264::start_ffmpeg_decoder_thread(
@@ -27,6 +28,7 @@ pub fn start_video_decoder_thread(
             chunks_receiver,
             frame_sender,
             input_id,
+            send_eos,
         ),
 
         VideoDecoder::FFmpegVp8 => ffmpeg_vp8::start_ffmpeg_decoder_thread(
@@ -34,6 +36,7 @@ pub fn start_video_decoder_thread(
             chunks_receiver,
             frame_sender,
             input_id,
+            send_eos,
         ),
 
         #[cfg(feature = "vk-video")]
@@ -42,6 +45,7 @@ pub fn start_video_decoder_thread(
             chunks_receiver,
             frame_sender,
             input_id,
+            send_eos,
         ),
     }
 }

--- a/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_h264.rs
+++ b/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_h264.rs
@@ -25,6 +25,7 @@ pub fn start_ffmpeg_decoder_thread(
     chunks_receiver: Receiver<PipelineEvent<EncodedChunk>>,
     frame_sender: Sender<PipelineEvent<Frame>>,
     input_id: InputId,
+    send_eos: bool,
 ) -> Result<(), InputInitError> {
     let (init_result_sender, init_result_receiver) = crossbeam_channel::bounded(0);
 
@@ -50,6 +51,7 @@ pub fn start_ffmpeg_decoder_thread(
                 init_result_sender,
                 chunks_receiver,
                 frame_sender,
+                send_eos,
             )
         })
         .unwrap();
@@ -72,6 +74,7 @@ fn run_decoder_thread(
     init_result_sender: Sender<Result<(), InputInitError>>,
     chunks_receiver: Receiver<PipelineEvent<EncodedChunk>>,
     frame_sender: Sender<PipelineEvent<Frame>>,
+    send_eos: bool,
 ) {
     let decoder = Context::from_parameters(parameters.clone())
         .map_err(InputInitError::FfmpegError)
@@ -148,7 +151,7 @@ fn run_decoder_thread(
             }
         }
     }
-    if frame_sender.send(PipelineEvent::EOS).is_err() {
+    if send_eos && frame_sender.send(PipelineEvent::EOS).is_err() {
         debug!("Failed to send EOS from H264 decoder. Channel closed.")
     }
 }
@@ -179,15 +182,9 @@ fn frame_from_av(
     decoded: &mut Video,
     pts_offset: &mut Option<i64>,
 ) -> Result<Frame, DecoderFrameConversionError> {
-    let original_pts = decoded.pts();
-    if let (Some(pts), None) = (decoded.pts(), &pts_offset) {
-        *pts_offset = Some(-pts)
-    }
-    let pts = original_pts
-        .map(|original_pts| original_pts + pts_offset.unwrap_or(0))
-        .ok_or_else(|| {
-            DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
-        })?;
+    let pts = decoded.pts().ok_or_else(|| {
+        DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
+    })?;
     if pts < 0 {
         error!(pts, pts_offset, "Received negative PTS. PTS values of the decoder output are not monotonically increasing.")
     }

--- a/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_h264.rs
+++ b/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_h264.rs
@@ -182,9 +182,11 @@ fn frame_from_av(
     decoded: &mut Video,
     pts_offset: &mut Option<i64>,
 ) -> Result<Frame, DecoderFrameConversionError> {
-    let pts = decoded.pts().ok_or_else(|| {
-        DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
-    })?;
+    let Some(pts) = decoded.pts() else {
+        return Err(DecoderFrameConversionError::FrameConversionError(
+            "missing pts".to_owned(),
+        ));
+    };
     if pts < 0 {
         error!(pts, pts_offset, "Received negative PTS. PTS values of the decoder output are not monotonically increasing.")
     }

--- a/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_vp8.rs
+++ b/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_vp8.rs
@@ -25,6 +25,7 @@ pub fn start_ffmpeg_decoder_thread(
     chunks_receiver: Receiver<PipelineEvent<EncodedChunk>>,
     frame_sender: Sender<PipelineEvent<Frame>>,
     input_id: InputId,
+    send_eos: bool,
 ) -> Result<(), InputInitError> {
     let (init_result_sender, init_result_receiver) = crossbeam_channel::bounded(0);
 
@@ -46,6 +47,7 @@ pub fn start_ffmpeg_decoder_thread(
                 init_result_sender,
                 chunks_receiver,
                 frame_sender,
+                send_eos,
             )
         })
         .unwrap();
@@ -68,6 +70,7 @@ fn run_decoder_thread(
     init_result_sender: Sender<Result<(), InputInitError>>,
     chunks_receiver: Receiver<PipelineEvent<EncodedChunk>>,
     frame_sender: Sender<PipelineEvent<Frame>>,
+    send_eos: bool,
 ) {
     let decoder = Context::from_parameters(parameters.clone())
         .map_err(InputInitError::FfmpegError)
@@ -141,7 +144,7 @@ fn run_decoder_thread(
             }
         }
     }
-    if frame_sender.send(PipelineEvent::EOS).is_err() {
+    if send_eos && frame_sender.send(PipelineEvent::EOS).is_err() {
         debug!("Failed to send EOS from VP8 decoder. Channel closed.")
     }
 }
@@ -172,15 +175,9 @@ fn frame_from_av(
     decoded: &mut Video,
     pts_offset: &mut Option<i64>,
 ) -> Result<Frame, DecoderFrameConversionError> {
-    let original_pts = decoded.pts();
-    if let (Some(pts), None) = (decoded.pts(), &pts_offset) {
-        *pts_offset = Some(-pts)
-    }
-    let pts = original_pts
-        .map(|original_pts| original_pts + pts_offset.unwrap_or(0))
-        .ok_or_else(|| {
-            DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
-        })?;
+    let pts = decoded.pts().ok_or_else(|| {
+        DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
+    })?;
     if pts < 0 {
         error!(pts, pts_offset, "Received negative PTS. PTS values of the decoder output are not monotonically increasing.")
     }

--- a/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_vp8.rs
+++ b/compositor_pipeline/src/pipeline/decoder/video/ffmpeg_vp8.rs
@@ -175,9 +175,11 @@ fn frame_from_av(
     decoded: &mut Video,
     pts_offset: &mut Option<i64>,
 ) -> Result<Frame, DecoderFrameConversionError> {
-    let pts = decoded.pts().ok_or_else(|| {
-        DecoderFrameConversionError::FrameConversionError("missing pts".to_owned())
-    })?;
+    let Some(pts) = decoded.pts() else {
+        return Err(DecoderFrameConversionError::FrameConversionError(
+            "missing pts".to_owned(),
+        ));
+    };
     if pts < 0 {
         error!(pts, pts_offset, "Received negative PTS. PTS values of the decoder output are not monotonically increasing.")
     }

--- a/compositor_pipeline/src/pipeline/input.rs
+++ b/compositor_pipeline/src/pipeline/input.rs
@@ -184,6 +184,7 @@ fn start_input_threads(
                     chunk_receiver,
                     sender,
                     input_id.clone(),
+                    true,
                 )?;
                 Some(receiver)
             }
@@ -219,6 +220,7 @@ fn start_input_threads(
                     chunk_receiver,
                     sender,
                     input_id.clone(),
+                    true,
                 )?;
                 Some(receiver)
             }


### PR DESCRIPTION
 - Prevent resetting pts to zero in audio and video decoder.
 - Add a send_eos flag, allowing control over whether eos is sent to the queue. This is needed for WHIP input to be able to reconnect to the same input without dropping the queue."







