### PR TITLE
Prevent transitions from resetting on update

### DIFF
--- a/compositor_api/src/types/from_util.rs
+++ b/compositor_api/src/types/from_util.rs
@@ -54,7 +54,7 @@ impl TryFrom<Transition> for scene::Transition {
         Ok(Self {
             duration: Duration::from_secs_f64(transition.duration_ms / 1000.0),
             interpolation_kind,
-            reset_on_update: transition.reset_on_update.unwrap_or(false),
+            should_interrupt: transition.should_interrupt.unwrap_or(false),
         })
     }
 }

--- a/compositor_api/src/types/from_util.rs
+++ b/compositor_api/src/types/from_util.rs
@@ -54,6 +54,7 @@ impl TryFrom<Transition> for scene::Transition {
         Ok(Self {
             duration: Duration::from_secs_f64(transition.duration_ms / 1000.0),
             interpolation_kind,
+            reset_on_update: transition.reset_on_update.unwrap_or(false),
         })
     }
 }

--- a/compositor_api/src/types/util.rs
+++ b/compositor_api/src/types/util.rs
@@ -17,6 +17,8 @@ pub struct Transition {
     pub duration_ms: f64,
     /// (**default=`"linear"`**) Easing function to be used for the transition.
     pub easing_function: Option<EasingFunction>,
+    /// (**default=`false`**) If `true`, the ongoing transition will reset on scene update.
+    pub reset_on_update: Option<bool>,
 }
 
 /// Easing functions are used to interpolate between two values over time.

--- a/compositor_api/src/types/util.rs
+++ b/compositor_api/src/types/util.rs
@@ -17,7 +17,8 @@ pub struct Transition {
     pub duration_ms: f64,
     /// (**default=`"linear"`**) Easing function to be used for the transition.
     pub easing_function: Option<EasingFunction>,
-    /// (**default=`false`**) If `true`, the ongoing transition will reset on scene update.
+    /// (**default=`false`**) On scene update, if there is already a transition in progress,
+    /// it will be canceled and the new transition will start from the current state.
     pub reset_on_update: Option<bool>,
 }
 

--- a/compositor_api/src/types/util.rs
+++ b/compositor_api/src/types/util.rs
@@ -18,8 +18,8 @@ pub struct Transition {
     /// (**default=`"linear"`**) Easing function to be used for the transition.
     pub easing_function: Option<EasingFunction>,
     /// (**default=`false`**) On scene update, if there is already a transition in progress,
-    /// it will be canceled and the new transition will start from the current state.
-    pub reset_on_update: Option<bool>,
+    /// it will be interrupted and the new transition will start from the current state.
+    pub should_interrupt: Option<bool>,
 }
 
 /// Easing functions are used to interpolate between two values over time.

--- a/compositor_render/src/scene/components.rs
+++ b/compositor_render/src/scene/components.rs
@@ -163,7 +163,7 @@ pub enum Overflow {
 pub struct Transition {
     pub duration: Duration,
     pub interpolation_kind: InterpolationKind,
-    pub reset_on_update: bool,
+    pub should_interrupt: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/compositor_render/src/scene/components.rs
+++ b/compositor_render/src/scene/components.rs
@@ -152,7 +152,7 @@ pub struct ViewComponent {
     pub padding: Padding,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Overflow {
     Visible,
     Hidden,
@@ -163,9 +163,10 @@ pub enum Overflow {
 pub struct Transition {
     pub duration: Duration,
     pub interpolation_kind: InterpolationKind,
+    pub reset_on_update: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Position {
     Static {
         width: Option<f32>,
@@ -174,13 +175,13 @@ pub enum Position {
     Absolute(AbsolutePosition),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ViewChildrenDirection {
     Row,
     Column,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct Padding {
     pub top: f32,
     pub right: f32,
@@ -217,7 +218,7 @@ pub struct RescalerComponent {
     pub box_shadow: Vec<BoxShadow>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RescaleMode {
     Fit,
     Fill,

--- a/compositor_render/src/scene/rescaler_component.rs
+++ b/compositor_render/src/scene/rescaler_component.rs
@@ -118,8 +118,11 @@ impl RescalerComponent {
             box_shadow: self.box_shadow,
         };
 
-        let props_changed = previous_state.map(|state| state.end != end).unwrap_or(true);
-        let should_reset_transition = self.transition.map(|t| t.reset_on_update).unwrap_or(false);
+        let props_changed = previous_state
+            .map(|state| state.end != end)
+            .unwrap_or(false);
+        let interrupt_previous_transition =
+            self.transition.map(|t| t.should_interrupt).unwrap_or(false);
         let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
@@ -127,7 +130,7 @@ impl RescalerComponent {
             }),
             previous_state.and_then(|s| s.transition.clone()),
             props_changed,
-            should_reset_transition,
+            interrupt_previous_transition,
             ctx.last_render_pts,
         );
         let rescaler = StatefulRescalerComponent {

--- a/compositor_render/src/scene/rescaler_component.rs
+++ b/compositor_render/src/scene/rescaler_component.rs
@@ -23,7 +23,7 @@ pub(super) struct StatefulRescalerComponent {
     child: Box<StatefulComponent>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct RescalerComponentParam {
     id: Option<ComponentId>,
 
@@ -106,27 +106,33 @@ impl RescalerComponent {
         // TODO: to handle cases like transition from top to bottom this view needs
         // to be further processed to use the same type of coordinates as end
         let start = previous_state.map(|state| state.transition_snapshot(ctx.last_render_pts));
+        let end = RescalerComponentParam {
+            id: self.id,
+            position: self.position,
+            mode: self.mode,
+            horizontal_align: self.horizontal_align,
+            vertical_align: self.vertical_align,
+            border_radius: self.border_radius,
+            border_width: self.border_width,
+            border_color: self.border_color,
+            box_shadow: self.box_shadow,
+        };
+
+        let props_changed = previous_state.map(|state| state.end != end).unwrap_or(true);
+        let should_reset_transition = self.transition.map(|t| t.reset_on_update).unwrap_or(false);
         let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
                 interpolation_kind: transition.interpolation_kind,
             }),
             previous_state.and_then(|s| s.transition.clone()),
+            props_changed,
+            should_reset_transition,
             ctx.last_render_pts,
         );
         let rescaler = StatefulRescalerComponent {
             start,
-            end: RescalerComponentParam {
-                id: self.id,
-                position: self.position,
-                mode: self.mode,
-                horizontal_align: self.horizontal_align,
-                vertical_align: self.vertical_align,
-                border_radius: self.border_radius,
-                border_width: self.border_width,
-                border_color: self.border_color,
-                box_shadow: self.box_shadow,
-            },
+            end,
             transition,
             child: Box::new(Component::stateful_component(*self.child, ctx)?),
         };

--- a/compositor_render/src/scene/tiles_component.rs
+++ b/compositor_render/src/scene/tiles_component.rs
@@ -36,7 +36,7 @@ pub(super) struct StatefulTilesComponent {
     children: Vec<StatefulComponent>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct TilesComponentParams {
     id: Option<ComponentId>,
 
@@ -131,39 +131,63 @@ impl TilesComponent {
             });
 
         let start = previous_state.and_then(|state| state.last_layout.clone());
+        let component = TilesComponentParams {
+            id: self.id,
+            width: self.width,
+            height: self.height,
+            background_color: self.background_color,
+            tile_aspect_ratio: self.tile_aspect_ratio,
+            margin: self.margin,
+            padding: self.padding,
+            horizontal_align: self.horizontal_align,
+            vertical_align: self.vertical_align,
+        };
+        let children = self
+            .children
+            .into_iter()
+            .map(|c| Component::stateful_component(c, ctx))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let props_changed = previous_state
+            .map(|state| {
+                state.component != component
+                    || Self::did_child_order_change(&state.children, &children)
+            })
+            .unwrap_or(true);
+        let should_reset_transition = self.transition.map(|t| t.reset_on_update).unwrap_or(false);
         let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
                 interpolation_kind: transition.interpolation_kind,
             }),
             previous_state.and_then(|s| s.transition.clone()),
+            props_changed,
+            should_reset_transition,
             ctx.last_render_pts,
         );
-
         let tiles = StatefulTilesComponent {
             start,
             last_layout: previous_state.and_then(|state| state.last_layout.clone()),
-            component: TilesComponentParams {
-                id: self.id,
-                width: self.width,
-                height: self.height,
-                background_color: self.background_color,
-                tile_aspect_ratio: self.tile_aspect_ratio,
-                margin: self.margin,
-                padding: self.padding,
-                horizontal_align: self.horizontal_align,
-                vertical_align: self.vertical_align,
-            },
+            component,
             transition,
-            children: self
-                .children
-                .into_iter()
-                .map(|c| Component::stateful_component(c, ctx))
-                .collect::<Result<_, _>>()?,
+            children,
         };
 
         Ok(StatefulComponent::Layout(StatefulLayoutComponent::Tiles(
             tiles,
         )))
+    }
+
+    fn did_child_order_change(
+        previous_children: &[StatefulComponent],
+        current_children: &[StatefulComponent],
+    ) -> bool {
+        if current_children.len() != previous_children.len() {
+            return true;
+        }
+        previous_children
+            .iter()
+            .zip(current_children.iter())
+            .any(|(c1, c2)| c1.component_id() != c2.component_id())
     }
 }

--- a/compositor_render/src/scene/tiles_component.rs
+++ b/compositor_render/src/scene/tiles_component.rs
@@ -153,8 +153,9 @@ impl TilesComponent {
                 state.component != component
                     || Self::did_child_order_change(&state.children, &children)
             })
-            .unwrap_or(true);
-        let should_reset_transition = self.transition.map(|t| t.reset_on_update).unwrap_or(false);
+            .unwrap_or(false);
+        let interrupt_previous_transition =
+            self.transition.map(|t| t.should_interrupt).unwrap_or(false);
         let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
@@ -162,7 +163,7 @@ impl TilesComponent {
             }),
             previous_state.and_then(|s| s.transition.clone()),
             props_changed,
-            should_reset_transition,
+            interrupt_previous_transition,
             ctx.last_render_pts,
         );
         let tiles = StatefulTilesComponent {

--- a/compositor_render/src/scene/types.rs
+++ b/compositor_render/src/scene/types.rs
@@ -43,13 +43,13 @@ pub struct RGBAColor(pub u8, pub u8, pub u8, pub u8);
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Degree(pub f64);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Size {
     pub width: f32,
     pub height: f32,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AbsolutePosition {
     pub width: Option<f32>,
     pub height: Option<f32>,
@@ -58,26 +58,26 @@ pub struct AbsolutePosition {
     pub rotation_degrees: f32,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum VerticalPosition {
     TopOffset(f32),
     BottomOffset(f32),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum HorizontalPosition {
     LeftOffset(f32),
     RightOffset(f32),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum InterpolationKind {
     Linear,
     Bounce,
     CubicBezier { x1: f64, y1: f64, x2: f64, y2: f64 },
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BorderRadius {
     pub top_left: f32,
     pub top_right: f32,
@@ -155,7 +155,7 @@ impl Sub<f32> for BorderRadius {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BoxShadow {
     pub offset_x: f32,
     pub offset_y: f32,

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -23,7 +23,7 @@ pub(super) struct StatefulViewComponent {
     children: Vec<StatefulComponent>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 struct ViewComponentParam {
     id: Option<ComponentId>,
 
@@ -114,28 +114,34 @@ impl ViewComponent {
         // TODO: to handle cases like transition from top to bottom this view needs
         // to be further processed to use the same type of coordinates as end
         let start = previous_state.map(|state| state.view(ctx.last_render_pts));
+        let end = ViewComponentParam {
+            id: self.id,
+            direction: self.direction,
+            position: self.position,
+            background_color: self.background_color,
+            overflow: self.overflow,
+            border_radius: self.border_radius,
+            border_width: self.border_width,
+            border_color: self.border_color,
+            box_shadow: self.box_shadow,
+            padding: self.padding,
+        };
+
+        let props_changed = previous_state.map(|state| state.end != end).unwrap_or(true);
+        let should_reset_transition = self.transition.map(|t| t.reset_on_update).unwrap_or(false);
         let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
                 interpolation_kind: transition.interpolation_kind,
             }),
             previous_state.and_then(|s| s.transition.clone()),
+            props_changed,
+            should_reset_transition,
             ctx.last_render_pts,
         );
         let view = StatefulViewComponent {
             start,
-            end: ViewComponentParam {
-                id: self.id,
-                direction: self.direction,
-                position: self.position,
-                background_color: self.background_color,
-                overflow: self.overflow,
-                border_radius: self.border_radius,
-                border_width: self.border_width,
-                border_color: self.border_color,
-                box_shadow: self.box_shadow,
-                padding: self.padding,
-            },
+            end,
             transition,
             children: self
                 .children

--- a/compositor_render/src/scene/view_component.rs
+++ b/compositor_render/src/scene/view_component.rs
@@ -127,8 +127,11 @@ impl ViewComponent {
             padding: self.padding,
         };
 
-        let props_changed = previous_state.map(|state| state.end != end).unwrap_or(true);
-        let should_reset_transition = self.transition.map(|t| t.reset_on_update).unwrap_or(false);
+        let props_changed = previous_state
+            .map(|state| state.end != end)
+            .unwrap_or(false);
+        let interrupt_previous_transition =
+            self.transition.map(|t| t.should_interrupt).unwrap_or(false);
         let transition = TransitionState::new(
             self.transition.map(|transition| TransitionOptions {
                 duration: transition.duration,
@@ -136,7 +139,7 @@ impl ViewComponent {
             }),
             previous_state.and_then(|s| s.transition.clone()),
             props_changed,
-            should_reset_transition,
+            interrupt_previous_transition,
             ctx.last_render_pts,
         );
         let view = StatefulViewComponent {

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -951,7 +951,7 @@
           ]
         },
         "reset_on_update": {
-          "description": "(**default=`false`**) If `true`, the ongoing transition will reset on scene update.",
+          "description": "(**default=`false`**) On scene update, if there is already a transition in progress, it will be canceled and the new transition will start from the current state.",
           "type": [
             "boolean",
             "null"

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -949,6 +949,13 @@
               "type": "null"
             }
           ]
+        },
+        "reset_on_update": {
+          "description": "(**default=`false`**) If `true`, the ongoing transition will reset on scene update.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/schemas/scene.schema.json
+++ b/schemas/scene.schema.json
@@ -950,8 +950,8 @@
             }
           ]
         },
-        "reset_on_update": {
-          "description": "(**default=`false`**) On scene update, if there is already a transition in progress, it will be canceled and the new transition will start from the current state.",
+        "should_interrupt": {
+          "description": "(**default=`false`**) On scene update, if there is already a transition in progress, it will be interrupted and the new transition will start from the current state.",
           "type": [
             "boolean",
             "null"

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -832,6 +832,10 @@ export interface Transition {
    * (**default=`"linear"`**) Easing function to be used for the transition.
    */
   easing_function?: EasingFunction | null;
+  /**
+   * (**default=`false`**) If `true`, the ongoing transition will reset on scene update.
+   */
+  reset_on_update?: boolean | null;
 }
 export interface BoxShadow {
   offset_x?: number | null;

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -833,7 +833,8 @@ export interface Transition {
    */
   easing_function?: EasingFunction | null;
   /**
-   * (**default=`false`**) If `true`, the ongoing transition will reset on scene update.
+   * (**default=`false`**) On scene update, if there is already a transition in progress,
+   * it will be canceled and the new transition will start from the current state.
    */
   reset_on_update?: boolean | null;
 }

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -833,10 +833,9 @@ export interface Transition {
    */
   easing_function?: EasingFunction | null;
   /**
-   * (**default=`false`**) On scene update, if there is already a transition in progress,
-   * it will be canceled and the new transition will start from the current state.
+   * (**default=`false`**) On scene update, if there is already a transition in progress, it will be interrupted and the new transition will start from the current state.
    */
-  reset_on_update?: boolean | null;
+  should_interrupt?: boolean | null;
 }
 export interface BoxShadow {
   offset_x?: number | null;

--- a/ts/smelter/src/components/common.ts
+++ b/ts/smelter/src/components/common.ts
@@ -10,7 +10,8 @@ export interface Transition {
    */
   easingFunction?: EasingFunction | null;
   /**
-   * (**default=`false`**) If `true`, the ongoing transition will reset on update.
+   * (**default=`false`**) On scene update, if there is already a transition in progress,
+   * it will be canceled and the new transition will start from the current state.
    */
   resetOnUpdate?: boolean;
 }

--- a/ts/smelter/src/components/common.ts
+++ b/ts/smelter/src/components/common.ts
@@ -11,9 +11,9 @@ export interface Transition {
   easingFunction?: EasingFunction | null;
   /**
    * (**default=`false`**) On scene update, if there is already a transition in progress,
-   * it will be canceled and the new transition will start from the current state.
+   * it will be interrupted and the new transition will start from the current state.
    */
-  resetOnUpdate?: boolean;
+  shouldInterrupt?: boolean;
 }
 
 export function intoApiTransition(transition: Transition): Api.Transition {
@@ -22,7 +22,7 @@ export function intoApiTransition(transition: Transition): Api.Transition {
     easing_function: transition.easingFunction
       ? intoApiEasingFunction(transition.easingFunction)
       : undefined,
-    reset_on_update: transition.resetOnUpdate,
+    should_interrupt: transition.shouldInterrupt,
   };
 }
 

--- a/ts/smelter/src/components/common.ts
+++ b/ts/smelter/src/components/common.ts
@@ -9,6 +9,10 @@ export interface Transition {
    * (**default=`"linear"`**) Easing function to be used for the transition.
    */
   easingFunction?: EasingFunction | null;
+  /**
+   * (**default=`false`**) If `true`, the ongoing transition will reset on update.
+   */
+  resetOnUpdate?: boolean;
 }
 
 export function intoApiTransition(transition: Transition): Api.Transition {
@@ -17,6 +21,7 @@ export function intoApiTransition(transition: Transition): Api.Transition {
     easing_function: transition.easingFunction
       ? intoApiEasingFunction(transition.easingFunction)
       : undefined,
+    reset_on_update: transition.resetOnUpdate,
   };
 }
 


### PR DESCRIPTION
The behaviour on scene update:
- If component props changed between updates
  - If `should_interrupt` flag is `true`, new transition is started
  - If there is a transition already in progress, it's continued, but the destination is changed
  - otherwise, new transition is started
- otherwise, no new transition is applied
 
Snapshots PR: https://github.com/membraneframework-labs/video_compositor_snapshot_tests/pull/56

Closes #1019 