### PR TITLE
[web-wasm] Reduce number of input frame copies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = "--cfg web_sys_unstable_apis"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,6 +929,7 @@ dependencies = [
  "compositor_render",
  "console_error_panic_hook",
  "crossbeam-channel",
+ "futures",
  "getrandom 0.2.15",
  "glyphon",
  "js-sys",

--- a/compositor_web/Cargo.toml
+++ b/compositor_web/Cargo.toml
@@ -25,7 +25,9 @@ web-sys = { version = "0.3.77", features = [
     "CanvasRenderingContext2d",
     "ImageData",
     "VideoFrame",
-    "DomRectReadOnly", 
+    "VideoFrameCopyToOptions",
+    "Navigator",
+    "DomRectReadOnly",
 ] }
 serde = { workspace = true }
 serde-wasm-bindgen = "0.6.5"
@@ -34,6 +36,7 @@ crossbeam-channel = { workspace = true }
 reqwest = { workspace = true }
 bytes = { workspace = true }
 glyphon = { workspace = true }
+futures = "0.3.31"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/compositor_web/Cargo.toml
+++ b/compositor_web/Cargo.toml
@@ -23,7 +23,9 @@ web-sys = { version = "0.3.77", features = [
     "Window",
     "Element",
     "CanvasRenderingContext2d",
-    "ImageData"
+    "ImageData",
+    "VideoFrame",
+    "DomRectReadOnly", 
 ] }
 serde = { workspace = true }
 serde-wasm-bindgen = "0.6.5"

--- a/compositor_web/src/wasm.rs
+++ b/compositor_web/src/wasm.rs
@@ -37,7 +37,12 @@ pub async fn create_renderer(options: JsValue) -> Result<SmelterRenderer, JsValu
     );
 
     let (device, queue) = create_wgpu_context().await?;
-    let renderer = renderer::Renderer::new(device, queue, options.into())?;
+    let renderer = renderer::Renderer::new(
+        device,
+        queue,
+        options.upload_frames_with_copy_external,
+        options.into(),
+    )?;
     Ok(SmelterRenderer(Mutex::new(renderer)))
 }
 
@@ -46,9 +51,9 @@ pub struct SmelterRenderer(Mutex<renderer::Renderer>);
 
 #[wasm_bindgen]
 impl SmelterRenderer {
-    pub fn render(&self, input: types::FrameSet) -> Result<types::FrameSet, JsValue> {
+    pub async fn render(&self, input: types::FrameSet) -> Result<types::FrameSet, JsValue> {
         let mut renderer = self.0.lock().unwrap();
-        renderer.render(input)
+        renderer.render(input).await
     }
 
     pub fn update_scene(

--- a/compositor_web/src/wasm/output_downloader.rs
+++ b/compositor_web/src/wasm/output_downloader.rs
@@ -7,7 +7,7 @@ use tracing::error;
 use wasm_bindgen::JsValue;
 
 use super::{
-    types::{self, to_js_error},
+    types::{self, to_js_error, ObjectExt},
     wgpu::pad_to_256,
 };
 
@@ -131,16 +131,5 @@ impl OutputDownloader {
             },
             size,
         );
-    }
-}
-
-trait ObjectExt {
-    fn set<T: Into<JsValue>>(&self, key: &str, value: T) -> Result<(), JsValue>;
-}
-
-impl ObjectExt for Object {
-    fn set<T: Into<JsValue>>(&self, key: &str, value: T) -> Result<(), JsValue> {
-        js_sys::Reflect::set(self, &JsValue::from_str(key), &value.into())?;
-        Ok(())
     }
 }

--- a/compositor_web/src/wasm/output_downloader.rs
+++ b/compositor_web/src/wasm/output_downloader.rs
@@ -24,7 +24,6 @@ impl OutputDownloader {
         outputs: FrameSet<OutputId>,
     ) -> Result<types::FrameSet, JsValue> {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-
         for (id, frame) in outputs.frames.iter() {
             let FrameData::Rgba8UnormWgpuTexture(texture) = &frame.data else {
                 panic!("Expected Rgba8UnormWgpuTexture");

--- a/compositor_web/src/wasm/renderer.rs
+++ b/compositor_web/src/wasm/renderer.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use compositor_api::types as api;
 use compositor_render::{
-    image::ImageSpec, shader::ShaderSpec, InputId, OutputFrameFormat, OutputId, RegistryType,
-    RendererId, RendererOptions, RendererSpec,
+    InputId, OutputFrameFormat, OutputId, RegistryType, RendererId, RendererOptions, RendererSpec,
 };
 use glyphon::fontdb::Source;
 use wasm_bindgen::JsValue;

--- a/compositor_web/src/wasm/renderer.rs
+++ b/compositor_web/src/wasm/renderer.rs
@@ -19,6 +19,7 @@ impl Renderer {
     pub fn new(
         device: Arc<wgpu::Device>,
         queue: Arc<wgpu::Queue>,
+        upload_frames_with_copy_external: bool,
         options: RendererOptions,
     ) -> Result<Self, JsValue> {
         let (renderer, _) = compositor_render::Renderer::new(RendererOptions {
@@ -26,7 +27,7 @@ impl Renderer {
             ..options
         })
         .map_err(types::to_js_error)?;
-        let input_uploader = InputUploader::default();
+        let input_uploader = InputUploader::new(upload_frames_with_copy_external);
         let output_downloader = OutputDownloader::default();
 
         Ok(Self {
@@ -36,9 +37,9 @@ impl Renderer {
         })
     }
 
-    pub fn render(&mut self, input: types::FrameSet) -> Result<types::FrameSet, JsValue> {
+    pub async fn render(&mut self, input: types::FrameSet) -> Result<types::FrameSet, JsValue> {
         let (device, queue) = self.renderer.wgpu_ctx();
-        let frame_set = self.input_uploader.upload(&device, &queue, input)?;
+        let frame_set = self.input_uploader.upload(&device, &queue, input).await?;
 
         let outputs = self
             .renderer

--- a/ts/examples/vite-example/src/renderer-examples/Counter.tsx
+++ b/ts/examples/vite-example/src/renderer-examples/Counter.tsx
@@ -41,12 +41,12 @@ function Counter() {
     );
 
     let pts = 0;
-    const renderInterval = setInterval(() => {
+    const renderInterval = setInterval(async () => {
       const input = {
         ptsMs: pts,
         frames: {},
       };
-      const outputs = renderer.render(input);
+      const outputs = await renderer.render(input);
       const frame = outputs.frames['output'];
       const resolution = frame.resolution;
       const canvas = canvasRef.current;

--- a/ts/smelter-browser-render/src/renderer.ts
+++ b/ts/smelter-browser-render/src/renderer.ts
@@ -15,6 +15,11 @@ export type FrameSet<T> = {
   frames: { [id: string]: T };
 };
 
+export type InputFrame = {
+  readonly frame: VideoFrame;
+  readonly ptsMs: number;
+};
+
 export type OutputFrame = {
   resolution: Api.Resolution;
   format: FrameFormat;
@@ -41,7 +46,7 @@ export class Renderer {
     return new Renderer(renderer);
   }
 
-  public render(input: FrameSet<VideoFrame>): FrameSet<OutputFrame> {
+  public render(input: FrameSet<InputFrame>): FrameSet<OutputFrame> {
     const frames = new Map(Object.entries(input.frames));
     const inputFrameSet = new wasm.FrameSet(input.ptsMs, frames);
     const output = this.renderer.render(inputFrameSet);

--- a/ts/smelter-browser-render/src/renderer.ts
+++ b/ts/smelter-browser-render/src/renderer.ts
@@ -10,12 +10,12 @@ export type RendererOptions = {
   loggerLevel?: 'error' | 'warn' | 'info' | 'debug' | 'trace';
 };
 
-export type FrameSet = {
+export type FrameSet<T> = {
   ptsMs: number;
-  frames: { [id: string]: Frame };
+  frames: { [id: string]: T };
 };
 
-export type Frame = {
+export type OutputFrame = {
   resolution: Api.Resolution;
   format: FrameFormat;
   data: Uint8ClampedArray;
@@ -41,7 +41,7 @@ export class Renderer {
     return new Renderer(renderer);
   }
 
-  public render(input: FrameSet): FrameSet {
+  public render(input: FrameSet<VideoFrame>): FrameSet<OutputFrame> {
     const frames = new Map(Object.entries(input.frames));
     const inputFrameSet = new wasm.FrameSet(input.ptsMs, frames);
     const output = this.renderer.render(inputFrameSet);

--- a/ts/smelter-browser-render/src/renderer.ts
+++ b/ts/smelter-browser-render/src/renderer.ts
@@ -8,6 +8,13 @@ export type RendererOptions = {
   streamFallbackTimeoutMs: number;
 
   loggerLevel?: 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+  /**
+   * Input frame upload strategy.
+   * On most platforms it's more performant to copy input VideoFrame data to CPU and then upload it to texture.
+   * But on macOS using dedicated wgpu copy_external_image_to_texture function results in better performance.
+   */
+  uploadFramesWithCopyExternal?: boolean;
 };
 
 export type FrameSet<T> = {
@@ -42,14 +49,15 @@ export class Renderer {
     const renderer = await wasm.create_renderer({
       stream_fallback_timeout_ms: options.streamFallbackTimeoutMs,
       logger_level: options.loggerLevel ?? 'warn',
+      upload_frames_with_copy_external: options.uploadFramesWithCopyExternal ?? false,
     });
     return new Renderer(renderer);
   }
 
-  public render(input: FrameSet<InputFrame>): FrameSet<OutputFrame> {
+  public async render(input: FrameSet<InputFrame>): Promise<FrameSet<OutputFrame>> {
     const frames = new Map(Object.entries(input.frames));
     const inputFrameSet = new wasm.FrameSet(input.ptsMs, frames);
-    const output = this.renderer.render(inputFrameSet);
+    const output = await this.renderer.render(inputFrameSet);
     return {
       ptsMs: output.pts_ms,
       frames: Object.fromEntries(output.frames),

--- a/ts/smelter-web-wasm/src/workerContext/input/QueuedInput.ts
+++ b/ts/smelter-web-wasm/src/workerContext/input/QueuedInput.ts
@@ -1,4 +1,4 @@
-import type { Frame, InputId } from '@swmansion/smelter-browser-render';
+import type { InputId } from '@swmansion/smelter-browser-render';
 import type { Logger } from 'pino';
 import { Queue } from '@datastructures-js/queue';
 import { workerPostEvent } from '../pipeline';
@@ -124,14 +124,11 @@ export class QueuedInput implements Input {
   /**
    * Retrieves reference of a frame closest to the provided `currentQueuePts`.
    */
-  public async getFrame(currentQueuePts: number): Promise<Frame | undefined> {
+  public async getFrame(currentQueuePts: number): Promise<InputVideoFrameRef | undefined> {
     this.dropOldFrames(currentQueuePts);
     const frameRef = this.frames.front();
     if (frameRef) {
       frameRef.incrementRefCount();
-      const frame = await frameRef.getFrame();
-      frameRef.decrementRefCount();
-
       if (!this.sentFirstFrame) {
         this.sentFirstFrame = true;
         this.logger.debug('Input started');
@@ -150,7 +147,7 @@ export class QueuedInput implements Input {
         });
       }
 
-      return frame;
+      return frameRef;
     }
     return;
   }
@@ -163,7 +160,7 @@ export class QueuedInput implements Input {
       this.firstFramePtsMs = frame.ptsMs;
     }
     frame.ptsMs = frame.ptsMs - this.firstFramePtsMs;
-    return new InputVideoFrameRef(frame, this.logger);
+    return new InputVideoFrameRef(frame);
   }
 
   /**

--- a/ts/smelter-web-wasm/src/workerContext/input/QueuedInput.ts
+++ b/ts/smelter-web-wasm/src/workerContext/input/QueuedInput.ts
@@ -5,14 +5,19 @@ import { workerPostEvent } from '../pipeline';
 import { SmelterEventType } from '../../eventSender';
 import { assert, sleep } from '../../utils';
 import type { Input, InputStartResult, QueuedInputSource } from './input';
-import type { InputAudioData, InputVideoFrame } from './frame';
-import { InputVideoFrameRef } from './frame';
+import type { InputAudioData, InternalVideoFrame } from './frame';
+import { InputVideoFrame, InputVideoFrameRef } from './frame';
 import type { AudioWorkletMessage } from '../../audioWorkletContext/workletApi';
 
 export type InputState = 'started' | 'playing' | 'finished';
 
 const MAX_BUFFER_FRAME_COUNT = 10;
 const ENQUEUE_INTERVAL_MS = 50;
+
+type QueueFrame = {
+  ref: InputVideoFrameRef;
+  ptsMs: number;
+};
 
 export class QueuedInput implements Input {
   private inputId: InputId;
@@ -21,7 +26,7 @@ export class QueuedInput implements Input {
   /**
    * frames PTS start from 0, where 0 represents first frame
    */
-  private frames: Queue<InputVideoFrameRef>;
+  private frames: Queue<QueueFrame>;
 
   private shouldClose: boolean = false;
 
@@ -124,11 +129,11 @@ export class QueuedInput implements Input {
   /**
    * Retrieves reference of a frame closest to the provided `currentQueuePts`.
    */
-  public async getFrame(currentQueuePts: number): Promise<InputVideoFrameRef | undefined> {
+  public async getFrame(currentQueuePts: number): Promise<InputVideoFrame | undefined> {
     this.dropOldFrames(currentQueuePts);
-    const frameRef = this.frames.front();
-    if (frameRef) {
-      frameRef.incrementRefCount();
+    const frame = this.frames.front();
+    if (frame) {
+      frame.ref.incrementRefCount();
       if (!this.sentFirstFrame) {
         this.sentFirstFrame = true;
         this.logger.debug('Input started');
@@ -139,7 +144,7 @@ export class QueuedInput implements Input {
       }
 
       if (this.frames.size() === 1 && this.receivedEos) {
-        this.frames.pop().decrementRefCount();
+        this.frames.pop().ref.decrementRefCount();
         this.logger.debug('Input finished');
         workerPostEvent({
           type: SmelterEventType.VIDEO_INPUT_EOS,
@@ -147,12 +152,12 @@ export class QueuedInput implements Input {
         });
       }
 
-      return frameRef;
+      return new InputVideoFrame(frame.ref, frame.ptsMs);
     }
     return;
   }
 
-  private newFrameRef(frame: InputVideoFrame): InputVideoFrameRef {
+  private newFrameRef(frame: InternalVideoFrame): QueueFrame {
     if (!this.firstFrameTimeMs) {
       this.firstFrameTimeMs = Date.now();
     }
@@ -160,7 +165,10 @@ export class QueuedInput implements Input {
       this.firstFramePtsMs = frame.ptsMs;
     }
     frame.ptsMs = frame.ptsMs - this.firstFramePtsMs;
-    return new InputVideoFrameRef(frame);
+    return {
+      ref: new InputVideoFrameRef(frame.frame),
+      ptsMs: frame.ptsMs,
+    };
   }
 
   /**
@@ -179,12 +187,15 @@ export class QueuedInput implements Input {
       return prevPtsDiff < currPtsDiff ? prevFrame : frame;
     });
 
-    for (const frame of frames) {
-      if (frame.ptsMs < targetFrame.ptsMs) {
-        frame.decrementRefCount();
-        this.frames.pop();
-      }
-    }
+    this.frames = Queue.fromArray(
+      frames.filter(frame => {
+        if (frame.ptsMs < targetFrame.ptsMs) {
+          frame.ref.decrementRefCount();
+          return false;
+        }
+        return true;
+      })
+    );
   }
 
   private queuePtsToInputPts(queuePts: number): number {

--- a/ts/smelter-web-wasm/src/workerContext/input/frame.ts
+++ b/ts/smelter-web-wasm/src/workerContext/input/frame.ts
@@ -1,10 +1,7 @@
-import type { Frame } from '@swmansion/smelter-browser-render';
-import { FrameFormat } from '@swmansion/smelter-browser-render';
 import { assert } from '../../utils';
-import type { Logger } from 'pino';
 
 export type InputVideoFrame = {
-  frame: Omit<VideoFrame, 'timestamp'>;
+  frame: VideoFrame;
   ptsMs: number;
 };
 
@@ -22,12 +19,9 @@ export type InputAudioData = {
 export class InputVideoFrameRef {
   private frame: InputVideoFrame;
   private refCount: number;
-  private downloadedFrame?: Frame;
-  private logger: Logger;
 
-  public constructor(frame: InputVideoFrame, logger: Logger) {
+  public constructor(frame: InputVideoFrame) {
     this.frame = frame;
-    this.logger = logger;
     this.refCount = 1;
   }
 
@@ -60,83 +54,8 @@ export class InputVideoFrameRef {
   /**
    * Returns underlying frame. Fails if frame was freed from memory.
    */
-  public async getFrame(): Promise<Frame> {
+  public getFrame(): VideoFrame {
     assert(this.refCount > 0);
-
-    if (!this.downloadedFrame) {
-      this.downloadedFrame = await this.downloadFrame(this.frame);
-    }
-    return this.downloadedFrame;
+    return this.frame.frame;
   }
-
-  private async downloadFrame(inputFrame: InputVideoFrame): Promise<Frame> {
-    // TODO: Add support back from safari
-    // Safari does not support conversion to RGBA
-    // Chrome does not support conversion to YUV
-
-    const frame = inputFrame.frame;
-
-    // visibleRect is undefined when inputFrame is detached
-    assert(frame.visibleRect);
-
-    const options = {
-      format: 'RGBA',
-      layout: [
-        {
-          offset: 0,
-          stride: frame.visibleRect.width * 4,
-        },
-      ],
-    };
-
-    const buffer = new Uint8ClampedArray(frame.allocationSize(options as VideoFrameCopyToOptions));
-    const planeLayouts = await frame.copyTo(buffer, options as VideoFrameCopyToOptions);
-
-    if (!checkPlaneLayouts(options.layout, planeLayouts)) {
-      const frameInfo = {
-        displayWidth: frame.displayWidth,
-        displayHeight: frame.displayHeight,
-        codedWidth: frame.codedWidth,
-        codedHeight: frame.codedHeight,
-        visibleRect: frame.visibleRect,
-        codedRect: frame.codedRect,
-        format: frame.format,
-        colorSpace: frame.colorSpace,
-        duration: frame.duration,
-      };
-
-      this.logger.error(
-        { planeLayouts, frameInfo },
-        "Copied frame's plane layouts do not match expected layouts"
-      );
-    }
-
-    return {
-      resolution: {
-        width: frame.visibleRect.width,
-        height: frame.visibleRect.height,
-      },
-      format: FrameFormat.RGBA_BYTES,
-      data: buffer,
-    };
-  }
-}
-
-/**
- * Returns `true` if plane layouts are valid
- */
-function checkPlaneLayouts(expected: PlaneLayout[], received: PlaneLayout[]): boolean {
-  if (expected.length !== received.length) {
-    return false;
-  }
-  for (let i = 0; i < expected.length; i++) {
-    if (expected[i].offset !== received[i].offset) {
-      return false;
-    }
-    if (expected[i].stride !== received[i].stride) {
-      return false;
-    }
-  }
-
-  return true;
 }

--- a/ts/smelter-web-wasm/src/workerContext/input/input.ts
+++ b/ts/smelter-web-wasm/src/workerContext/input/input.ts
@@ -1,6 +1,6 @@
 import Mp4Source from './source/Mp4Source';
 import { QueuedInput } from './QueuedInput';
-import type { InputAudioData, InputVideoFrame, InputVideoFrameRef } from './frame';
+import type { InputAudioData, InputVideoFrame, InternalVideoFrame } from './frame';
 import { MediaStreamInput } from './MediaStreamInput';
 import type { RegisterInput } from '../../workerApi';
 import type { Logger } from 'pino';
@@ -28,11 +28,14 @@ export type ContainerInfo = {
 export interface Input {
   start(): InputStartResult;
   updateQueueStartTime(queueStartTimeMs: number): void;
-  getFrame(currentQueuePts: number): Promise<InputVideoFrameRef | undefined>;
+  /*
+   * Return frame for the specified pts. Close method has to be called on the returned InputVideoFrame.
+   */
+  getFrame(currentQueuePts: number): Promise<InputVideoFrame | undefined>;
   close(): void;
 }
 
-export type VideoFramePayload = { type: 'frame'; frame: InputVideoFrame } | { type: 'eos' };
+export type VideoFramePayload = { type: 'frame'; frame: InternalVideoFrame } | { type: 'eos' };
 
 export type AudioDataPayload =
   | { type: 'sampleBatch'; sampleBatch: InputAudioData }

--- a/ts/smelter-web-wasm/src/workerContext/input/input.ts
+++ b/ts/smelter-web-wasm/src/workerContext/input/input.ts
@@ -1,7 +1,6 @@
 import Mp4Source from './source/Mp4Source';
 import { QueuedInput } from './QueuedInput';
-import type { InputAudioData, InputVideoFrame } from './frame';
-import type { Frame } from '@swmansion/smelter-browser-render';
+import type { InputAudioData, InputVideoFrame, InputVideoFrameRef } from './frame';
 import { MediaStreamInput } from './MediaStreamInput';
 import type { RegisterInput } from '../../workerApi';
 import type { Logger } from 'pino';
@@ -29,7 +28,7 @@ export type ContainerInfo = {
 export interface Input {
   start(): InputStartResult;
   updateQueueStartTime(queueStartTimeMs: number): void;
-  getFrame(currentQueuePts: number): Promise<Frame | undefined>;
+  getFrame(currentQueuePts: number): Promise<InputVideoFrameRef | undefined>;
   close(): void;
 }
 
@@ -89,7 +88,7 @@ export async function createInput(
     return new QueuedInput(inputId, source, inputLogger);
   } else if (request.type === 'stream') {
     assert(request.videoStream);
-    return new MediaStreamInput(inputId, request.videoStream, inputLogger);
+    return new MediaStreamInput(inputId, request.videoStream);
   }
   throw new Error(`Unknown input type ${(request as any).type}`);
 }

--- a/ts/smelter-web-wasm/src/workerContext/input/videoDecoder.ts
+++ b/ts/smelter-web-wasm/src/workerContext/input/videoDecoder.ts
@@ -1,5 +1,5 @@
 import { Queue } from '@datastructures-js/queue';
-import type { InputVideoFrame } from './frame';
+import type { InternalVideoFrame } from './frame';
 import type { InputVideoFrameSource, EncodedSource, VideoFramePayload } from './input';
 import type { Logger } from 'pino';
 import { assert, sleep } from '../../utils';
@@ -11,7 +11,7 @@ export class InputVideoDecoder implements InputVideoFrameSource {
   private source: EncodedSource;
   private decoder: VideoDecoder;
   private offsetMs?: number;
-  private frames: Queue<InputVideoFrame>;
+  private frames: Queue<InternalVideoFrame>;
   private receivedEos: boolean = false;
   private firstFramePromise: Promise<void>;
   private workloadBalancerNode: WorkloadBalancerNode;

--- a/ts/smelter-web-wasm/src/workerContext/output/canvas.ts
+++ b/ts/smelter-web-wasm/src/workerContext/output/canvas.ts
@@ -1,4 +1,4 @@
-import type { Frame } from '@swmansion/smelter-browser-render';
+import type { OutputFrame } from '@swmansion/smelter-browser-render';
 import type { OutputSink } from './sink';
 import { assert } from '../../utils';
 
@@ -11,7 +11,7 @@ export default class CanvasSink implements OutputSink {
     this.ctx = ctx;
   }
 
-  public async send(frame: Frame): Promise<void> {
+  public async send(frame: OutputFrame): Promise<void> {
     const resolution = frame.resolution;
     this.ctx.putImageData(new ImageData(frame.data, resolution.width, resolution.height), 0, 0);
   }

--- a/ts/smelter-web-wasm/src/workerContext/output/output.ts
+++ b/ts/smelter-web-wasm/src/workerContext/output/output.ts
@@ -1,4 +1,4 @@
-import type { Frame, Resolution } from '@swmansion/smelter-browser-render';
+import type { OutputFrame, Resolution } from '@swmansion/smelter-browser-render';
 import type { OutputSink } from './sink';
 import CanvasSink from './canvas';
 import type { RegisterOutput } from '../../workerApi';
@@ -16,7 +16,7 @@ export class Output {
     this.resolution = request.video.resolution;
   }
 
-  public async send(frame: Frame): Promise<void> {
+  public async send(frame: OutputFrame): Promise<void> {
     await this.sink.send(frame);
   }
 }

--- a/ts/smelter-web-wasm/src/workerContext/output/sink.ts
+++ b/ts/smelter-web-wasm/src/workerContext/output/sink.ts
@@ -1,5 +1,5 @@
-import type { Frame } from '@swmansion/smelter-browser-render';
+import type { OutputFrame } from '@swmansion/smelter-browser-render';
 
 export interface OutputSink {
-  send(frame: Frame): Promise<void>;
+  send(frame: OutputFrame): Promise<void>;
 }

--- a/ts/smelter-web-wasm/src/workerContext/queue.ts
+++ b/ts/smelter-web-wasm/src/workerContext/queue.ts
@@ -89,7 +89,7 @@ export class Queue {
     this.logger.trace({ frames }, 'onQueueTick');
 
     try {
-      const outputs = this.renderer.render({
+      const outputs = await this.renderer.render({
         ptsMs: currentPtsMs,
         frames,
       });

--- a/ts/smelter-web-wasm/src/workerContext/runWorker.ts
+++ b/ts/smelter-web-wasm/src/workerContext/runWorker.ts
@@ -17,7 +17,7 @@ async function initInstance(options: InitOptions) {
   const renderer = await Renderer.create({
     streamFallbackTimeoutMs: 500,
     loggerLevel,
-    uploadFramesWithCopyExternal: self.navigator.userAgent.includes("Macintosh"),
+    uploadFramesWithCopyExternal: self.navigator.userAgent.includes('Macintosh'),
   });
   const logger = pino({ level: options.loggerLevel }).child({ runtime: 'worker' });
   onMessageLogger = logger.child({ element: 'onMessage' });

--- a/ts/smelter-web-wasm/src/workerContext/runWorker.ts
+++ b/ts/smelter-web-wasm/src/workerContext/runWorker.ts
@@ -17,6 +17,7 @@ async function initInstance(options: InitOptions) {
   const renderer = await Renderer.create({
     streamFallbackTimeoutMs: 500,
     loggerLevel,
+    uploadFramesWithCopyExternal: self.navigator.userAgent.includes("Macintosh"),
   });
   const logger = pino({ level: options.loggerLevel }).child({ runtime: 'worker' });
   onMessageLogger = logger.child({ element: 'onMessage' });


### PR DESCRIPTION
Tested on Chrome and Safari. This PR improved performance only on macOS. The approach used here actually makes the performance worse on most platforms (except macOS, probably due to the fact that CPU and GPU share the same memory on  macs)

Closes #1034