### PR TITLE
[ts-sdk] Add RTMP output + update examples

### DIFF
--- a/compositor_api/src/types/from_register_output.rs
+++ b/compositor_api/src/types/from_register_output.rs
@@ -301,18 +301,18 @@ impl TryFrom<RtmpClient> for pipeline::RegisterOutputOptions<output::OutputOptio
             })
             .transpose()?;
         let rtmp_audio = audio.as_ref().map(|a| match &a.encoder {
-            RtmpAudioEncoderOptions::Aac {
+            RtmpClientAudioEncoderOptions::Aac {
                 channels,
                 sample_rate,
             } => RtmpAudioTrack {
                 channels: channels.clone().into(),
-                sample_rate: sample_rate.unwrap_or(44100),
+                sample_rate: sample_rate.unwrap_or(48000),
             },
         });
 
         let (video_encoder_options, output_video_options) = maybe_video_options(video)?;
         let (audio_encoder_options, output_audio_options) = match audio {
-            Some(OutputRtmpAudioOptions {
+            Some(OutputRtmpClientAudioOptions {
                 mixing_strategy,
                 send_eos_when,
                 encoder,
@@ -401,10 +401,10 @@ impl From<Mp4AudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
     }
 }
 
-impl From<RtmpAudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
-    fn from(value: RtmpAudioEncoderOptions) -> Self {
+impl From<RtmpClientAudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
+    fn from(value: RtmpClientAudioEncoderOptions) -> Self {
         match value {
-            RtmpAudioEncoderOptions::Aac {
+            RtmpClientAudioEncoderOptions::Aac {
                 channels,
                 sample_rate,
             } => AudioEncoderOptions::Aac(AacEncoderOptions {

--- a/compositor_api/src/types/register_output.rs
+++ b/compositor_api/src/types/register_output.rs
@@ -34,7 +34,7 @@ pub struct RtmpClient {
     /// Video stream configuration.
     pub video: Option<OutputVideoOptions>,
     /// Audio stream configuration.
-    pub audio: Option<OutputRtmpAudioOptions>,
+    pub audio: Option<OutputRtmpClientAudioOptions>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
@@ -115,13 +115,13 @@ pub struct OutputWhipAudioOptions {
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct OutputRtmpAudioOptions {
+pub struct OutputRtmpClientAudioOptions {
     /// (**default="sum_clip"**) Specifies how audio should be mixed.
     pub mixing_strategy: Option<MixingStrategy>,
     /// Condition for termination of output stream based on the input streams states.
     pub send_eos_when: Option<OutputEndCondition>,
     /// Audio encoder options.
-    pub encoder: RtmpAudioEncoderOptions,
+    pub encoder: RtmpClientAudioEncoderOptions,
     /// Initial audio mixer configuration for output.
     pub initial: Audio,
 }
@@ -171,7 +171,7 @@ pub enum Mp4AudioEncoderOptions {
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
-pub enum RtmpAudioEncoderOptions {
+pub enum RtmpClientAudioEncoderOptions {
     Aac {
         channels: AudioChannels,
         /// (**default=`48000`**) Sample rate. Allowed values: [8000, 16000, 24000, 44100, 48000].

--- a/ts/create-smelter-app/templates/node-express-zustand/src/smelter.tsx
+++ b/ts/create-smelter-app/templates/node-express-zustand/src/smelter.tsx
@@ -8,13 +8,11 @@ export async function initializeSmelterInstance() {
   await SmelterInstance.init();
 
   // Display output with `ffplay`.
-  await ffplayStartPlayerAsync('127.0.0.0', 8001);
+  await ffplayStartPlayerAsync(8001);
 
   await SmelterInstance.registerOutput('output_1', <App />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:8001',
     video: {
       encoder: {
         type: 'ffmpeg_h264',

--- a/ts/create-smelter-app/templates/node-express-zustand/src/smelterFfplayHelper.ts
+++ b/ts/create-smelter-app/templates/node-express-zustand/src/smelterFfplayHelper.ts
@@ -1,59 +1,19 @@
-import os from 'os';
-import path from 'path';
-import fs from 'fs';
-import type { ChildProcess, SpawnOptions } from 'child_process';
-import { spawn as nodeSpawn } from 'child_process';
-
-const TMP_SDP_DIR = path.join(os.tmpdir(), 'smelter-sdp');
+import { spawn } from 'child_process';
 
 /**
- * Util function that displays video sent over RTP to the specified port.
- * This is only for debugging, do not use for production use cases.
+ * Util function that starts RTMP server and display incoming streams with ffplay.
  */
-export async function ffplayStartPlayerAsync(ip: string, videoPort: number): Promise<void> {
-  if (!fs.existsSync(TMP_SDP_DIR)) {
-    fs.mkdirSync(TMP_SDP_DIR);
-  }
-  const sdpFilePath = path.join(TMP_SDP_DIR, `video_input_${videoPort}.sdp`);
-  writeVideoSdpFile(ip, videoPort, sdpFilePath);
-  void spawn('ffplay', ['-protocol_whitelist', 'file,rtp,udp', sdpFilePath], {});
-  await new Promise<void>(res => setTimeout(() => res(), 2000));
-}
-
-interface SpawnPromise extends Promise<void> {
-  child: ChildProcess;
-}
-
-function spawn(command: string, args: string[], options: SpawnOptions): SpawnPromise {
-  const child = nodeSpawn(command, args, {
-    stdio: 'inherit',
-    ...options,
+export async function ffplayStartPlayerAsync(port: number): Promise<void> {
+  const command = 'bash';
+  const args = [
+    '-c',
+    `ffmpeg -f flv -listen 1 -i rtmp://0.0.0.0:${port} -vcodec copy  -f flv - | ffplay -f flv -i -`,
+  ];
+  const child = spawn(command, args, { stdio: 'inherit' });
+  child.on('exit', code => {
+    if (code !== 0) {
+      console.error(`Command "${command} ${args.join(' ')}" failed with exit code ${code}.`);
+    }
   });
-  const promise = new Promise((res, rej) => {
-    child.on('exit', code => {
-      if (code === 0) {
-        res();
-      } else {
-        rej(new Error(`Command "${command} ${args.join(' ')}" failed with exit code ${code}.`));
-      }
-    });
-  }) as SpawnPromise;
-  promise.child = child;
-  return promise;
-}
-
-function writeVideoSdpFile(ip: string, port: number, destination: string): void {
-  fs.writeFileSync(
-    destination,
-    `
-v=0
-o=- 0 0 IN IP4 ${ip}
-s=No Name
-c=IN IP4 ${ip}
-m=video ${port} RTP/AVP 96
-a=rtpmap:96 H264/90000
-a=fmtp:96 packetization-mode=1
-a=rtcp-mux
-`
-  );
+  await new Promise<void>(res => setTimeout(() => res(), 2000));
 }

--- a/ts/create-smelter-app/templates/node-minimal/src/index.tsx
+++ b/ts/create-smelter-app/templates/node-minimal/src/index.tsx
@@ -27,13 +27,11 @@ async function run() {
   await smelter.init();
 
   // Display output with `ffplay`.
-  await ffplayStartPlayerAsync('127.0.0.0', 8001);
+  await ffplayStartPlayerAsync(8001);
 
   await smelter.registerOutput('output_1', <App />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:8001',
     video: {
       encoder: {
         type: 'ffmpeg_h264',

--- a/ts/create-smelter-app/templates/node-minimal/src/smelterFfplayHelper.ts
+++ b/ts/create-smelter-app/templates/node-minimal/src/smelterFfplayHelper.ts
@@ -1,59 +1,19 @@
-import os from 'os';
-import path from 'path';
-import fs from 'fs';
-import type { ChildProcess, SpawnOptions } from 'child_process';
-import { spawn as nodeSpawn } from 'child_process';
-
-const TMP_SDP_DIR = path.join(os.tmpdir(), 'smelter-sdp');
+import { spawn } from 'child_process';
 
 /**
- * Util function that displays video sent over RTP to the specified port.
- * This is only for debugging, do not use for production use cases.
+ * Util function that starts RTMP server and display incoming streams with ffplay.
  */
-export async function ffplayStartPlayerAsync(ip: string, videoPort: number): Promise<void> {
-  if (!fs.existsSync(TMP_SDP_DIR)) {
-    fs.mkdirSync(TMP_SDP_DIR);
-  }
-  const sdpFilePath = path.join(TMP_SDP_DIR, `video_input_${videoPort}.sdp`);
-  writeVideoSdpFile(ip, videoPort, sdpFilePath);
-  void spawn('ffplay', ['-protocol_whitelist', 'file,rtp,udp', sdpFilePath], {});
-  await new Promise<void>(res => setTimeout(() => res(), 2000));
-}
-
-interface SpawnPromise extends Promise<void> {
-  child: ChildProcess;
-}
-
-function spawn(command: string, args: string[], options: SpawnOptions): SpawnPromise {
-  const child = nodeSpawn(command, args, {
-    stdio: 'inherit',
-    ...options,
+export async function ffplayStartPlayerAsync(port: number): Promise<void> {
+  const command = 'bash';
+  const args = [
+    '-c',
+    `ffmpeg -f flv -listen 1 -i rtmp://0.0.0.0:${port} -vcodec copy  -f flv - | ffplay -f flv -i -`,
+  ];
+  const child = spawn(command, args, { stdio: 'inherit' });
+  child.on('exit', code => {
+    if (code !== 0) {
+      console.error(`Command "${command} ${args.join(' ')}" failed with exit code ${code}.`);
+    }
   });
-  const promise = new Promise((res, rej) => {
-    child.on('exit', code => {
-      if (code === 0) {
-        res();
-      } else {
-        rej(new Error(`Command "${command} ${args.join(' ')}" failed with exit code ${code}.`));
-      }
-    });
-  }) as SpawnPromise;
-  promise.child = child;
-  return promise;
-}
-
-function writeVideoSdpFile(ip: string, port: number, destination: string): void {
-  fs.writeFileSync(
-    destination,
-    `
-v=0
-o=- 0 0 IN IP4 ${ip}
-s=No Name
-c=IN IP4 ${ip}
-m=video ${port} RTP/AVP 96
-a=rtpmap:96 H264/90000
-a=fmtp:96 packetization-mode=1
-a=rtcp-mux
-`
-  );
+  await new Promise<void>(res => setTimeout(() => res(), 2000));
 }

--- a/ts/examples/node-examples/src/dynamic-text.tsx
+++ b/ts/examples/node-examples/src/dynamic-text.tsx
@@ -1,7 +1,7 @@
 import Smelter from '@swmansion/smelter-node';
 import { View, Text, Image } from '@swmansion/smelter';
 import { useEffect, useState } from 'react';
-import { ffplayStartPlayerAsync, sleep } from './utils';
+import { ffplayStartRtmpServerAsync } from './utils';
 
 type PartialTextProps = {
   text: string;
@@ -58,8 +58,7 @@ async function run() {
   const smelter = new Smelter();
   await smelter.init();
 
-  await ffplayStartPlayerAsync('127.0.0.1', 8001);
-  await sleep(2000);
+  await ffplayStartRtmpServerAsync(9002);
 
   await smelter.registerFont(
     'https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9a6Vc.ttf'
@@ -71,10 +70,8 @@ async function run() {
   });
 
   await smelter.registerOutput('output_1', <ExampleApp />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:9002',
     video: {
       encoder: {
         type: 'ffmpeg_h264',

--- a/ts/examples/node-examples/src/simple.tsx
+++ b/ts/examples/node-examples/src/simple.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Smelter from '@swmansion/smelter-node';
 import { View, Text } from '@swmansion/smelter';
-import { ffplayStartPlayerAsync, sleep } from './utils';
+import { ffplayStartRtmpServerAsync } from './utils';
 
 type PartialTextProps = {
   text: string;
@@ -44,14 +44,11 @@ async function run() {
   const smelter = new Smelter();
   await smelter.init();
 
-  void ffplayStartPlayerAsync('127.0.0.1', 8001);
-  await sleep(2000);
+  await ffplayStartRtmpServerAsync(9002);
 
   await smelter.registerOutput('output_1', <ExampleApp />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:9002',
     video: {
       encoder: {
         type: 'ffmpeg_h264',

--- a/ts/examples/node-examples/src/utils.ts
+++ b/ts/examples/node-examples/src/utils.ts
@@ -10,7 +10,7 @@ const pipeline = promisify(Stream.pipeline);
 
 const TMP_SDP_DIR = '/tmp/smelter-examples';
 
-export async function ffplayStartPlayerAsync(
+export async function ffplayStartRtpServerAsync(
   ip: string,
   video_port: number,
   audio_port: number | undefined = undefined
@@ -26,6 +26,18 @@ export async function ffplayStartPlayerAsync(
   }
 
   const promise = spawn('ffplay', ['-protocol_whitelist', 'file,rtp,udp', sdpFilePath]);
+  await sleep(2000);
+  return { spawn_promise: promise };
+}
+
+export async function ffplayStartRtmpServerAsync(
+  port: number
+): Promise<{ spawn_promise: SpawnPromise }> {
+  const promise = spawn('bash', [
+    '-c',
+    `ffmpeg -f flv -listen 1 -i rtmp://0.0.0.0:${port} -vcodec copy  -f flv - | ffplay -f flv -i -`,
+  ]);
+  await sleep(2000);
   return { spawn_promise: promise };
 }
 

--- a/ts/examples/node-examples/src/web-view.tsx
+++ b/ts/examples/node-examples/src/web-view.tsx
@@ -1,6 +1,6 @@
 import Smelter, { LocallySpawnedInstanceManager } from '@swmansion/smelter-node';
 import { Image, View, WebView, Text, Rescaler, Mp4 } from '@swmansion/smelter';
-import { ffplayStartPlayerAsync, sleep } from './utils';
+import { ffplayStartRtmpServerAsync } from './utils';
 import path from 'path';
 
 const WEBSITE_INSTANCE = 'example_website';
@@ -31,8 +31,7 @@ async function run() {
   );
   await smelter.init();
 
-  void ffplayStartPlayerAsync('127.0.0.1', 8001);
-  await sleep(2000);
+  await ffplayStartRtmpServerAsync(9002);
 
   await smelter.registerImage('logo', {
     assetType: 'svg',
@@ -45,10 +44,8 @@ async function run() {
     embeddingMethod: 'native_embedding_over_content',
   });
   await smelter.registerOutput('output_1', <ExampleApp />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:9002',
     video: {
       encoder: {
         type: 'ffmpeg_h264',

--- a/ts/smelter-core/src/api/output.ts
+++ b/ts/smelter-core/src/api/output.ts
@@ -4,11 +4,13 @@ import type {
   RegisterMp4Output,
   RegisterWhipOutput,
   _smelterInternals,
+  RegisterRtmpClientOutput,
 } from '@swmansion/smelter';
 import { inputRefIntoRawId } from './input';
 import { intoRegisterWhipOutput } from './output/whip';
 import { intoRegisterRtpOutput } from './output/rtp';
 import { intoRegisterMp4Output } from './output/mp4';
+import { intoRegisterRtmpClientOutput } from './output/rtmp';
 
 /**
  * It represents HTTP request that can be sent to
@@ -62,6 +64,7 @@ export type RegisterOutput =
   | ({ type: 'rtp_stream' } & RegisterRtpOutput)
   | ({ type: 'mp4' } & RegisterMp4Output)
   | ({ type: 'whip' } & RegisterWhipOutput)
+  | ({ type: 'rtmp_client' } & RegisterRtmpClientOutput)
   | RegisterWasmSpecificOutput;
 
 export function intoRegisterOutput(
@@ -77,6 +80,8 @@ export function intoRegisterOutput(
     return intoRegisterMp4Output(output, initial);
   } else if (output.type === 'whip') {
     return intoRegisterWhipOutput(output, initial);
+  } else if (output.type === 'rtmp_client') {
+    return intoRegisterRtmpClientOutput(output, initial);
   } else if (['web-wasm-canvas', 'web-wasm-whip', 'web-wasm-stream'].includes(output.type)) {
     // just pass wasm types as they are, they will not be serialized
     return { ...output, initial };

--- a/ts/smelter-core/src/api/output/rtmp.ts
+++ b/ts/smelter-core/src/api/output/rtmp.ts
@@ -1,0 +1,40 @@
+import type { Api, Outputs, _smelterInternals } from '@swmansion/smelter';
+import type { RegisterOutputRequest } from '../output';
+import { intoOutputEosCondition, intoOutputVideoOptions } from './common';
+
+export function intoRegisterRtmpClientOutput(
+  output: Outputs.RegisterRtmpClientOutput,
+  initial: { video?: Api.Video; audio?: Api.Audio }
+): RegisterOutputRequest {
+  return {
+    type: 'rtmp_client',
+    url: output.url,
+
+    video: output.video && initial.video && intoOutputVideoOptions(output.video, initial.video),
+    audio:
+      output.audio &&
+      initial.audio &&
+      intoOutputRtmpClientAudioOptions(output.audio, initial.audio),
+  };
+}
+
+function intoOutputRtmpClientAudioOptions(
+  audio: Outputs.RtmpClientAudioOptions,
+  initial: Api.Audio
+): Api.OutputRtmpClientAudioOptions {
+  return {
+    send_eos_when: audio.sendEosWhen && intoOutputEosCondition(audio.sendEosWhen),
+    encoder: intoRtmpClientAudioEncoderOptions(audio.encoder),
+    initial,
+  };
+}
+
+function intoRtmpClientAudioEncoderOptions(
+  encoder: Outputs.RtmpClientAudioEncoderOptions
+): Api.RtmpClientAudioEncoderOptions {
+  return {
+    type: 'aac',
+    channels: encoder.channels,
+    sample_rate: encoder.sampleRate,
+  };
+}

--- a/ts/smelter-node/src/api.ts
+++ b/ts/smelter-node/src/api.ts
@@ -1,0 +1,20 @@
+import type {
+  RegisterMp4Input,
+  RegisterMp4Output,
+  RegisterRtmpClientOutput,
+  RegisterRtpInput,
+  RegisterRtpOutput,
+  RegisterWhipInput,
+  RegisterWhipOutput,
+} from '@swmansion/smelter';
+
+export type RegisterOutput =
+  | ({ type: 'rtp_stream' } & RegisterRtpOutput)
+  | ({ type: 'mp4' } & RegisterMp4Output)
+  | ({ type: 'whip' } & RegisterWhipOutput)
+  | ({ type: 'rtmp_client' } & RegisterRtmpClientOutput);
+
+export type RegisterInput =
+  | ({ type: 'rtp_stream' } & RegisterRtpInput)
+  | ({ type: 'mp4' } & RegisterMp4Input)
+  | ({ type: 'whip' } & RegisterWhipInput);

--- a/ts/smelter-node/src/live/compositor.ts
+++ b/ts/smelter-node/src/live/compositor.ts
@@ -1,22 +1,20 @@
-import type {
-  SmelterManager,
-  Input as CoreInput,
-  Output as CoreOutput,
-} from '@swmansion/smelter-core';
-import { Smelter as CoreSmelter } from '@swmansion/smelter-core';
-import { createLogger } from '../logger';
-import LocallySpawnedInstanceManager from '../manager/locallySpawnedInstance';
 import type { ReactElement } from 'react';
-import type { Renderers } from '@swmansion/smelter';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
+import type { Renderers } from '@swmansion/smelter';
+import type { SmelterManager } from '@swmansion/smelter-core';
+import { Smelter as CoreSmelter } from '@swmansion/smelter-core';
+
+import LocallySpawnedInstance from '../manager/locallySpawnedInstance';
+import { createLogger } from '../logger';
+import type { RegisterInput, RegisterOutput } from '../api';
 
 export default class Smelter {
   private coreSmelter: CoreSmelter;
 
   public constructor(manager?: SmelterManager) {
     this.coreSmelter = new CoreSmelter(
-      manager ?? LocallySpawnedInstanceManager.defaultManager(),
+      manager ?? LocallySpawnedInstance.defaultManager(),
       createLogger()
     );
   }
@@ -28,7 +26,7 @@ export default class Smelter {
   public async registerOutput(
     outputId: string,
     root: ReactElement,
-    request: CoreOutput.RegisterOutput
+    request: RegisterOutput
   ): Promise<void> {
     await this.coreSmelter.registerOutput(outputId, root, request);
   }
@@ -37,7 +35,7 @@ export default class Smelter {
     await this.coreSmelter.unregisterOutput(outputId);
   }
 
-  public async registerInput(inputId: string, request: CoreInput.RegisterInput): Promise<void> {
+  public async registerInput(inputId: string, request: RegisterInput): Promise<void> {
     await this.coreSmelter.registerInput(inputId, request);
   }
 

--- a/ts/smelter-node/src/offline/compositor.ts
+++ b/ts/smelter-node/src/offline/compositor.ts
@@ -1,15 +1,13 @@
-import type {
-  Input as CoreInput,
-  Output as CoreOutput,
-  SmelterManager,
-} from '@swmansion/smelter-core';
-import { OfflineSmelter as CoreSmelter } from '@swmansion/smelter-core';
-import { createLogger } from '../logger';
-import LocallySpawnedInstanceManager from '../manager/locallySpawnedInstance';
-import type { ReactElement } from 'react';
-import type { Renderers } from '@swmansion/smelter';
 import fetch from 'node-fetch';
 import FormData from 'form-data';
+import type { ReactElement } from 'react';
+import type { SmelterManager } from '@swmansion/smelter-core';
+import { OfflineSmelter as CoreSmelter } from '@swmansion/smelter-core';
+import type { Renderers } from '@swmansion/smelter';
+
+import type { RegisterInput, RegisterOutput } from '../api';
+import { createLogger } from '../logger';
+import LocallySpawnedInstanceManager from '../manager/locallySpawnedInstance';
 
 export default class OfflineSmelter {
   private coreSmelter: CoreSmelter;
@@ -25,11 +23,11 @@ export default class OfflineSmelter {
     await this.coreSmelter.init();
   }
 
-  public async render(root: ReactElement, request: CoreOutput.RegisterOutput, durationMs?: number) {
+  public async render(root: ReactElement, request: RegisterOutput, durationMs?: number) {
     await this.coreSmelter.render(root, request, durationMs);
   }
 
-  public async registerInput(inputId: string, request: CoreInput.RegisterInput) {
+  public async registerInput(inputId: string, request: RegisterInput) {
     await this.coreSmelter.registerInput(inputId, request);
   }
 

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -6,8 +6,7 @@
  */
 
 /**
- * This enum is used to generate JSON schema for all API types.
- * This prevents repeating types in generated schema.
+ * This enum is used to generate JSON schema for all API types. This prevents repeating types in generated schema.
  */
 export type ApiTypes = RegisterInput | RegisterOutput | ImageSpec | WebRendererSpec | ShaderSpec | UpdateOutputRequest;
 export type RegisterInput =
@@ -30,14 +29,11 @@ export type RegisterInput =
        */
       audio?: InputRtpAudioOptions | null;
       /**
-       * (**default=`false`**) If input is required and the stream is not delivered
-       * on time, then Smelter will delay producing output frames.
+       * (**default=`false`**) If input is required and the stream is not delivered on time, then Smelter will delay producing output frames.
        */
       required?: boolean | null;
       /**
-       * Offset in milliseconds relative to the pipeline start (start request). If the offset is
-       * not defined then the stream will be synchronized based on the delivery time of the initial
-       * frames.
+       * Offset in milliseconds relative to the pipeline start (start request). If the offset is not defined then the stream will be synchronized based on the delivery time of the initial frames.
        */
       offset_ms?: number | null;
     }
@@ -56,13 +52,11 @@ export type RegisterInput =
        */
       loop?: boolean | null;
       /**
-       * (**default=`false`**) If input is required and frames are not processed
-       * on time, then Smelter will delay producing output frames.
+       * (**default=`false`**) If input is required and frames are not processed on time, then Smelter will delay producing output frames.
        */
       required?: boolean | null;
       /**
-       * Offset in milliseconds relative to the pipeline start (start request). If offset is
-       * not defined then stream is synchronized based on the first frames delivery time.
+       * Offset in milliseconds relative to the pipeline start (start request). If offset is not defined then stream is synchronized based on the first frames delivery time.
        */
       offset_ms?: number | null;
       /**
@@ -81,43 +75,32 @@ export type RegisterInput =
        */
       audio?: InputWhipAudioOptions | null;
       /**
-       * (**default=`false`**) If input is required and the stream is not delivered
-       * on time, then Smelter will delay producing output frames.
+       * (**default=`false`**) If input is required and the stream is not delivered on time, then Smelter will delay producing output frames.
        */
       required?: boolean | null;
       /**
-       * Offset in milliseconds relative to the pipeline start (start request). If the offset is
-       * not defined then the stream will be synchronized based on the delivery time of the initial
-       * frames.
+       * Offset in milliseconds relative to the pipeline start (start request). If the offset is not defined then the stream will be synchronized based on the delivery time of the initial frames.
        */
       offset_ms?: number | null;
     }
   | {
       type: "decklink";
       /**
-       * Single DeckLink device can consist of multiple sub-devices. This field defines
-       * index of sub-device that should be used.
+       * Single DeckLink device can consist of multiple sub-devices. This field defines index of sub-device that should be used.
        *
-       * The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`.
-       * All of them need to match the device if they are specified. If nothing is matched, the error response
-       * will list available devices.
+       * The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`. All of them need to match the device if they are specified. If nothing is matched, the error response will list available devices.
        */
       subdevice_index?: number | null;
       /**
-       * Select sub-device to use based on the display name. This is the value you see in e.g.
-       * Blackmagic Media Express app. like "DeckLink Quad HDMI Recorder (3)"
+       * Select sub-device to use based on the display name. This is the value you see in e.g. Blackmagic Media Express app. like "DeckLink Quad HDMI Recorder (3)"
        *
-       * The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`.
-       * All of them need to match the device if they are specified. If nothing is matched, the error response
-       * will list available devices.
+       * The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`. All of them need to match the device if they are specified. If nothing is matched, the error response will list available devices.
        */
       display_name?: string | null;
       /**
        * Persistent ID of a device represented by 32-bit hex number. Each DeckLink sub-device has a separate id.
        *
-       * The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`.
-       * All of them need to match the device if they are specified. If nothing is matched, the error response
-       * will list available devices.
+       * The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`. All of them need to match the device if they are specified. If nothing is matched, the error response will list available devices.
        */
       persistent_id?: string | null;
       /**
@@ -125,8 +108,7 @@ export type RegisterInput =
        */
       enable_audio?: boolean | null;
       /**
-       * (**default=`false`**) If input is required and frames are not processed
-       * on time, then Smelter will delay producing output frames.
+       * (**default=`false`**) If input is required and frames are not processed on time, then Smelter will delay producing output frames.
        */
       required?: boolean | null;
     };
@@ -137,34 +119,24 @@ export type InputRtpAudioOptions =
   | {
       decoder: "opus";
       /**
-       * (**default=`false`**) Specifies whether the stream uses forward error correction.
-       * It's specific for Opus codec.
-       * For more information, check out [RFC](https://datatracker.ietf.org/doc/html/rfc6716#section-2.1.7).
+       * (**default=`false`**) Specifies whether the stream uses forward error correction. It's specific for Opus codec. For more information, check out [RFC](https://datatracker.ietf.org/doc/html/rfc6716#section-2.1.7).
        */
       forward_error_correction?: boolean | null;
     }
   | {
       decoder: "aac";
       /**
-       * AudioSpecificConfig as described in MPEG-4 part 3, section 1.6.2.1
-       * The config should be encoded as described in [RFC 3640](https://datatracker.ietf.org/doc/html/rfc3640#section-4.1).
+       * AudioSpecificConfig as described in MPEG-4 part 3, section 1.6.2.1 The config should be encoded as described in [RFC 3640](https://datatracker.ietf.org/doc/html/rfc3640#section-4.1).
        *
-       * The simplest way to obtain this value when using ffmpeg to stream to the compositor is
-       * to pass the additional `-sdp_file FILENAME` option to ffmpeg. This will cause it to
-       * write out an sdp file, which will contain this field. Programs which have the ability
-       * to stream AAC to the compositor should provide this information.
+       * The simplest way to obtain this value when using ffmpeg to stream to the compositor is to pass the additional `-sdp_file FILENAME` option to ffmpeg. This will cause it to write out an sdp file, which will contain this field. Programs which have the ability to stream AAC to the compositor should provide this information.
        *
-       * In MP4 files, the ASC is embedded inside the esds box (note that it is not the whole
-       * box, only a part of it). This also applies to fragmented MP4s downloaded over HLS, if
-       * the playlist uses MP4s instead of MPEG Transport Streams
+       * In MP4 files, the ASC is embedded inside the esds box (note that it is not the whole box, only a part of it). This also applies to fragmented MP4s downloaded over HLS, if the playlist uses MP4s instead of MPEG Transport Streams
        *
        * In FLV files and the RTMP protocol, the ASC can be found in the `AACAUDIODATA` tag.
        */
       audio_specific_config: string;
       /**
-       * (**default=`"high_bitrate"`**)
-       * Specifies the [RFC 3640 mode](https://datatracker.ietf.org/doc/html/rfc3640#section-3.3.1)
-       * that should be used when depacketizing this stream.
+       * (**default=`"high_bitrate"`**) Specifies the [RFC 3640 mode](https://datatracker.ietf.org/doc/html/rfc3640#section-3.3.1) that should be used when depacketizing this stream.
        */
       rtp_mode?: AacRtpMode | null;
     };
@@ -172,9 +144,7 @@ export type AacRtpMode = "low_bitrate" | "high_bitrate";
 export type InputWhipAudioOptions = {
   decoder: "opus";
   /**
-   * (**default=`false`**) Specifies whether the stream uses forward error correction.
-   * It's specific for Opus codec.
-   * For more information, check out [RFC](https://datatracker.ietf.org/doc/html/rfc6716#section-2.1.7).
+   * (**default=`false`**) Specifies whether the stream uses forward error correction. It's specific for Opus codec. For more information, check out [RFC](https://datatracker.ietf.org/doc/html/rfc6716#section-2.1.7).
    */
   forward_error_correction?: boolean | null;
 };
@@ -182,9 +152,7 @@ export type RegisterOutput =
   | {
       type: "rtp_stream";
       /**
-       * Depends on the value of the `transport_protocol` field:
-       * - `udp` - An UDP port number that RTP packets will be sent to.
-       * - `tcp_server` - A local TCP port number or a port range that Smelter will listen for incoming connections.
+       * Depends on the value of the `transport_protocol` field: - `udp` - An UDP port number that RTP packets will be sent to. - `tcp_server` - A local TCP port number or a port range that Smelter will listen for incoming connections.
        */
       port: PortOrPortRange;
       /**
@@ -203,6 +171,18 @@ export type RegisterOutput =
        * Audio stream configuration.
        */
       audio?: OutputRtpAudioOptions | null;
+    }
+  | {
+      type: "rtmp_client";
+      url: string;
+      /**
+       * Video stream configuration.
+       */
+      video?: OutputVideoOptions | null;
+      /**
+       * Audio stream configuration.
+       */
+      audio?: OutputRtmpClientAudioOptions | null;
     }
   | {
       type: "mp4";
@@ -236,19 +216,29 @@ export type RegisterOutput =
       audio?: OutputWhipAudioOptions | null;
     };
 export type InputId = string;
-export type VideoEncoderOptions = {
-  type: "ffmpeg_h264";
-  /**
-   * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
-   */
-  preset?: H264EncoderPreset | null;
-  /**
-   * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
-   */
-  ffmpeg_options?: {
-    [k: string]: string;
-  } | null;
-};
+export type VideoEncoderOptions =
+  | {
+      type: "ffmpeg_h264";
+      /**
+       * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
+       */
+      preset?: H264EncoderPreset | null;
+      /**
+       * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
+       */
+      ffmpeg_options?: {
+        [k: string]: string;
+      } | null;
+    }
+  | {
+      type: "ffmpeg_vp8";
+      /**
+       * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
+       */
+      ffmpeg_options?: {
+        [k: string]: string;
+      } | null;
+    };
 export type H264EncoderPreset =
   | "ultrafast"
   | "superfast"
@@ -283,19 +273,11 @@ export type Component =
        */
       children?: Component[] | null;
       /**
-       * Width of a component in pixels (without a border). Exact behavior might be different
-       * based on the parent component:
-       * - If the parent component is a layout, check sections "Absolute positioning" and "Static
-       * positioning" of that component.
-       * - If the parent component is not a layout, then this field is required.
+       * Width of a component in pixels (without a border). Exact behavior might be different based on the parent component: - If the parent component is a layout, check sections "Absolute positioning" and "Static positioning" of that component. - If the parent component is not a layout, then this field is required.
        */
       width?: number | null;
       /**
-       * Height of a component in pixels (without a border). Exact behavior might be different
-       * based on the parent component:
-       * - If the parent component is a layout, check sections "Absolute positioning" and "Static
-       * positioning" of that component.
-       * - If the parent component is not a layout, then this field is required.
+       * Height of a component in pixels (without a border). Exact behavior might be different based on the parent component: - If the parent component is a layout, check sections "Absolute positioning" and "Static positioning" of that component. - If the parent component is not a layout, then this field is required.
        */
       height?: number | null;
       /**
@@ -303,36 +285,27 @@ export type Component =
        */
       direction?: ViewDirection | null;
       /**
-       * Distance in pixels between this component's top edge and its parent's top edge (including a border).
-       * If this field is defined, then the component will ignore a layout defined by its parent.
+       * Distance in pixels between this component's top edge and its parent's top edge (including a border). If this field is defined, then the component will ignore a layout defined by its parent.
        */
       top?: number | null;
       /**
-       * Distance in pixels between this component's left edge and its parent's left edge (including a border).
-       * If this field is defined, this element will be absolutely positioned, instead of being
-       * laid out by its parent.
+       * Distance in pixels between this component's left edge and its parent's left edge (including a border). If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       left?: number | null;
       /**
-       * Distance in pixels between the bottom edge of this component and the bottom edge of its
-       * parent (including a border). If this field is defined, this element will be absolutely
-       * positioned, instead of being laid out by its parent.
+       * Distance in pixels between the bottom edge of this component and the bottom edge of its parent (including a border). If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       bottom?: number | null;
       /**
-       * Distance in pixels between this component's right edge and its parent's right edge.
-       * If this field is defined, this element will be absolutely positioned, instead of being
-       * laid out by its parent.
+       * Distance in pixels between this component's right edge and its parent's right edge. If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       right?: number | null;
       /**
-       * Rotation of a component in degrees. If this field is defined, this element will be
-       * absolutely positioned, instead of being laid out by its parent.
+       * Rotation of a component in degrees. If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       rotation?: number | null;
       /**
-       * Defines how this component will behave during a scene update. This will only have an
-       * effect if the previous scene already contained a `View` component with the same id.
+       * Defines how this component will behave during a scene update. This will only have an effect if the previous scene already contained a `View` component with the same id.
        */
       transition?: Transition | null;
       /**
@@ -399,12 +372,9 @@ export type Component =
        */
       children?: Component[] | null;
       /**
-       * Id of a web renderer instance. It identifies an instance registered using a
-       * [`register web renderer`](../routes.md#register-web-renderer-instance) request.
+       * Id of a web renderer instance. It identifies an instance registered using a [`register web renderer`](../routes.md#register-web-renderer-instance) request.
        *
-       * :::warning
-       * You can only refer to specific instances in one Component at a time.
-       * :::
+       * :::warning You can only refer to specific instances in one Component at a time. :::
        */
       instance_id: RendererId;
     }
@@ -425,15 +395,7 @@ export type Component =
       /**
        * Object that will be serialized into a `struct` and passed inside the shader as:
        *
-       * ```wgsl
-       * @group(1) @binding(0) var<uniform>
-       * ```
-       * :::note
-       * This object's structure must match the structure defined in a shader source code.
-       * Currently, we do not handle memory layout automatically. To achieve the correct memory
-       * alignment, you might need to pad your data with additional fields. See
-       * [WGSL documentation](https://www.w3.org/TR/WGSL/#alignment-and-size) for more details.
-       * :::
+       * ```wgsl @group(1) @binding(0) var<uniform> ``` :::note This object's structure must match the structure defined in a shader source code. Currently, we do not handle memory layout automatically. To achieve the correct memory alignment, you might need to pad your data with additional fields. See [WGSL documentation](https://www.w3.org/TR/WGSL/#alignment-and-size) for more details. :::
        */
       shader_param?: ShaderParam | null;
       /**
@@ -463,24 +425,19 @@ export type Component =
        */
       text: string;
       /**
-       * Width of a texture that text will be rendered on. If not provided, the resulting texture
-       * will be sized based on the defined text but limited to `max_width` value.
+       * Width of a texture that text will be rendered on. If not provided, the resulting texture will be sized based on the defined text but limited to `max_width` value.
        */
       width?: number | null;
       /**
-       * Height of a texture that text will be rendered on. If not provided, the resulting texture
-       * will be sized based on the defined text but limited to `max_height` value.
-       * It's an error to provide `height` if `width` is not defined.
+       * Height of a texture that text will be rendered on. If not provided, the resulting texture will be sized based on the defined text but limited to `max_height` value. It's an error to provide `height` if `width` is not defined.
        */
       height?: number | null;
       /**
-       * (**default=`7682`**) Maximal `width`. Limits the width of the texture that the text will be rendered on.
-       * Value is ignored if `width` is defined.
+       * (**default=`7682`**) Maximal `width`. Limits the width of the texture that the text will be rendered on. Value is ignored if `width` is defined.
        */
       max_width?: number | null;
       /**
-       * (**default=`4320`**) Maximal `height`. Limits the height of the texture that the text will be rendered on.
-       * Value is ignored if height is defined.
+       * (**default=`4320`**) Maximal `height`. Limits the height of the texture that the text will be rendered on. Value is ignored if height is defined.
        */
       max_height?: number | null;
       /**
@@ -500,8 +457,7 @@ export type Component =
        */
       background_color?: RGBAColor | null;
       /**
-       * (**default=`"Verdana"`**) Font family. Provide [family-name](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value)
-       * for a specific font. "generic-family" values like e.g. "sans-serif" will not work.
+       * (**default=`"Verdana"`**) Font family. Provide [family-name](https://www.w3.org/TR/2018/REC-css-fonts-3-20180920/#family-name-value) for a specific font. "generic-family" values like e.g. "sans-serif" will not work.
        */
       font_family?: string | null;
       /**
@@ -532,19 +488,11 @@ export type Component =
        */
       children?: Component[] | null;
       /**
-       * Width of a component in pixels. Exact behavior might be different based on the parent
-       * component:
-       * - If the parent component is a layout, check sections "Absolute positioning" and "Static
-       * positioning" of that component.
-       * - If the parent component is not a layout, then this field is required.
+       * Width of a component in pixels. Exact behavior might be different based on the parent component: - If the parent component is a layout, check sections "Absolute positioning" and "Static positioning" of that component. - If the parent component is not a layout, then this field is required.
        */
       width?: number | null;
       /**
-       * Height of a component in pixels. Exact behavior might be different based on the parent
-       * component:
-       * - If the parent component is a layout, check sections "Absolute positioning" and "Static
-       * positioning" of that component.
-       * - If the parent component is not a layout, then this field is required.
+       * Height of a component in pixels. Exact behavior might be different based on the parent component: - If the parent component is a layout, check sections "Absolute positioning" and "Static positioning" of that component. - If the parent component is not a layout, then this field is required.
        */
       height?: number | null;
       /**
@@ -572,8 +520,7 @@ export type Component =
        */
       vertical_align?: VerticalAlign | null;
       /**
-       * Defines how this component will behave during a scene update. This will only have an
-       * effect if the previous scene already contained a `Tiles` component with the same id.
+       * Defines how this component will behave during a scene update. This will only have an effect if the previous scene already contained a `Tiles` component with the same id.
        */
       transition?: Transition | null;
     }
@@ -600,52 +547,35 @@ export type Component =
        */
       vertical_align?: VerticalAlign | null;
       /**
-       * Width of a component in pixels (without a border). Exact behavior might be different
-       * based on the parent component:
-       * - If the parent component is a layout, check sections "Absolute positioning" and "Static
-       * positioning" of that component.
-       * - If the parent component is not a layout, then this field is required.
+       * Width of a component in pixels (without a border). Exact behavior might be different based on the parent component: - If the parent component is a layout, check sections "Absolute positioning" and "Static positioning" of that component. - If the parent component is not a layout, then this field is required.
        */
       width?: number | null;
       /**
-       * Height of a component in pixels (without a border). Exact behavior might be different
-       * based on the parent component:
-       * - If the parent component is a layout, check sections "Absolute positioning" and "Static
-       * positioning" of that component.
-       * - If the parent component is not a layout, then this field is required.
+       * Height of a component in pixels (without a border). Exact behavior might be different based on the parent component: - If the parent component is a layout, check sections "Absolute positioning" and "Static positioning" of that component. - If the parent component is not a layout, then this field is required.
        */
       height?: number | null;
       /**
-       * Distance in pixels between this component's top edge and its parent's top edge (including a border).
-       * If this field is defined, then the component will ignore a layout defined by its parent.
+       * Distance in pixels between this component's top edge and its parent's top edge (including a border). If this field is defined, then the component will ignore a layout defined by its parent.
        */
       top?: number | null;
       /**
-       * Distance in pixels between this component's left edge and its parent's left edge (including a border).
-       * If this field is defined, this element will be absolutely positioned, instead of being
-       * laid out by its parent.
+       * Distance in pixels between this component's left edge and its parent's left edge (including a border). If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       left?: number | null;
       /**
-       * Distance in pixels between the bottom edge of this component and the bottom edge of its
-       * parent (including a border). If this field is defined, this element will be absolutely
-       * positioned, instead of being laid out by its parent.
+       * Distance in pixels between the bottom edge of this component and the bottom edge of its parent (including a border). If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       bottom?: number | null;
       /**
-       * Distance in pixels between this component's right edge and its parent's right edge.
-       * If this field is defined, this element will be absolutely positioned, instead of being
-       * laid out by its parent.
+       * Distance in pixels between this component's right edge and its parent's right edge. If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       right?: number | null;
       /**
-       * Rotation of a component in degrees. If this field is defined, this element will be
-       * absolutely positioned, instead of being laid out by its parent.
+       * Rotation of a component in degrees. If this field is defined, this element will be absolutely positioned, instead of being laid out by its parent.
        */
       rotation?: number | null;
       /**
-       * Defines how this component will behave during a scene update. This will only have an
-       * effect if the previous scene already contained a `Rescaler` component with the same id.
+       * Defines how this component will behave during a scene update. This will only have an effect if the previous scene already contained a `Rescaler` component with the same id.
        */
       transition?: Transition | null;
       /**
@@ -670,9 +600,7 @@ export type ViewDirection = "row" | "column";
 /**
  * Easing functions are used to interpolate between two values over time.
  *
- * Custom easing functions can be implemented with cubic Bézier.
- * The control points are defined with `points` field by providing four numerical values: `x1`, `y1`, `x2` and `y2`. The `x1` and `x2` values have to be in the range `[0; 1]`. The cubic Bézier result is clamped to the range `[0; 1]`.
- * You can find example control point configurations [here](https://easings.net/).
+ * Custom easing functions can be implemented with cubic Bézier. The control points are defined with `points` field by providing four numerical values: `x1`, `y1`, `x2` and `y2`. The `x1` and `x2` values have to be in the range `[0; 1]`. The cubic Bézier result is clamped to the range `[0; 1]`. You can find example control point configurations [here](https://easings.net/).
  */
 export type EasingFunction =
   | {
@@ -779,6 +707,14 @@ export type RtpAudioEncoderOptions = {
 };
 export type AudioChannels = "mono" | "stereo";
 export type OpusEncoderPreset = "quality" | "voip" | "lowest_latency";
+export type RtmpClientAudioEncoderOptions = {
+  type: "aac";
+  channels: AudioChannels;
+  /**
+   * (**default=`48000`**) Sample rate. Allowed values: [8000, 16000, 24000, 44100, 48000].
+   */
+  sample_rate?: number | null;
+};
 export type Mp4AudioEncoderOptions = {
   type: "aac";
   channels: AudioChannels;
@@ -864,12 +800,7 @@ export interface Resolution {
   height: number;
 }
 /**
- * This type defines when end of an input stream should trigger end of the output stream. Only one of those fields can be set at the time.
- * Unless specified otherwise the input stream is considered finished/ended when:
- * - TCP connection was dropped/closed.
- * - RTCP Goodbye packet (`BYE`) was received.
- * - Mp4 track has ended.
- * - Input was unregistered already (or never registered).
+ * This type defines when end of an input stream should trigger end of the output stream. Only one of those fields can be set at the time. Unless specified otherwise the input stream is considered finished/ended when: - TCP connection was dropped/closed. - RTCP Goodbye packet (`BYE`) was received. - Mp4 track has ended. - Input was unregistered already (or never registered).
  */
 export interface OutputEndCondition {
   /**
@@ -935,6 +866,24 @@ export interface InputAudio {
    * (**default=`1.0`**) float in `[0, 1]` range representing input volume
    */
   volume?: number | null;
+}
+export interface OutputRtmpClientAudioOptions {
+  /**
+   * (**default="sum_clip"**) Specifies how audio should be mixed.
+   */
+  mixing_strategy?: MixingStrategy | null;
+  /**
+   * Condition for termination of output stream based on the input streams states.
+   */
+  send_eos_when?: OutputEndCondition | null;
+  /**
+   * Audio encoder options.
+   */
+  encoder: RtmpClientAudioEncoderOptions;
+  /**
+   * Initial audio mixer configuration for output.
+   */
+  initial: Audio;
 }
 export interface OutputMp4AudioOptions {
   /**

--- a/ts/smelter/src/index.ts
+++ b/ts/smelter/src/index.ts
@@ -19,7 +19,12 @@ import { SlideShow, Slide, SlideProps, SlideShowProps } from './components/Slide
 import Mp4, { Mp4Props } from './components/Mp4.js';
 
 export { RegisterRtpInput, RegisterMp4Input, RegisterWhipInput } from './types/input.js';
-export { RegisterRtpOutput, RegisterMp4Output, RegisterWhipOutput } from './types/output.js';
+export {
+  RegisterRtpOutput,
+  RegisterMp4Output,
+  RegisterWhipOutput,
+  RegisterRtmpClientOutput,
+} from './types/output.js';
 
 export * as Inputs from './types/input.js';
 export * as Outputs from './types/output.js';

--- a/ts/smelter/src/types/output.ts
+++ b/ts/smelter/src/types/output.ts
@@ -1,5 +1,6 @@
 import type * as Api from '../api.js';
 import type { Mp4AudioOptions, Mp4VideoOptions } from './output/mp4.js';
+import type { RtmpClientAudioOptions, RtmpClientVideoOptions } from './output/rtmp.js';
 import type { RtpAudioOptions, RtpVideoOptions } from './output/rtp.js';
 import type { WhipAudioOptions, WhipVideoOptions } from './output/whip.js';
 
@@ -7,6 +8,7 @@ export * from './output/mp4.js';
 export * from './output/whip.js';
 export * from './output/rtp.js';
 export * from './output/common.js';
+export * from './output/rtmp.js';
 
 export type RegisterRtpOutput = {
   /**
@@ -59,4 +61,19 @@ export type RegisterWhipOutput = {
    * Audio track configuration.
    */
   audio?: WhipAudioOptions | null;
+};
+
+export type RegisterRtmpClientOutput = {
+  /**
+   * RTMP url.
+   */
+  url: string;
+  /**
+   * Video track configuration.
+   */
+  video?: RtmpClientVideoOptions | null;
+  /**
+   * Audio track configuration.
+   */
+  audio?: RtmpClientAudioOptions | null;
 };

--- a/ts/smelter/src/types/output/rtmp.ts
+++ b/ts/smelter/src/types/output/rtmp.ts
@@ -1,0 +1,53 @@
+import type * as Api from '../../api.js';
+import type { OutputEndCondition } from './common.js';
+
+export type RtmpClientVideoOptions = {
+  /**
+   * Output resolution in pixels.
+   */
+  resolution: Api.Resolution;
+  /**
+   * Defines when output stream should end if some of the input streams are finished. If output includes both audio and video streams, then EOS needs to be sent on both.
+   */
+  sendEosWhen?: OutputEndCondition | null;
+  /**
+   * Video encoder options.
+   */
+  encoder: RtmpClientVideoEncoderOptions;
+};
+
+export type RtmpClientVideoEncoderOptions = {
+  type: 'ffmpeg_h264';
+  /**
+   * (**default=`"fast"`**) Preset for an encoder. See `FFmpeg` [docs](https://trac.ffmpeg.org/wiki/Encode/H.264#Preset) to learn more.
+   */
+  preset: Api.H264EncoderPreset;
+  /**
+   * Raw FFmpeg encoder options. See [docs](https://ffmpeg.org/ffmpeg-codecs.html) for more.
+   */
+  ffmpegOptions?: Api.VideoEncoderOptions['ffmpeg_options'];
+};
+
+export type RtmpClientAudioOptions = {
+  /**
+   * (**default="sum_clip"**) Specifies how audio should be mixed.
+   */
+  mixingStrategy?: Api.MixingStrategy | null;
+  /**
+   * Condition for termination of output stream based on the input streams states.
+   */
+  sendEosWhen?: OutputEndCondition | null;
+  /**
+   * Audio encoder options.
+   */
+  encoder: RtmpClientAudioEncoderOptions;
+};
+
+export type RtmpClientAudioEncoderOptions = {
+  type: 'aac';
+  channels: Api.AudioChannels;
+  /**
+   * (**default=`48000`**) Sample rate. Allowed values: [8000, 16000, 24000, 44100, 48000].
+   */
+  sampleRate?: number;
+};


### PR DESCRIPTION
Rust
- Few type renames
- change default sample rate for RTMP

JS
- Add types
- switch templates and examples to use RTMP instead of RTP