### PR TITLE
Refactor output audio api, move `channels` from encoder options to audio options

### DIFF
--- a/compositor_api/src/types/from_register_output.rs
+++ b/compositor_api/src/types/from_register_output.rs
@@ -5,10 +5,13 @@ use compositor_pipeline::pipeline::{
         self,
         fdk_aac::AacEncoderOptions,
         ffmpeg_h264::{self},
-        ffmpeg_vp8, AudioEncoderOptions,
+        ffmpeg_vp8,
+        opus::OpusEncoderOptions,
+        AudioEncoderOptions,
     },
     output::{self, mp4::Mp4OutputOptions, rtmp::RtmpSenderOptions},
 };
+use tracing::warn;
 
 use super::register_output::*;
 use super::util::*;
@@ -38,14 +41,37 @@ impl TryFrom<RtpOutput> for pipeline::RegisterOutputOptions<output::OutputOption
                 mixing_strategy,
                 send_eos_when,
                 encoder,
+                channels,
                 initial,
             }) => {
-                let audio_encoder_options: AudioEncoderOptions = encoder.into();
+                let (audio_encoder_options, resolved_channels) = match encoder {
+                    RtpAudioEncoderOptions::Opus {
+                        preset,
+                        sample_rate,
+                        channels: channels_deprecated,
+                    } => {
+                        if channels_deprecated.is_some() {
+                            warn!("The 'channels' field within the encoder options is deprecated and will be removed in future releases. Please use the 'channels' field in the audio options for setting the audio channels.");
+                        }
+                        let resolved_channels = channels
+                            .or(channels_deprecated)
+                            .unwrap_or(audio::AudioChannels::Stereo);
+
+                        (
+                            AudioEncoderOptions::Opus(OpusEncoderOptions {
+                                channels: resolved_channels.clone().into(),
+                                preset: preset.unwrap_or(OpusEncoderPreset::Voip).into(),
+                                sample_rate: sample_rate.unwrap_or(48000),
+                            }),
+                            resolved_channels,
+                        )
+                    }
+                };
                 let output_audio_options = pipeline::OutputAudioOptions {
                     initial: initial.try_into()?,
                     end_condition: send_eos_when.unwrap_or_default().try_into()?,
                     mixing_strategy: mixing_strategy.unwrap_or(MixingStrategy::SumClip).into(),
-                    channels: audio_encoder_options.channels(),
+                    channels: resolved_channels.into(),
                 };
 
                 (Some(audio_encoder_options), Some(output_audio_options))
@@ -115,14 +141,34 @@ impl TryFrom<Mp4Output> for pipeline::RegisterOutputOptions<output::OutputOption
                 mixing_strategy,
                 send_eos_when,
                 encoder,
+                channels,
                 initial,
             }) => {
-                let audio_encoder_options: AudioEncoderOptions = encoder.into();
+                let (audio_encoder_options, resolved_channels) = match encoder {
+                    Mp4AudioEncoderOptions::Aac {
+                        sample_rate,
+                        channels: channels_deprecated,
+                    } => {
+                        if channels_deprecated.is_some() {
+                            warn!("The 'channels' field within the encoder options is deprecated and will be removed in future releases. Please use the 'channels' field in the audio options for setting the audio channels.");
+                        }
+                        let resolved_channels = channels
+                            .or(channels_deprecated)
+                            .unwrap_or(audio::AudioChannels::Stereo);
+                        (
+                            AudioEncoderOptions::Aac(AacEncoderOptions {
+                                channels: resolved_channels.clone().into(),
+                                sample_rate: sample_rate.unwrap_or(44100),
+                            }),
+                            resolved_channels,
+                        )
+                    }
+                };
                 let output_audio_options = pipeline::OutputAudioOptions {
                     initial: initial.try_into()?,
                     end_condition: send_eos_when.unwrap_or_default().try_into()?,
                     mixing_strategy: mixing_strategy.unwrap_or(MixingStrategy::SumClip).into(),
-                    channels: audio_encoder_options.channels(),
+                    channels: resolved_channels.into(),
                 };
 
                 (Some(audio_encoder_options), Some(output_audio_options))
@@ -173,14 +219,36 @@ impl TryFrom<WhipOutput> for pipeline::RegisterOutputOptions<output::OutputOptio
                 mixing_strategy,
                 send_eos_when,
                 encoder,
+                channels,
                 initial,
             }) => {
-                let audio_encoder_options: AudioEncoderOptions = encoder.into();
+                let (audio_encoder_options, resolved_channels) = match encoder {
+                    WhipAudioEncoderOptions::Opus {
+                        preset,
+                        sample_rate,
+                        channels: channels_deprecated,
+                    } => {
+                        if channels_deprecated.is_some() {
+                            warn!("The 'channels' field within the encoder options is deprecated and will be removed in future releases. Please use the 'channels' field in the audio options for setting the audio channels.");
+                        }
+                        let resolved_channels = channels
+                            .or(channels_deprecated)
+                            .unwrap_or(audio::AudioChannels::Stereo);
+                        (
+                            AudioEncoderOptions::Opus(OpusEncoderOptions {
+                                channels: resolved_channels.clone().into(),
+                                preset: preset.unwrap_or(OpusEncoderPreset::Voip).into(),
+                                sample_rate: sample_rate.unwrap_or(48000),
+                            }),
+                            resolved_channels,
+                        )
+                    }
+                };
                 let output_audio_options = pipeline::OutputAudioOptions {
                     initial: initial.try_into()?,
                     end_condition: send_eos_when.unwrap_or_default().try_into()?,
                     mixing_strategy: mixing_strategy.unwrap_or(MixingStrategy::SumClip).into(),
-                    channels: audio_encoder_options.channels(),
+                    channels: resolved_channels.into(),
                 };
 
                 (Some(audio_encoder_options), Some(output_audio_options))
@@ -221,14 +289,34 @@ impl TryFrom<RtmpClient> for pipeline::RegisterOutputOptions<output::OutputOptio
                 mixing_strategy,
                 send_eos_when,
                 encoder,
+                channels,
                 initial,
             }) => {
-                let audio_encoder_options: AudioEncoderOptions = encoder.into();
+                let (audio_encoder_options, resolved_channels) = match encoder {
+                    RtmpClientAudioEncoderOptions::Aac {
+                        sample_rate,
+                        channels: channels_deprecated,
+                    } => {
+                        if channels_deprecated.is_some() {
+                            warn!("The 'channels' field within the encoder options is deprecated and will be removed in future releases. Please use the 'channels' field in the audio options for setting the audio channels.");
+                        }
+                        let resolved_channels = channels
+                            .or(channels_deprecated)
+                            .unwrap_or(audio::AudioChannels::Stereo);
+                        (
+                            AudioEncoderOptions::Aac(AacEncoderOptions {
+                                channels: resolved_channels.clone().into(),
+                                sample_rate: sample_rate.unwrap_or(44100),
+                            }),
+                            resolved_channels,
+                        )
+                    }
+                };
                 let output_audio_options = pipeline::OutputAudioOptions {
                     initial: initial.try_into()?,
                     end_condition: send_eos_when.unwrap_or_default().try_into()?,
                     mixing_strategy: mixing_strategy.unwrap_or(MixingStrategy::SumClip).into(),
-                    channels: audio_encoder_options.channels(),
+                    channels: resolved_channels.into(),
                 };
 
                 (Some(audio_encoder_options), Some(output_audio_options))
@@ -286,66 +374,6 @@ fn maybe_video_options(
     };
 
     Ok((Some(encoder_options), Some(output_options)))
-}
-
-impl From<Mp4AudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
-    fn from(value: Mp4AudioEncoderOptions) -> Self {
-        match value {
-            Mp4AudioEncoderOptions::Aac {
-                channels,
-                sample_rate,
-            } => AudioEncoderOptions::Aac(AacEncoderOptions {
-                channels: channels.into(),
-                sample_rate: sample_rate.unwrap_or(44100),
-            }),
-        }
-    }
-}
-
-impl From<RtmpClientAudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
-    fn from(value: RtmpClientAudioEncoderOptions) -> Self {
-        match value {
-            RtmpClientAudioEncoderOptions::Aac {
-                channels,
-                sample_rate,
-            } => AudioEncoderOptions::Aac(AacEncoderOptions {
-                channels: channels.into(),
-                sample_rate: sample_rate.unwrap_or(44100),
-            }),
-        }
-    }
-}
-
-impl From<RtpAudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
-    fn from(value: RtpAudioEncoderOptions) -> Self {
-        match value {
-            RtpAudioEncoderOptions::Opus {
-                channels,
-                preset,
-                sample_rate,
-            } => AudioEncoderOptions::Opus(encoder::opus::OpusEncoderOptions {
-                channels: channels.into(),
-                preset: preset.unwrap_or(OpusEncoderPreset::Voip).into(),
-                sample_rate: sample_rate.unwrap_or(48000),
-            }),
-        }
-    }
-}
-
-impl From<WhipAudioEncoderOptions> for pipeline::encoder::AudioEncoderOptions {
-    fn from(value: WhipAudioEncoderOptions) -> Self {
-        match value {
-            WhipAudioEncoderOptions::Opus {
-                channels,
-                preset,
-                sample_rate,
-            } => AudioEncoderOptions::Opus(encoder::opus::OpusEncoderOptions {
-                channels: channels.into(),
-                preset: preset.unwrap_or(OpusEncoderPreset::Voip).into(),
-                sample_rate: sample_rate.unwrap_or(48000),
-            }),
-        }
-    }
 }
 
 impl TryFrom<OutputEndCondition> for pipeline::PipelineOutputEndCondition {

--- a/compositor_api/src/types/register_output.rs
+++ b/compositor_api/src/types/register_output.rs
@@ -83,6 +83,8 @@ pub struct OutputRtpAudioOptions {
     pub send_eos_when: Option<OutputEndCondition>,
     /// Audio encoder options.
     pub encoder: RtpAudioEncoderOptions,
+    /// Specifies channels configuration.
+    pub channels: Option<AudioChannels>,
     /// Initial audio mixer configuration for output.
     pub initial: Audio,
 }
@@ -96,6 +98,8 @@ pub struct OutputMp4AudioOptions {
     pub send_eos_when: Option<OutputEndCondition>,
     /// Audio encoder options.
     pub encoder: Mp4AudioEncoderOptions,
+    /// Specifies channels configuration.
+    pub channels: Option<AudioChannels>,
     /// Initial audio mixer configuration for output.
     pub initial: Audio,
 }
@@ -109,6 +113,8 @@ pub struct OutputWhipAudioOptions {
     pub send_eos_when: Option<OutputEndCondition>,
     /// Audio encoder options.
     pub encoder: WhipAudioEncoderOptions,
+    /// Specifies channels configuration.
+    pub channels: Option<AudioChannels>,
     /// Initial audio mixer configuration for output.
     pub initial: Audio,
 }
@@ -122,6 +128,8 @@ pub struct OutputRtmpClientAudioOptions {
     pub send_eos_when: Option<OutputEndCondition>,
     /// Audio encoder options.
     pub encoder: RtmpClientAudioEncoderOptions,
+    /// Specifies channels configuration.
+    pub channels: Option<AudioChannels>,
     /// Initial audio mixer configuration for output.
     pub initial: Audio,
 }
@@ -149,7 +157,7 @@ pub enum VideoEncoderOptions {
 pub enum RtpAudioEncoderOptions {
     Opus {
         /// Specifies channels configuration.
-        channels: AudioChannels,
+        channels: Option<AudioChannels>,
 
         /// (**default="voip"**) Specifies preset for audio output encoder.
         preset: Option<OpusEncoderPreset>,
@@ -163,7 +171,7 @@ pub enum RtpAudioEncoderOptions {
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Mp4AudioEncoderOptions {
     Aac {
-        channels: AudioChannels,
+        channels: Option<AudioChannels>,
         /// (**default=`44100`**) Sample rate. Allowed values: [8000, 16000, 24000, 44100, 48000].
         sample_rate: Option<u32>,
     },
@@ -173,7 +181,7 @@ pub enum Mp4AudioEncoderOptions {
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum RtmpClientAudioEncoderOptions {
     Aac {
-        channels: AudioChannels,
+        channels: Option<AudioChannels>,
         /// (**default=`48000`**) Sample rate. Allowed values: [8000, 16000, 24000, 44100, 48000].
         sample_rate: Option<u32>,
     },
@@ -184,7 +192,7 @@ pub enum RtmpClientAudioEncoderOptions {
 pub enum WhipAudioEncoderOptions {
     Opus {
         /// Specifies channels configuration.
-        channels: AudioChannels,
+        channels: Option<AudioChannels>,
 
         /// (**default="voip"**) Specifies preset for audio output encoder.
         preset: Option<OpusEncoderPreset>,

--- a/integration_tests/examples/aac_rtp_input.rs
+++ b/integration_tests/examples/aac_rtp_input.rs
@@ -92,9 +92,9 @@ fn client_code() -> Result<()> {
                         {"input_id": "input_2"},
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             }
         }),

--- a/integration_tests/examples/audio.rs
+++ b/integration_tests/examples/audio.rs
@@ -120,9 +120,9 @@ fn client_code() -> Result<()> {
                         {"input_id": "input_4"}
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             }
         }),

--- a/integration_tests/examples/decklink.rs
+++ b/integration_tests/examples/decklink.rs
@@ -72,9 +72,9 @@ fn client_code() -> Result<()> {
                         {"input_id": "input_1"}
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo"
                 }
             }
         }),

--- a/integration_tests/examples/mp4_output.rs
+++ b/integration_tests/examples/mp4_output.rs
@@ -59,9 +59,9 @@ fn client_code() -> Result<()> {
                 }
             },
             "audio": {
+                "channels": "stereo",
                 "encoder": {
                     "type": "aac",
-                    "channels": "stereo"
                 },
                 "initial": {
                     "inputs": [

--- a/integration_tests/examples/rtmp_output.rs
+++ b/integration_tests/examples/rtmp_output.rs
@@ -57,9 +57,9 @@ fn client_code() -> Result<()> {
                 }
             },
             "audio": {
+                "channels": "stereo",
                 "encoder": {
                     "type": "aac",
-                    "channels": "stereo",
                     "sample_rate": 44100
                 },
                 "initial": {

--- a/integration_tests/examples/rtp_tcp.rs
+++ b/integration_tests/examples/rtp_tcp.rs
@@ -66,9 +66,9 @@ fn client_code() -> Result<()> {
                         {"input_id": "input_2"},
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                    "type": "opus",
-                   "channels": "stereo",
                 }
             },
             "video": {

--- a/integration_tests/examples/samples_demo.rs
+++ b/integration_tests/examples/samples_demo.rs
@@ -168,9 +168,9 @@ fn start_example_client_code() -> Result<()> {
                         {"input_id": "input_4"}
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),

--- a/integration_tests/examples/whip_client.rs
+++ b/integration_tests/examples/whip_client.rs
@@ -54,9 +54,9 @@ fn client_code() -> Result<()> {
                 }
             },
             "audio": {
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 },
                 "initial": {
                     "inputs": [

--- a/integration_tests/examples/whip_server.rs
+++ b/integration_tests/examples/whip_server.rs
@@ -95,9 +95,9 @@ fn client_code() -> Result<()> {
 
             },
             "audio": {
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 },
                 "initial": {
                     "inputs": [

--- a/integration_tests/src/tests/audio_only.rs
+++ b/integration_tests/src/tests/audio_only.rs
@@ -37,9 +37,9 @@ pub fn audio_mixing_with_offset() -> Result<()> {
                         }
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),
@@ -136,9 +136,9 @@ pub fn audio_mixing_no_offset() -> Result<()> {
                         }
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),
@@ -236,9 +236,9 @@ pub fn single_input_opus() -> Result<()> {
                         }
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),
@@ -314,9 +314,9 @@ pub fn single_input_aac() -> Result<()> {
                         },
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),

--- a/integration_tests/src/tests/offline_processing.rs
+++ b/integration_tests/src/tests/offline_processing.rs
@@ -69,9 +69,9 @@ pub fn offline_processing() -> Result<()> {
                 "send_eos_when": { "all_inputs": true }
             },
             "audio": {
+                "channels": "stereo",
                 "encoder": {
                     "type": "aac",
-                    "channels": "stereo"
                 },
                 "initial": {
                     "inputs": [{ "input_id": "input_1" }]

--- a/integration_tests/src/tests/required_inputs.rs
+++ b/integration_tests/src/tests/required_inputs.rs
@@ -270,9 +270,9 @@ pub fn required_audio_inputs_no_offset() -> Result<()> {
                         },
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),
@@ -357,9 +357,9 @@ pub fn required_audio_inputs_with_offset() -> Result<()> {
                         },
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),
@@ -449,9 +449,9 @@ pub fn required_audio_inputs_with_offset_missing_data() -> Result<()> {
                         },
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo",
                 }
             },
         }),

--- a/integration_tests/src/tests/video_audio.rs
+++ b/integration_tests/src/tests/video_audio.rs
@@ -51,9 +51,9 @@ pub fn single_input_with_video_and_audio_flaky() -> Result<()> {
                         }
                     ]
                 },
+                "channels": "stereo",
                 "encoder": {
                     "type": "opus",
-                    "channels": "stereo"
                 }
             }
         }),


### PR DESCRIPTION
Make audio channels (Mono/Stereo) option for audio output, not specific for each audio encoder.