### PR TITLE
Make `registerInput` return value in `smelter-node`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
+                  toolchain: 1.85.0
                   components: rustfmt, clippy
 
             - name: Install pnpm

--- a/.github/workflows/macos_lint.yml
+++ b/.github/workflows/macos_lint.yml
@@ -20,6 +20,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
+                  toolchain: 1.85.0
                   components: rustfmt, clippy
 
             - name: 📥 Checkout repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
 
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: 1.85.0
 
             - name: 🔬 Install nextest
               uses: taiki-e/install-action@v2

--- a/.github/workflows/ts_sdk_check.yml
+++ b/.github/workflows/ts_sdk_check.yml
@@ -22,7 +22,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.81.0
+                  toolchain: 1.85.0
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -29,6 +29,8 @@ jobs:
 
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
+              with:
+                toolchain: 1.85.0
 
             - name: 📥 Checkout repo
               uses: actions/checkout@v4

--- a/ts/smelter-node/src/live/compositor.ts
+++ b/ts/smelter-node/src/live/compositor.ts
@@ -37,6 +37,7 @@ export default class Smelter {
     await this.coreSmelter.unregisterOutput(outputId);
   }
 
+  // TODO: Temporary fix to get bearer_token for WHIP input
   public async registerInput(inputId: string, request: CoreInput.RegisterInput): Promise<object> {
     let result = await this.coreSmelter.registerInput(inputId, request);
     const mappedResult: any = {};

--- a/ts/smelter-node/src/live/compositor.ts
+++ b/ts/smelter-node/src/live/compositor.ts
@@ -29,16 +29,28 @@ export default class Smelter {
     outputId: string,
     root: ReactElement,
     request: CoreOutput.RegisterOutput
-  ): Promise<void> {
-    await this.coreSmelter.registerOutput(outputId, root, request);
+  ): Promise<object> {
+    return await this.coreSmelter.registerOutput(outputId, root, request);
   }
 
   public async unregisterOutput(outputId: string): Promise<void> {
     await this.coreSmelter.unregisterOutput(outputId);
   }
 
-  public async registerInput(inputId: string, request: CoreInput.RegisterInput): Promise<void> {
-    await this.coreSmelter.registerInput(inputId, request);
+  public async registerInput(inputId: string, request: CoreInput.RegisterInput): Promise<object> {
+    let result = await this.coreSmelter.registerInput(inputId, request);
+    const mappedResult: any = {};
+
+    if ('bearer_token' in result) {
+      mappedResult.bearerToken = result['bearer_token'];
+    }
+    if ('video_duration_ms' in result) {
+      mappedResult.videoDurationMs = result['video_duration_ms'];
+    }
+    if ('audio_duration_ms' in result) {
+      mappedResult.audioDurationMs = result['audio_duration_ms'];
+    }
+    return mappedResult;
   }
 
   public async unregisterInput(inputId: string): Promise<void> {

--- a/ts/smelter-node/src/offline/compositor.ts
+++ b/ts/smelter-node/src/offline/compositor.ts
@@ -29,8 +29,20 @@ export default class OfflineSmelter {
     await this.coreSmelter.render(root, request, durationMs);
   }
 
-  public async registerInput(inputId: string, request: CoreInput.RegisterInput) {
-    await this.coreSmelter.registerInput(inputId, request);
+  public async registerInput(inputId: string, request: CoreInput.RegisterInput): Promise<object> {
+    let result = await this.coreSmelter.registerInput(inputId, request);
+    const mappedResult: any = {};
+
+    if ('bearer_token' in result) {
+      mappedResult.bearerToken = result['bearer_token'];
+    }
+    if ('video_duration_ms' in result) {
+      mappedResult.videoDurationMs = result['video_duration_ms'];
+    }
+    if ('audio_duration_ms' in result) {
+      mappedResult.audioDurationMs = result['audio_duration_ms'];
+    }
+    return mappedResult;
   }
 
   public async registerImage(imageId: string, request: Renderers.RegisterImage): Promise<void> {

--- a/ts/smelter-node/src/offline/compositor.ts
+++ b/ts/smelter-node/src/offline/compositor.ts
@@ -29,6 +29,7 @@ export default class OfflineSmelter {
     await this.coreSmelter.render(root, request, durationMs);
   }
 
+  // TODO: Temporary fix to get bearer_token for WHIP input
   public async registerInput(inputId: string, request: CoreInput.RegisterInput): Promise<object> {
     let result = await this.coreSmelter.registerInput(inputId, request);
     const mappedResult: any = {};


### PR DESCRIPTION
Temporary fix, due to the inability to get a bearer_token while using WHIP input in the ts-sdk. Modifications in smelter-core api will be needed for right solution