### PR TITLE
[ts-sdk] Refactor WASM types + add HTMLVideoElement as input

### DIFF
--- a/compositor_web/src/lib.rs
+++ b/compositor_web/src/lib.rs
@@ -1,2 +1,5 @@
-#[cfg(target_arch = "wasm32")]
+#![cfg(target_arch = "wasm32")]
+
+mod types;
+
 pub mod wasm;

--- a/compositor_web/src/types.rs
+++ b/compositor_web/src/types.rs
@@ -1,0 +1,144 @@
+use std::time::Duration;
+
+use compositor_render::InputId;
+use tracing::error;
+use wasm_bindgen::prelude::*;
+
+use crate::wasm::{self, InputFrameKind};
+
+#[wasm_bindgen(typescript_custom_section)]
+const TS_DEFINITIONS: &'static str = r#"
+export interface InputFrame {
+  inputId: string;
+  frame: VideoFrame | HTMLVideoElement;
+  ptsMs: number;
+}
+
+export interface InputFrameSet {
+  frames: Array<InputFrame>;
+  ptsMs: number;
+}
+
+export interface Resolution {
+  width: number;
+  height: number;
+}
+
+export interface OutputFrame {
+  outputId: string;
+  resolution: Resolution;
+  data: Uint8ClampedArray;
+}
+
+export interface OutputFrameSet {
+  frames: Array<OutputFrame>;
+  ptsMs: number;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "InputFrameSet")]
+    pub type InputFrameSet;
+
+    #[wasm_bindgen(typescript_type = "OutputFrameSet")]
+    pub type OutputFrameSet;
+}
+
+impl TryFrom<InputFrameSet> for wasm::InputFrameSet {
+    type Error = JsValue;
+
+    fn try_from(value: InputFrameSet) -> Result<Self, Self::Error> {
+        let pts_ms = js_sys::Reflect::get(&value.obj, &"ptsMs".into())?
+            .as_f64()
+            .ok_or_else(|| JsValue::from_str("Expected ptsMs to be a number."))?;
+
+        let frames =
+            js_sys::Reflect::get(&value.obj, &"frames".into())?.dyn_into::<js_sys::Array>()?;
+
+        Ok(Self {
+            pts: Duration::from_secs_f64(pts_ms / 1000.0),
+            frames: frames
+                .into_iter()
+                .map(wasm::InputFrame::try_from)
+                .collect::<Result<Vec<_>, JsValue>>()?,
+        })
+    }
+}
+
+impl TryFrom<JsValue> for wasm::InputFrame {
+    type Error = JsValue;
+
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+        let id = InputId(
+            js_sys::Reflect::get(&value, &"inputId".into())?
+                .as_string()
+                .ok_or(JsValue::from_str("Expected string used as a inputId"))?
+                .into(),
+        );
+        let pts_ms = js_sys::Reflect::get(&value, &"ptsMs".into())?
+            .as_f64()
+            .ok_or(JsValue::from_str("Expected number used as a ptsMs"))?;
+
+        let frame = js_sys::Reflect::get(&value, &"frame".into())?;
+        let frame = if frame.is_instance_of::<web_sys::VideoFrame>() {
+            InputFrameKind::VideoFrame(frame.dyn_into()?)
+        } else if frame.is_instance_of::<web_sys::HtmlVideoElement>() {
+            InputFrameKind::HtmlVideoElement(frame.dyn_into()?)
+        } else if frame.is_undefined() {
+            return Err(JsValue::from_str("missing frame"));
+        } else {
+            error!("Error {:?}", frame);
+            return Err(JsValue::from_str(
+                "Unknown frame, expected VideoFrame or HtmlVideoElement",
+            ));
+        };
+
+        Ok(Self {
+            id,
+            pts: Duration::from_secs_f64(pts_ms / 1000.0),
+            frame,
+        })
+    }
+}
+
+impl From<wasm::OutputFrameSet> for OutputFrameSet {
+    fn from(value: wasm::OutputFrameSet) -> Self {
+        let result = js_sys::Object::new();
+        result.set("ptsMs", value.pts.as_millis());
+        result.set(
+            "frames",
+            value
+                .frames
+                .into_iter()
+                .map(|frame| frame.into())
+                .collect::<Vec<JsValue>>(),
+        );
+        OutputFrameSet { obj: result.into() }
+    }
+}
+
+impl From<wasm::OutputFrame> for JsValue {
+    fn from(value: wasm::OutputFrame) -> Self {
+        let resolution = js_sys::Object::new();
+        resolution.set("width", value.resolution.width);
+        resolution.set("height", value.resolution.height);
+
+        let result = js_sys::Object::new();
+        result.set("outputId", value.output_id.0.as_ref());
+        result.set("resolution", resolution);
+        result.set("data", value.data);
+
+        result.into()
+    }
+}
+
+pub trait ObjectExt {
+    fn set<T: Into<JsValue>>(&self, key: &str, value: T);
+}
+
+impl ObjectExt for js_sys::Object {
+    fn set<T: Into<JsValue>>(&self, key: &str, value: T) {
+        js_sys::Reflect::set(self, &JsValue::from_str(key), &value.into()).unwrap();
+    }
+}

--- a/compositor_web/src/wasm/input.rs
+++ b/compositor_web/src/wasm/input.rs
@@ -1,0 +1,293 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use compositor_render::{Frame, FrameData, FrameSet, InputId};
+use futures::future::join_all;
+use js_sys::Object;
+use tracing::error;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::VideoFrameCopyToOptions;
+
+use crate::types::ObjectExt;
+
+use super::{
+    types::{InputFrame, WgpuCtx},
+    InputFrameKind, InputFrameSet,
+};
+
+pub struct RendererInputs {
+    textures: HashMap<InputId, Arc<wgpu::Texture>>,
+    use_copy_external: bool,
+}
+
+impl RendererInputs {
+    pub fn new(use_copy_external: bool) -> Self {
+        Self {
+            textures: HashMap::default(),
+            use_copy_external,
+        }
+    }
+
+    pub async fn create_input_frames(
+        &mut self,
+        wgpu_ctx: &WgpuCtx,
+        inputs: InputFrameSet,
+    ) -> Result<FrameSet<InputId>, JsValue> {
+        let pending_uploads = inputs
+            .frames
+            .into_iter()
+            .map(|input| match &input.frame {
+                InputFrameKind::VideoFrame(video_frame) => {
+                    let size = video_frame.size();
+                    let texture = self.ensure_texture(&input.id, &wgpu_ctx.device, size);
+                    (input, texture)
+                }
+                InputFrameKind::HtmlVideoElement(video_element) => {
+                    let size = video_element.size();
+                    let texture = self.ensure_texture(&input.id, &wgpu_ctx.device, size);
+                    (input, texture)
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|(input, texture)| async {
+                let input_id = input.id.clone();
+                let frame =
+                    RendererInputs::upload_frame(wgpu_ctx, input, texture, self.use_copy_external)
+                        .await?;
+                Ok((input_id, frame))
+            });
+
+        let mut frames = join_all(pending_uploads)
+            .await
+            .into_iter()
+            .collect::<Result<HashMap<_, _>, JsValue>>()?;
+
+        // TODO: MP4 are not calculated correctly, so we are resetting
+        // them to the same value as set for now
+        for (_, value) in frames.iter_mut() {
+            value.pts = inputs.pts
+        }
+
+        Ok(FrameSet {
+            frames,
+            pts: inputs.pts,
+        })
+    }
+
+    pub async fn upload_frame(
+        wgpu_ctx: &WgpuCtx,
+        input: InputFrame,
+        texture: Arc<wgpu::Texture>,
+        use_copy_external: bool,
+    ) -> Result<Frame, JsValue> {
+        let InputFrame { pts, frame, .. } = input;
+        match frame {
+            InputFrameKind::VideoFrame(video_frame) => match use_copy_external {
+                true => Self::copy_direct_from_video_frame(wgpu_ctx, video_frame, texture, pts),
+                false => {
+                    Self::copy_via_cpu_from_video_frame(wgpu_ctx, video_frame, texture, pts).await
+                }
+            },
+            InputFrameKind::HtmlVideoElement(element) => {
+                Self::copy_from_video_element(wgpu_ctx, element, texture, pts)
+            }
+        }
+    }
+
+    fn copy_direct_from_video_frame(
+        wgpu_ctx: &WgpuCtx,
+        video_frame: web_sys::VideoFrame,
+        texture: Arc<wgpu::Texture>,
+        pts: Duration,
+    ) -> Result<Frame, JsValue> {
+        wgpu_ctx.queue.copy_external_image_to_texture(
+            &wgpu::CopyExternalImageSourceInfo {
+                source: wgpu::ExternalImageSource::VideoFrame(video_frame),
+                origin: wgpu::Origin2d::ZERO,
+                flip_y: false,
+            },
+            wgpu::CopyExternalImageDestInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+                color_space: wgpu::PredefinedColorSpace::Srgb,
+                premultiplied_alpha: false,
+            },
+            texture.size(),
+        );
+
+        Ok(Frame {
+            resolution: texture.size().into(),
+            data: FrameData::Rgba8UnormWgpuTexture(texture),
+            pts,
+        })
+    }
+
+    async fn copy_via_cpu_from_video_frame(
+        wgpu_ctx: &WgpuCtx,
+        video_frame: web_sys::VideoFrame,
+        texture: Arc<wgpu::Texture>,
+        pts: Duration,
+    ) -> Result<Frame, JsValue> {
+        let size = video_frame.size();
+        let frame_data = get_frame_data(video_frame).await?;
+
+        wgpu_ctx.queue.write_texture(
+            texture.as_image_copy(),
+            &frame_data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * size.width),
+                rows_per_image: Some(size.height),
+            },
+            size,
+        );
+
+        Ok(Frame {
+            data: FrameData::Rgba8UnormWgpuTexture(texture),
+            resolution: size.into(),
+            pts,
+        })
+    }
+
+    fn copy_from_video_element(
+        wgpu_ctx: &WgpuCtx,
+        video_element: web_sys::HtmlVideoElement,
+        texture: Arc<wgpu::Texture>,
+        pts: Duration,
+    ) -> Result<Frame, JsValue> {
+        wgpu_ctx.queue.copy_external_image_to_texture(
+            &wgpu::CopyExternalImageSourceInfo {
+                source: wgpu::ExternalImageSource::HTMLVideoElement(video_element),
+                origin: wgpu::Origin2d::ZERO,
+                flip_y: false,
+            },
+            wgpu::CopyExternalImageDestInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+                color_space: wgpu::PredefinedColorSpace::Srgb,
+                premultiplied_alpha: true,
+            },
+            texture.size(),
+        );
+
+        Ok(Frame {
+            resolution: texture.size().into(),
+            data: FrameData::Rgba8UnormWgpuTexture(texture),
+            pts,
+        })
+    }
+
+    pub fn remove_input(&mut self, input_id: &InputId) {
+        self.textures.remove(input_id);
+    }
+
+    fn ensure_texture(
+        &mut self,
+        input_id: &InputId,
+        device: &wgpu::Device,
+        size: wgpu::Extent3d,
+    ) -> Arc<wgpu::Texture> {
+        let texture = self
+            .textures
+            .entry(input_id.clone())
+            .or_insert_with(|| Self::create_texture(device, size));
+        if size != texture.size() {
+            *texture = Self::create_texture(device, size);
+        }
+        texture.clone()
+    }
+
+    fn create_texture(device: &wgpu::Device, size: wgpu::Extent3d) -> Arc<wgpu::Texture> {
+        device
+            .create_texture(&wgpu::TextureDescriptor {
+                size,
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8UnormSrgb,
+                view_formats: &[wgpu::TextureFormat::Rgba8UnormSrgb],
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::COPY_DST
+                    | wgpu::TextureUsages::COPY_SRC
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                label: None,
+            })
+            .into()
+    }
+}
+
+async fn get_frame_data(frame: web_sys::VideoFrame) -> Result<Vec<u8>, JsValue> {
+    let rect = frame.visible_rect().unwrap();
+
+    let rgba_layout = Object::new();
+    rgba_layout.set("offset", 0);
+    rgba_layout.set("stride", rect.width() * 4.0);
+    let rgba_layout = js_sys::Array::of1(&rgba_layout);
+
+    let options = VideoFrameCopyToOptions::new();
+    options.set("format", "RGBA");
+    options.set_layout(&rgba_layout);
+
+    let buffer_size = frame.allocation_size_with_options(&options)? as usize;
+    let mut buffer = vec![0; buffer_size];
+    let copy_promise = frame.copy_to_with_u8_slice_and_options(&mut buffer, &options);
+
+    let plane_layouts = JsFuture::from(copy_promise).await?;
+    if !check_plane_layouts(&rgba_layout, plane_layouts.dyn_ref().unwrap()) {
+        error!(layouts = ?plane_layouts, frame = ?frame, "Copied frame's plane layouts do not match expected layouts")
+    }
+    Ok(buffer)
+}
+
+fn check_plane_layouts(expected: &js_sys::Array, received: &js_sys::Array) -> bool {
+    if expected.length() != received.length() {
+        return false;
+    }
+
+    use js_sys::Reflect::get;
+    for (expected, received) in expected.iter().zip(received.iter()) {
+        if get(&expected, &"offset".into()) != get(&received, &"offset".into()) {
+            return false;
+        }
+        if get(&expected, &"stride".into()) != get(&received, &"stride".into()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+trait ExtVideoFrame {
+    fn size(&self) -> wgpu::Extent3d;
+}
+
+impl ExtVideoFrame for web_sys::VideoFrame {
+    fn size(&self) -> wgpu::Extent3d {
+        // `visible_rect` is `None` when frame is detached
+        let rect = self.visible_rect().unwrap();
+        wgpu::Extent3d {
+            width: rect.width() as u32,
+            height: rect.height() as u32,
+            depth_or_array_layers: 1,
+        }
+    }
+}
+
+trait ExtHtmlVideoElement {
+    fn size(&self) -> wgpu::Extent3d;
+}
+
+impl ExtHtmlVideoElement for web_sys::HtmlVideoElement {
+    fn size(&self) -> wgpu::Extent3d {
+        wgpu::Extent3d {
+            width: self.video_width(),
+            height: self.video_height(),
+            depth_or_array_layers: 1,
+        }
+    }
+}

--- a/compositor_web/src/wasm/output.rs
+++ b/compositor_web/src/wasm/output.rs
@@ -1,0 +1,130 @@
+use std::collections::HashMap;
+
+use compositor_render::{Frame, FrameData, FrameSet, OutputId, Resolution};
+use tracing::error;
+use wasm_bindgen::JsValue;
+
+use super::{
+    types::{to_js_error, WgpuCtx},
+    wgpu::pad_to_256,
+    OutputFrame,
+};
+
+#[derive(Default)]
+pub struct RendererOutputs {
+    buffers: HashMap<OutputId, wgpu::Buffer>,
+}
+
+impl RendererOutputs {
+    pub fn process_output_frames(
+        &mut self,
+        wgpu_ctx: &WgpuCtx,
+        outputs: FrameSet<OutputId>,
+    ) -> Result<Vec<OutputFrame>, JsValue> {
+        let mut encoder = wgpu_ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        for (id, frame) in outputs.frames.iter() {
+            let FrameData::Rgba8UnormWgpuTexture(texture) = &frame.data else {
+                panic!("Expected Rgba8UnormWgpuTexture");
+            };
+
+            let buffer = self
+                .buffers
+                .entry(id.clone())
+                .or_insert_with(|| Self::create_buffer(wgpu_ctx, frame.resolution));
+            Self::ensure_buffer(wgpu_ctx, buffer, frame.resolution);
+            Self::copy_texture_to_buffer(texture, buffer, &mut encoder);
+        }
+        wgpu_ctx.queue.submit(Some(encoder.finish()));
+
+        let mut pending_downloads = Vec::with_capacity(outputs.frames.len());
+        for (id, buffer) in self.buffers.iter_mut() {
+            let (map_complete_sender, map_complete_receiver) = crossbeam_channel::bounded(1);
+            buffer
+                .slice(..)
+                .map_async(wgpu::MapMode::Read, move |result| {
+                    if let Err(err) = map_complete_sender.send(result) {
+                        error!("channel send error: {err}")
+                    }
+                });
+            pending_downloads.push((id.clone(), map_complete_receiver));
+        }
+
+        wgpu_ctx.device.poll(wgpu::Maintain::Wait);
+
+        let mut output_data = vec![];
+        for (id, map_complete_receiver) in pending_downloads {
+            map_complete_receiver.recv().unwrap().map_err(to_js_error)?;
+            let frame = outputs.frames.get(&id).unwrap();
+            let buffer = self.buffers.get(&id).unwrap();
+            output_data.push(Self::create_frame_object(&id, frame, buffer)?);
+            buffer.unmap();
+        }
+
+        Ok(output_data)
+    }
+
+    pub fn remove_output(&mut self, output_id: &OutputId) {
+        self.buffers.remove(output_id);
+    }
+
+    fn create_frame_object(
+        output_id: &OutputId,
+        frame: &Frame,
+        buffer: &wgpu::Buffer,
+    ) -> Result<OutputFrame, JsValue> {
+        let buffer_view = buffer.slice(..).get_mapped_range();
+        let resolution = Resolution {
+            width: frame.resolution.width,
+            height: frame.resolution.height,
+        };
+        let mut data: Vec<u8> = Vec::with_capacity(4 * resolution.width * resolution.height);
+        for chunk in buffer_view.chunks(pad_to_256(4 * resolution.width as u32) as usize) {
+            data.extend(&chunk[..(4 * frame.resolution.width)]);
+        }
+
+        return Ok(OutputFrame {
+            output_id: output_id.clone(),
+            resolution,
+            data: wasm_bindgen::Clamped(data),
+        });
+    }
+
+    fn create_buffer(wgpu_ctx: &WgpuCtx, resolution: Resolution) -> wgpu::Buffer {
+        let size = pad_to_256(4 * resolution.width as u32) * resolution.height as u32;
+        wgpu_ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: size as u64,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn ensure_buffer(wgpu_ctx: &WgpuCtx, buffer: &mut wgpu::Buffer, resolution: Resolution) {
+        let size = pad_to_256(4 * resolution.width as u32) * resolution.height as u32;
+        if buffer.size() != size as u64 {
+            *buffer = Self::create_buffer(wgpu_ctx, resolution);
+        }
+    }
+
+    fn copy_texture_to_buffer(
+        texture: &wgpu::Texture,
+        buffer: &wgpu::Buffer,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        let size = texture.size();
+        encoder.copy_texture_to_buffer(
+            texture.as_image_copy(),
+            wgpu::TexelCopyBufferInfo {
+                buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(pad_to_256(4 * size.width)),
+                    rows_per_image: Some(size.height),
+                },
+            },
+            size,
+        );
+    }
+}

--- a/compositor_web/src/wasm/types.rs
+++ b/compositor_web/src/wasm/types.rs
@@ -1,7 +1,14 @@
-use compositor_render::{error::ErrorStack, web_renderer::WebRendererInitOptions, InputId};
+use compositor_render::{
+    error::ErrorStack, web_renderer::WebRendererInitOptions, InputId, OutputId, Resolution,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::time::Duration;
 use wasm_bindgen::prelude::*;
+
+pub struct WgpuCtx {
+    pub device: wgpu::Device,
+    pub queue: wgpu::Queue,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct RendererOptions {
@@ -35,37 +42,31 @@ impl From<LoggerLevel> for tracing::Level {
     }
 }
 
-#[wasm_bindgen]
-pub struct FrameSet {
-    pub pts_ms: f64,
-
-    #[wasm_bindgen(skip)]
-    pub frames: js_sys::Map,
-}
-
-#[wasm_bindgen]
-impl FrameSet {
-    #[wasm_bindgen(constructor)]
-    pub fn new(pts_ms: f64, frames: js_sys::Map) -> Self {
-        Self { pts_ms, frames }
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn frames(&self) -> js_sys::Map {
-        self.frames.clone()
-    }
-
-    #[wasm_bindgen(setter)]
-    pub fn set_frames(&mut self, frames: js_sys::Map) {
-        self.frames = frames;
-    }
+pub struct InputFrameSet {
+    pub pts: Duration,
+    pub frames: Vec<InputFrame>,
 }
 
 pub struct InputFrame {
     pub id: InputId,
-    pub frame: web_sys::VideoFrame,
-    #[allow(dead_code)]
     pub pts: Duration,
+    pub frame: InputFrameKind,
+}
+
+pub enum InputFrameKind {
+    VideoFrame(web_sys::VideoFrame),
+    HtmlVideoElement(web_sys::HtmlVideoElement),
+}
+
+pub struct OutputFrameSet {
+    pub pts: Duration,
+    pub frames: Vec<OutputFrame>,
+}
+
+pub struct OutputFrame {
+    pub output_id: OutputId,
+    pub resolution: Resolution,
+    pub data: wasm_bindgen::Clamped<Vec<u8>>,
 }
 
 #[wasm_bindgen]
@@ -104,27 +105,6 @@ impl From<RendererOptions> for compositor_render::RendererOptions {
     }
 }
 
-impl TryFrom<JsValue> for InputFrame {
-    type Error = JsValue;
-
-    fn try_from(entry: JsValue) -> Result<Self, Self::Error> {
-        use js_sys::Reflect::{get, get_u32};
-
-        // 0 - map key
-        let id = get_u32(&entry, 0)?
-            .as_string()
-            .ok_or(JsValue::from_str("Expected string used as a key"))?;
-        let id = InputId(id.into());
-
-        // 1 - map value
-        let value = get_u32(&entry, 1)?;
-        let frame: web_sys::VideoFrame = get(&value, &"frame".into())?.into();
-        let pts =
-            Duration::from_secs_f64(get(&value, &"ptsMs".into())?.as_f64().unwrap_or(0.0) / 1000.0);
-        Ok(Self { id, frame, pts })
-    }
-}
-
 pub fn from_js_value<T: DeserializeOwned>(value: JsValue) -> Result<T, JsValue> {
     serde_wasm_bindgen::from_value(value).map_err(to_js_error)
 }
@@ -132,15 +112,4 @@ pub fn from_js_value<T: DeserializeOwned>(value: JsValue) -> Result<T, JsValue> 
 pub fn to_js_error(error: impl std::error::Error + 'static) -> JsValue {
     let error_stack = ErrorStack::new(&error);
     JsValue::from_str(&error_stack.into_string())
-}
-
-pub trait ObjectExt {
-    fn set<T: Into<JsValue>>(&self, key: &str, value: T) -> Result<(), JsValue>;
-}
-
-impl ObjectExt for js_sys::Object {
-    fn set<T: Into<JsValue>>(&self, key: &str, value: T) -> Result<(), JsValue> {
-        js_sys::Reflect::set(self, &JsValue::from_str(key), &value.into())?;
-        Ok(())
-    }
 }

--- a/ts/smelter-web-wasm/src/workerContext/queue.ts
+++ b/ts/smelter-web-wasm/src/workerContext/queue.ts
@@ -1,7 +1,6 @@
 import type {
-  FrameSet,
   InputId,
-  OutputFrame,
+  OutputFrameSet,
   OutputId,
   Renderer,
 } from '@swmansion/smelter-browser-render';
@@ -112,7 +111,7 @@ export class Queue {
     return Object.fromEntries(validFrames);
   }
 
-  private sendOutputs(outputs: FrameSet<OutputFrame>) {
+  private sendOutputs(outputs: OutputFrameSet) {
     for (const [outputId, frame] of Object.entries(outputs.frames)) {
       const output = this.outputs[outputId];
       if (!output) {

--- a/ts/smelter-web-wasm/src/workerContext/runWorker.ts
+++ b/ts/smelter-web-wasm/src/workerContext/runWorker.ts
@@ -17,7 +17,6 @@ async function initInstance(options: InitOptions) {
   const renderer = await Renderer.create({
     streamFallbackTimeoutMs: 500,
     loggerLevel,
-    uploadFramesWithCopyExternal: self.navigator.userAgent.includes('Macintosh'),
   });
   const logger = pino({ level: options.loggerLevel }).child({ runtime: 'worker' });
   onMessageLogger = logger.child({ element: 'onMessage' });


### PR DESCRIPTION
- Seprate binding layer from internal implementation
- Handle a case where `frame` is `HTMLVideoElement` (there is still some issue with that, output color space seems to be incorrect, but I'll verify that in follow up PRs that are using that feature)