### PR TITLE
[vk-video] Release `0.1.0`

### DIFF
--- a/vk-video/.gitignore
+++ b/vk-video/.gitignore
@@ -3,3 +3,4 @@ Cargo.lock
 *.h264
 *.jpeg
 *.mp4
+*.nv12


### PR DESCRIPTION
- version in `Cargo.toml` is set to 0.1.0
- adding rawvideo files to gitignore