### PR TITLE
Use `naga` from wgpu instead of having it as a separate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,7 +908,6 @@ dependencies = [
  "glyphon",
  "image",
  "log",
- "naga",
  "nalgebra-glm",
  "pollster",
  "rand",

--- a/compositor_render/Cargo.toml
+++ b/compositor_render/Cargo.toml
@@ -22,7 +22,6 @@ glyphon = { workspace = true }
 crossbeam-channel = { workspace = true }
 resvg = "0.35.0"
 nalgebra-glm = { version = "0.18.0", features = ["convert-bytemuck"] }
-naga = "24.0.0"
 rand = { workspace = true }
 tracing = { workspace = true }
 shared_memory = { workspace = true, optional = true }

--- a/compositor_render/src/transformations/shader/pipeline.rs
+++ b/compositor_render/src/transformations/shader/pipeline.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, num::NonZeroU32, sync::Arc, time::Duration};
 
-use wgpu::ShaderStages;
+use wgpu::{naga, ShaderStages};
 
 use crate::{
     scene::ShaderParam,

--- a/compositor_render/src/transformations/shader/validation.rs
+++ b/compositor_render/src/transformations/shader/validation.rs
@@ -1,4 +1,4 @@
-use naga::{ArraySize, Handle, Module, ScalarKind, ShaderStage, Type, VectorSize};
+use wgpu::naga::{self, ArraySize, Handle, Module, ScalarKind, ShaderStage, Type, VectorSize};
 
 use crate::scene::ShaderParam;
 

--- a/compositor_render/src/transformations/shader/validation/error.rs
+++ b/compositor_render/src/transformations/shader/validation/error.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Display, sync::Arc};
 
+use wgpu::naga;
+
 use crate::{
     transformations::shader::pipeline::{USER_DEFINED_BUFFER_BINDING, USER_DEFINED_BUFFER_GROUP},
     wgpu::common_pipeline::VERTEX_ENTRYPOINT_NAME,

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -18,7 +18,7 @@ pub struct WgpuCtx {
     pub queue: Arc<wgpu::Queue>,
     pub mode: RenderingMode,
 
-    pub shader_header: naga::Module,
+    pub shader_header: wgpu::naga::Module,
 
     pub format: TextureFormat,
     pub utils: TextureUtils,


### PR DESCRIPTION
wgpu reexports `naga` now. This patch makes our code use this reexported `naga` instead of having it as a separate dependency. This saves us the trouble of syncing the naga and wgpu versions every time we update wgpu.