### PR TITLE
Add `HLS` input

### DIFF
--- a/compositor_api/src/input.rs
+++ b/compositor_api/src/input.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 mod decklink;
 mod decklink_into;
+mod hls;
+mod hls_into;
 mod mp4;
 mod mp4_into;
 mod rtp;
@@ -11,6 +13,7 @@ mod whip;
 mod whip_into;
 
 pub use decklink::*;
+pub use hls::*;
 pub use mp4::*;
 pub use rtp::*;
 pub use whip::*;

--- a/compositor_api/src/input/hls.rs
+++ b/compositor_api/src/input/hls.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Parameters for an input stream from HLS source.
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct HlsInput {
+    /// URL to HLS playlist
+    pub url: Arc<str>,
+    /// (**default=`false`**) If input is required and the stream is not delivered
+    /// on time, then Smelter will delay producing output frames.
+    pub required: Option<bool>,
+    /// Offset in milliseconds relative to the pipeline start (start request). If the offset is
+    /// not defined then the stream will be synchronized based on the delivery time of the initial
+    /// frames.
+    pub offset_ms: Option<f64>,
+}

--- a/compositor_api/src/input/hls_into.rs
+++ b/compositor_api/src/input/hls_into.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use compositor_pipeline::{
+    pipeline::{
+        self, decoder,
+        input::{self, hls},
+    },
+    queue,
+};
+
+use crate::*;
+
+impl TryFrom<HlsInput> for pipeline::RegisterInputOptions {
+    type Error = TypeError;
+
+    fn try_from(value: HlsInput) -> Result<Self, Self::Error> {
+        let HlsInput {
+            url,
+            required,
+            offset_ms,
+        } = value;
+
+        let queue_options = queue::QueueInputOptions {
+            required: required.unwrap_or(false),
+            offset: offset_ms.map(|offset_ms| Duration::from_secs_f64(offset_ms / 1000.0)),
+            buffer_duration: None,
+        };
+
+        let input_options = hls::HlsInputOptions {
+            url,
+            video_decoder: decoder::VideoDecoderOptions {
+                decoder: pipeline::VideoDecoder::FFmpegH264,
+            },
+        };
+
+        Ok(pipeline::RegisterInputOptions {
+            input_options: input::InputOptions::Hls(input_options),
+            queue_options,
+        })
+    }
+}

--- a/compositor_api/src/input/rtp.rs
+++ b/compositor_api/src/input/rtp.rs
@@ -1,5 +1,3 @@
-use core::f64;
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/compositor_pipeline/src/pipeline/input/hls.rs
+++ b/compositor_pipeline/src/pipeline/input/hls.rs
@@ -1,0 +1,407 @@
+use std::{
+    ffi::CString,
+    ptr, slice,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use crate::{
+    error::InputInitError,
+    pipeline::{
+        decoder::{self, AacDecoderOptions, AudioDecoderOptions},
+        types::{EncodedChunk, IsKeyframe},
+        AudioCodec, EncodedChunkKind, VideoCodec,
+    },
+    queue::PipelineEvent,
+};
+use bytes::Bytes;
+use compositor_render::InputId;
+use crossbeam_channel::{bounded, Sender};
+use ffmpeg_next::{
+    ffi::{
+        avformat_alloc_context, avformat_close_input, avformat_find_stream_info,
+        avformat_open_input,
+    },
+    format::context,
+    media::Type,
+    util::interrupt,
+    Dictionary, Packet,
+};
+use tracing::{debug, error, span, warn, Level};
+
+use super::{AudioInputReceiver, Input, InputInitInfo, InputInitResult, VideoInputReceiver};
+
+#[derive(Debug, Clone)]
+pub struct HlsInputOptions {
+    pub url: Arc<str>,
+    pub video_decoder: decoder::VideoDecoderOptions,
+}
+
+pub struct HlsInput {
+    should_close: Arc<AtomicBool>,
+}
+
+impl HlsInput {
+    const PREFERABLE_BUFFER_SIZE: usize = 30;
+    const MIN_BUFFER_SIZE: usize = Self::PREFERABLE_BUFFER_SIZE / 2;
+
+    pub(super) fn start_new_input(
+        input_id: &InputId,
+        queue_start_time: Option<Instant>,
+        opts: HlsInputOptions,
+    ) -> Result<InputInitResult, InputInitError> {
+        let should_close = Arc::new(AtomicBool::new(false));
+        let (video, audio) = Self::spawn_thread(
+            input_id.clone(),
+            should_close.clone(),
+            queue_start_time,
+            opts,
+        )?;
+
+        Ok(InputInitResult {
+            input: Input::Hls(Self { should_close }),
+            video,
+            audio,
+            init_info: InputInitInfo::Other,
+        })
+    }
+
+    fn spawn_thread(
+        input_id: InputId,
+        should_close: Arc<AtomicBool>,
+        queue_start_time: Option<Instant>,
+        options: HlsInputOptions,
+    ) -> Result<(Option<VideoInputReceiver>, Option<AudioInputReceiver>), InputInitError> {
+        let (result_sender, result_receiver) = bounded(1);
+        std::thread::Builder::new()
+            .name(format!("HLS thread for input {}", input_id.clone()))
+            .spawn(move || {
+                let _span =
+                    span!(Level::INFO, "HLS thread", input_id = input_id.to_string()).entered();
+
+                Self::run_thread(options, should_close, queue_start_time, result_sender);
+            })
+            .unwrap();
+
+        result_receiver.recv().unwrap()
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn run_thread(
+        options: HlsInputOptions,
+        should_close: Arc<AtomicBool>,
+        queue_start_time: Option<Instant>,
+        result_sender: Sender<
+            Result<(Option<VideoInputReceiver>, Option<AudioInputReceiver>), InputInitError>,
+        >,
+    ) {
+        // careful: moving the input context in any way will cause ffmpeg to segfault
+        // I do not know why this happens
+        let mut input_ctx = match input_with_dictionary_and_interrupt(
+            &options.url,
+            Dictionary::from_iter([("protocol_whitelist", "tcp,hls,http,https,file,tls")]),
+            || should_close.load(Ordering::Relaxed),
+        ) {
+            Ok(i) => i,
+            Err(e) => {
+                result_sender
+                    .send(Err(InputInitError::FfmpegError(e)))
+                    .unwrap();
+                return;
+            }
+        };
+
+        let input_start_time = Instant::now();
+        let queue_start_time = queue_start_time.unwrap_or(Instant::now());
+
+        let (mut audio, mut audio_result) = match input_ctx.streams().best(Type::Audio) {
+            Some(stream) => {
+                // not tested it was always null, but audio is in ADTS, so config is not
+                // necessary
+                let config = unsafe {
+                    let codecpar = (*stream.as_ptr()).codecpar;
+                    let size = (*codecpar).extradata_size;
+                    if size > 0 {
+                        Some(bytes::Bytes::copy_from_slice(slice::from_raw_parts(
+                            (*codecpar).extradata,
+                            size as usize,
+                        )))
+                    } else {
+                        None
+                    }
+                };
+                let (sender, receiver) = bounded(2000);
+                let state =
+                    StreamState::new(input_start_time, queue_start_time, stream.time_base());
+                (
+                    Some((stream.index(), sender, state)),
+                    Some((receiver, config)),
+                )
+            }
+            None => (None, None),
+        };
+        let (mut video, mut video_receiver) = match input_ctx.streams().best(Type::Video) {
+            Some(stream) => {
+                let (sender, receiver) = bounded(2000);
+                let state =
+                    StreamState::new(input_start_time, queue_start_time, stream.time_base());
+                (Some((stream.index(), sender, state)), Some(receiver))
+            }
+            None => (None, None),
+        };
+
+        let mut is_buffering = true;
+        let mut pts_offset = Duration::ZERO;
+        loop {
+            let mut packet = Packet::empty();
+            match packet.read(&mut input_ctx) {
+                Ok(_) => (),
+                Err(ffmpeg_next::Error::Eof | ffmpeg_next::Error::Exit) => break,
+                Err(err) => {
+                    warn!("HLS read error {err:?}");
+                    continue;
+                }
+            }
+
+            if packet.is_corrupt() {
+                error!(
+                    "Corrupted packet {:?} {:?}",
+                    packet.stream(),
+                    packet.flags()
+                );
+                continue;
+            }
+
+            if let Some((index, ref sender, ref mut state)) = video {
+                if packet.stream() == index {
+                    let (pts, dts, is_discontinuity) = state.pts_dts_from_packet(&packet);
+
+                    // Some streams give us packets "from the past", which get dropped by the queue
+                    // resulting in no video or blinking. This heuritic moves the next packets forward in
+                    // time. We only care about video buffer, audio uses the same offset as video
+                    // to avoid audio sync issues.
+                    if is_discontinuity {
+                        pts_offset = Duration::ZERO;
+                    } else if !is_buffering && sender.len() < HlsInput::MIN_BUFFER_SIZE {
+                        pts_offset += Duration::from_secs_f64(0.1);
+                    }
+                    let pts = pts + pts_offset;
+
+                    let chunk = EncodedChunk {
+                        data: Bytes::copy_from_slice(packet.data().unwrap()),
+                        pts,
+                        dts,
+                        is_keyframe: IsKeyframe::Unknown,
+                        kind: EncodedChunkKind::Video(VideoCodec::H264),
+                    };
+
+                    if sender.is_empty() {
+                        debug!("HLS input video channel was drained");
+                    }
+                    if sender.send(PipelineEvent::Data(chunk)).is_err() {
+                        debug!("Channel closed")
+                    }
+                }
+            }
+
+            if let Some((index, ref sender, ref mut state)) = audio {
+                if packet.stream() == index {
+                    let (pts, dts, _) = state.pts_dts_from_packet(&packet);
+                    let pts = pts + pts_offset;
+
+                    let chunk = EncodedChunk {
+                        data: bytes::Bytes::copy_from_slice(packet.data().unwrap()),
+                        pts,
+                        dts,
+                        is_keyframe: IsKeyframe::Unknown,
+                        kind: EncodedChunkKind::Audio(AudioCodec::Aac),
+                    };
+
+                    if sender.is_empty() {
+                        debug!("HLS input audio channel was drained");
+                    }
+                    if sender.send(PipelineEvent::Data(chunk)).is_err() {
+                        debug!("Channel closed")
+                    }
+                }
+            }
+
+            if is_buffering && HlsInput::did_buffer_enough(video.as_ref(), audio.as_ref()) {
+                result_sender
+                    .send(Ok((
+                        video_receiver
+                            .take()
+                            .map(|video| VideoInputReceiver::Encoded {
+                                chunk_receiver: video,
+                                decoder_options: options.clone().video_decoder,
+                            }),
+                        audio_result
+                            .take()
+                            .map(|(receiver, asc)| AudioInputReceiver::Encoded {
+                                chunk_receiver: receiver,
+                                decoder_options: AudioDecoderOptions::Aac(AacDecoderOptions {
+                                    depayloader_mode: None,
+                                    asc,
+                                }),
+                            }),
+                    )))
+                    .unwrap();
+
+                is_buffering = false;
+            }
+        }
+
+        if let Some((_, sender, _)) = audio {
+            if sender.send(PipelineEvent::EOS).is_err() {
+                debug!("Failed to send EOS message.")
+            }
+        }
+
+        if let Some((_, sender, _)) = video {
+            if sender.send(PipelineEvent::EOS).is_err() {
+                debug!("Failed to send EOS message.")
+            }
+        }
+    }
+
+    fn did_buffer_enough(video: Option<&Stream>, audio: Option<&Stream>) -> bool {
+        let is_video_ready = video
+            .as_ref()
+            .map(|(_, sender, _)| sender.len() >= HlsInput::PREFERABLE_BUFFER_SIZE);
+        let is_audio_ready = audio
+            .as_ref()
+            .map(|(_, sender, _)| sender.len() >= HlsInput::PREFERABLE_BUFFER_SIZE);
+
+        matches!(
+            (is_video_ready, is_audio_ready),
+            (Some(true), Some(true)) | (Some(true), None) | (None, Some(true))
+        )
+    }
+}
+
+impl Drop for HlsInput {
+    fn drop(&mut self) {
+        self.should_close
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+type Stream = (usize, Sender<PipelineEvent<EncodedChunk>>, StreamState);
+
+struct StreamState {
+    input_start_time: Instant,
+    queue_start_time: Instant,
+    first_pts: Option<Duration>,
+
+    prev_dts: Option<f64>,
+    next_predicted_dts: Option<f64>,
+    discontinuity_offset: f64,
+    time_base: ffmpeg_next::Rational,
+}
+
+impl StreamState {
+    /// (10s) This value was picked arbitrarily but it's quite conservative.
+    const DISCONTINUITY_THRESHOLD: f64 = 10.0;
+
+    fn new(
+        input_start_time: Instant,
+        queue_start_time: Instant,
+        time_base: ffmpeg_next::Rational,
+    ) -> Self {
+        Self {
+            input_start_time,
+            queue_start_time,
+            first_pts: None,
+            prev_dts: None,
+            next_predicted_dts: None,
+            discontinuity_offset: 0.0,
+            time_base,
+        }
+    }
+
+    fn detect_discontinuity(&mut self, packet: &Packet) -> bool {
+        let dts = packet.dts().unwrap_or(0) as f64;
+        let (Some(prev_dts), Some(next_dts)) = (self.prev_dts, self.next_predicted_dts) else {
+            self.prev_dts = Some(dts);
+            self.next_predicted_dts = Some(dts + packet.duration() as f64);
+            return false;
+        };
+
+        // Detect discontinuity
+        let timestamp_delta = self.to_timestamp(f64::abs(next_dts - dts)).as_secs_f64();
+        let is_discontinuity = timestamp_delta >= Self::DISCONTINUITY_THRESHOLD || prev_dts > dts;
+        if is_discontinuity {
+            debug!("Discontinuity detected: {prev_dts} -> {dts} (dts)");
+            self.discontinuity_offset += next_dts - dts;
+        }
+
+        self.prev_dts = Some(dts);
+        self.next_predicted_dts = Some(dts + packet.duration() as f64);
+
+        is_discontinuity
+    }
+
+    fn pts_dts_from_packet(&mut self, packet: &Packet) -> (Duration, Option<Duration>, bool) {
+        let is_discontinuity = self.detect_discontinuity(packet);
+        let pts = self.to_timestamp(packet.pts().unwrap_or(0) as f64 + self.discontinuity_offset);
+        let dts = packet
+            .dts()
+            .map(|dts| self.to_timestamp(dts as f64 + self.discontinuity_offset));
+
+        // Recalculate pts in regards to queue start time
+        let first_pts = *self.first_pts.get_or_insert(pts);
+        let pts = self.to_queue_timestamp(pts.saturating_sub(first_pts));
+
+        (pts, dts, is_discontinuity)
+    }
+
+    fn to_timestamp(&self, timestamp: f64) -> Duration {
+        Duration::from_secs_f64(
+            f64::max(timestamp, 0.0) * self.time_base.numerator() as f64
+                / self.time_base.denominator() as f64,
+        )
+    }
+
+    fn to_queue_timestamp(&self, input_timestamp: Duration) -> Duration {
+        (self.input_start_time + input_timestamp).duration_since(self.queue_start_time)
+    }
+}
+
+/// Combined implementation of ffmpeg_next::format:input_with_interrupt and
+/// ffmpeg_next::format::input_with_dictionary that allows passing both interrupt
+/// callback and Dictionary with options
+fn input_with_dictionary_and_interrupt<F>(
+    path: &str,
+    options: Dictionary,
+    interrupt_fn: F,
+) -> Result<context::Input, ffmpeg_next::Error>
+where
+    F: FnMut() -> bool,
+{
+    unsafe {
+        let mut ps = avformat_alloc_context();
+
+        (*ps).interrupt_callback = interrupt::new(Box::new(interrupt_fn)).interrupt;
+
+        let path = CString::new(path).unwrap();
+        let mut opts = options.disown();
+        let res = avformat_open_input(&mut ps, path.as_ptr(), ptr::null_mut(), &mut opts);
+
+        Dictionary::own(opts);
+
+        match res {
+            0 => match avformat_find_stream_info(ps, ptr::null_mut()) {
+                r if r >= 0 => Ok(context::Input::wrap(ps)),
+                e => {
+                    avformat_close_input(&mut ps);
+                    Err(ffmpeg_next::Error::from(e))
+                }
+            },
+
+            e => Err(ffmpeg_next::Error::from(e)),
+        }
+    }
+}

--- a/compositor_pipeline/src/pipeline/pipeline_input.rs
+++ b/compositor_pipeline/src/pipeline/pipeline_input.rs
@@ -29,9 +29,13 @@ pub(super) fn register_pipeline_input<NewInputResult>(
         return Err(RegisterInputError::AlreadyRegistered(input_id));
     }
 
-    let pipeline_ctx = pipeline.lock().unwrap().ctx.clone();
+    let (pipeline_ctx, queue_start_time) = {
+        let guard = pipeline.lock().unwrap();
+        (guard.ctx.clone(), guard.queue.start_time())
+    };
 
-    let (input, receiver, input_result) = input_options.new_input(&input_id, &pipeline_ctx)?;
+    let (input, receiver, input_result) =
+        input_options.new_input(&input_id, queue_start_time, &pipeline_ctx)?;
 
     let (audio_eos_received, video_eos_received) = (
         receiver.audio.as_ref().map(|_| false),

--- a/integration_tests/examples/hls_input.rs
+++ b/integration_tests/examples/hls_input.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use compositor_api::Resolution;
+use serde_json::json;
+use std::time::Duration;
+
+use integration_tests::examples::{self, run_example};
+
+const VIDEO_RESOLUTION: Resolution = Resolution {
+    width: 1280,
+    height: 720,
+};
+
+fn main() {
+    run_example(client_code);
+}
+
+fn client_code() -> Result<()> {
+    let args = std::env::args().collect::<Vec<_>>();
+
+    if args.len() != 2 {
+        println!("Usage: {} <HLS playlist url>", args[0]);
+        return Ok(());
+    }
+
+    examples::post("start", &json!({}))?;
+    examples::post(
+        "input/input_1/register",
+        &json!({
+            "type": "hls",
+            "url": args[1],
+        }),
+    )?;
+
+    examples::post(
+        "output/output_1/register",
+        &json!({
+            "url": "rtmp://0.0.0.0:9002",
+            "type": "rtmp_client",
+            "video": {
+                "resolution": {
+                    "width": VIDEO_RESOLUTION.width,
+                    "height": VIDEO_RESOLUTION.height,
+                },
+                "encoder": {
+                    "type": "ffmpeg_h264",
+                    "preset": "ultrafast",
+                    "ffmpeg_options": {
+                        "g": "120", // keyframe every 100 frames
+                        "b": "6M"   // bitrate 6000 kb/s
+                    }
+                },
+                "initial": {
+                    "root": {
+                        "type": "input_stream",
+                        "input_id": "input_1"
+                    }
+                }
+            },
+            "audio": {
+                "channels": "stereo",
+                "encoder": {
+                    "type": "aac",
+                    "sample_rate": 44100
+                },
+                "initial": {
+                    "inputs": [
+                        {"input_id": "input_1"}
+                    ]
+                }
+            }
+        }),
+    )?;
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    Ok(())
+}

--- a/src/routes/register_request.rs
+++ b/src/routes/register_request.rs
@@ -12,8 +12,8 @@ use crate::{
     state::{Pipeline, Response},
 };
 use compositor_api::{
-    DeckLink, ImageSpec, InputId, Mp4Input, Mp4Output, OutputId, RendererId, RtmpClient, RtpInput,
-    RtpOutput, ShaderSpec, WebRendererSpec, WhipInput, WhipOutput,
+    DeckLink, HlsInput, ImageSpec, InputId, Mp4Input, Mp4Output, OutputId, RendererId, RtmpClient,
+    RtpInput, RtpOutput, ShaderSpec, WebRendererSpec, WhipInput, WhipOutput,
 };
 
 use super::ApiState;
@@ -24,6 +24,7 @@ pub enum RegisterInput {
     RtpStream(RtpInput),
     Mp4(Mp4Input),
     Whip(WhipInput),
+    Hls(HlsInput),
     #[serde(rename = "decklink")]
     DeckLink(DeckLink),
 }
@@ -56,6 +57,9 @@ pub(super) async fn handle_input(
             }
             RegisterInput::Whip(whip) => {
                 Pipeline::register_input(&api.pipeline, input_id.into(), whip.try_into()?)?
+            }
+            RegisterInput::Hls(hls) => {
+                Pipeline::register_input(&api.pipeline, input_id.into(), hls.try_into()?)?
             }
         };
         match response {

--- a/src/routes/status.rs
+++ b/src/routes/status.rs
@@ -56,6 +56,7 @@ pub(super) async fn status_handler(
                 Input::Rtp(_) => "rtp",
                 Input::Mp4(_) => "mp4",
                 Input::Whip(_) => "whip",
+                Input::Hls(_) => "hls",
                 #[cfg(feature = "decklink")]
                 Input::DeckLink(_) => "decklink",
                 Input::RawDataInput => "raw data",

--- a/ts/package.json
+++ b/ts/package.json
@@ -38,5 +38,6 @@
     "rollup-plugin-copy": {
       "globby": "11.0.4"
     }
-  }
+  },
+  "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/ts/smelter-core/src/api/input.ts
+++ b/ts/smelter-core/src/api/input.ts
@@ -1,6 +1,7 @@
 import type { Api } from '../api';
 import type {
   RegisterMp4Input,
+  RegisterHlsInput,
   RegisterRtpInput,
   Inputs,
   RegisterWhipInput,
@@ -14,6 +15,7 @@ import { _smelterInternals } from '@swmansion/smelter';
 export type RegisterInputRequest =
   | RegisterRtpStreamInputRequest
   | RegisterMp4InputRequest
+  | RegisterHlsInputRequest
   | RegisterWhipInputRequest
   | RegisterDecklinkInputRequest
   | { type: 'camera' }
@@ -22,6 +24,7 @@ export type RegisterInputRequest =
 
 export type RegisterRtpStreamInputRequest = Extract<Api.RegisterInput, { type: 'rtp_stream' }>;
 export type RegisterMp4InputRequest = { blob?: any } & Extract<Api.RegisterInput, { type: 'mp4' }>;
+export type RegisterHlsInputRequest = Extract<Api.RegisterInput, { type: 'hls' }>;
 export type RegisterWhipInputRequest = Extract<Api.RegisterInput, { type: 'whip' }>;
 export type RegisterDecklinkInputRequest = Extract<Api.RegisterInput, { type: 'decklink' }>;
 
@@ -32,6 +35,7 @@ export const parseInputRef = _smelterInternals.parseInputRef;
 export type RegisterInput =
   | ({ type: 'rtp_stream' } & RegisterRtpInput)
   | ({ type: 'mp4' } & RegisterMp4Input)
+  | ({ type: 'hls' } & RegisterHlsInput)
   | ({ type: 'whip' } & RegisterWhipInput)
   | { type: 'camera' }
   | { type: 'screen_capture' }
@@ -44,6 +48,8 @@ export type RegisterInput =
 export function intoRegisterInput(input: RegisterInput): RegisterInputRequest {
   if (input.type === 'mp4') {
     return intoMp4RegisterInput(input);
+  } else if (input.type === 'hls') {
+    return intoHlsRegisterInput(input);
   } else if (input.type === 'rtp_stream') {
     return intoRtpRegisterInput(input);
   } else if (input.type === 'whip') {
@@ -69,6 +75,15 @@ function intoMp4RegisterInput(input: Inputs.RegisterMp4Input): RegisterInputRequ
     required: input.required,
     offset_ms: input.offsetMs,
     video_decoder: input.videoDecoder,
+  };
+}
+
+function intoHlsRegisterInput(input: Inputs.RegisterHlsInput): RegisterInputRequest {
+  return {
+    type: 'hls',
+    url: input.url,
+    required: input.required,
+    offset_ms: input.offsetMs,
   };
 }
 

--- a/ts/smelter-node/src/api.ts
+++ b/ts/smelter-node/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   RegisterMp4Input,
   RegisterMp4Output,
+  RegisterHlsInput,
   RegisterRtmpClientOutput,
   RegisterRtpInput,
   RegisterRtpOutput,
@@ -17,4 +18,5 @@ export type RegisterOutput =
 export type RegisterInput =
   | ({ type: 'rtp_stream' } & RegisterRtpInput)
   | ({ type: 'mp4' } & RegisterMp4Input)
+  | ({ type: 'hls' } & RegisterHlsInput)
   | ({ type: 'whip' } & RegisterWhipInput);

--- a/ts/smelter-web-client/src/api.ts
+++ b/ts/smelter-web-client/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   RegisterMp4Input,
   RegisterMp4Output,
+  RegisterHlsInput,
   RegisterRtmpClientOutput,
   RegisterRtpInput,
   RegisterRtpOutput,
@@ -17,4 +18,5 @@ export type RegisterOutput =
 export type RegisterInput =
   | ({ type: 'rtp_stream' } & RegisterRtpInput)
   | ({ type: 'mp4' } & RegisterMp4Input)
+  | ({ type: 'hls' } & RegisterHlsInput)
   | ({ type: 'whip' } & RegisterWhipInput);

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -84,6 +84,21 @@ export type RegisterInput =
       offset_ms?: number | null;
     }
   | {
+      type: "hls";
+      /**
+       * URL to HLS playlist
+       */
+      url: string;
+      /**
+       * (**default=`false`**) If input is required and the stream is not delivered on time, then Smelter will delay producing output frames.
+       */
+      required?: boolean | null;
+      /**
+       * Offset in milliseconds relative to the pipeline start (start request). If the offset is not defined then the stream will be synchronized based on the delivery time of the initial frames.
+       */
+      offset_ms?: number | null;
+    }
+  | {
       type: "decklink";
       /**
        * Single DeckLink device can consist of multiple sub-devices. This field defines index of sub-device that should be used.

--- a/ts/smelter/src/index.ts
+++ b/ts/smelter/src/index.ts
@@ -18,7 +18,12 @@ import Show, { ShowProps } from './components/Show.js';
 import { SlideShow, Slide, SlideProps, SlideShowProps } from './components/SlideShow.js';
 import Mp4, { Mp4Props } from './components/Mp4.js';
 
-export { RegisterRtpInput, RegisterMp4Input, RegisterWhipInput } from './types/input.js';
+export {
+  RegisterRtpInput,
+  RegisterMp4Input,
+  RegisterHlsInput,
+  RegisterWhipInput,
+} from './types/input.js';
 export {
   RegisterRtpOutput,
   RegisterMp4Output,

--- a/ts/smelter/src/types/input.ts
+++ b/ts/smelter/src/types/input.ts
@@ -33,7 +33,6 @@ export type RegisterRtpInput = {
 };
 
 export type Mp4VideoDecoder = 'ffmpeg_h264' | 'vulkan_h264';
-
 export type RegisterMp4Input = {
   /**
    * URL of the MP4 file.
@@ -65,6 +64,23 @@ export type RegisterMp4Input = {
    * (**default=`ffmpeg_h264`**) The decoder to use for decoding video.
    */
   videoDecoder?: Mp4VideoDecoder | null;
+};
+
+export type RegisterHlsInput = {
+  /**
+   * URL of the HLS playlist.
+   */
+  url: string;
+  /**
+   * (**default=`false`**) If input is required and frames are not processed
+   * on time, then Smelter will delay producing output frames.
+   */
+  required?: boolean | null;
+  /**
+   * Offset in milliseconds relative to the pipeline start (start request). If offset is
+   * not defined then stream is synchronized based on the first frames delivery time.
+   */
+  offsetMs?: number | null;
 };
 
 export type WhipVideoDecoder = 'ffmpeg_h264' | 'ffmpeg_vp8' | 'ffmpeg_vp9' | 'vulkan_h264' | 'any';


### PR DESCRIPTION
This PR adds hls input with discontinuity handling.

Discontinuity is detected when dts difference is larger than 10s or dts is not monotonic.

This works for most streams but sometimes I found that the pts can fall behind the queue which causes the frames to get dropped. It mostly happens after discontinuity but I've seen it happen also without any detected discontinuities. 

I handle it by adjusting the pts if I notice that there is not enough packets in a buffer (they get quickly disposed by the queue). This solution works quite well compared to other players I've tested (ffplay & mpv).