### PR TITLE
Distinguish WHIP sessions on a single input

### DIFF
--- a/compositor_api/src/input/whip.rs
+++ b/compositor_api/src/input/whip.rs
@@ -19,7 +19,7 @@ pub struct WhipInput {
     /// will be generated and returned in the response.
     pub bearer_token: Option<Arc<str>>,
     /// Internal use only.
-    /// Overrides whip session id which is used when referencing the input via whip server.
+    /// Overrides whip endpoint id which is used when referencing the input via whip server.
     /// If not provided, it defaults to input id.
     pub endpoint_override: Option<Arc<str>>,
     /// (**default=`false`**) If input is required and the stream is not delivered

--- a/compositor_api/src/input/whip.rs
+++ b/compositor_api/src/input/whip.rs
@@ -21,7 +21,7 @@ pub struct WhipInput {
     /// Internal use only.
     /// Overrides whip session id which is used when referencing the input via whip server.
     /// If not provided, it defaults to input id.
-    pub whip_session_id_override: Option<Arc<str>>,
+    pub endpoint_override: Option<Arc<str>>,
     /// (**default=`false`**) If input is required and the stream is not delivered
     /// on time, then Smelter will delay producing output frames.
     pub required: Option<bool>,

--- a/compositor_api/src/input/whip_into.rs
+++ b/compositor_api/src/input/whip_into.rs
@@ -15,7 +15,7 @@ impl TryFrom<WhipInput> for pipeline::RegisterInputOptions {
             required,
             offset_ms,
             bearer_token,
-            whip_session_id_override,
+            endpoint_override,
         } = value;
 
         if video.clone().and_then(|v| v.decoder.clone()).is_some() {
@@ -70,7 +70,7 @@ impl TryFrom<WhipInput> for pipeline::RegisterInputOptions {
                 pipeline::WhipInputOptions {
                     video_preferences,
                     bearer_token,
-                    whip_session_id_override,
+                    endpoint_override,
                 }
             }
             None => pipeline::WhipInputOptions {
@@ -88,7 +88,7 @@ impl TryFrom<WhipInput> for pipeline::RegisterInputOptions {
                     pipeline::VideoDecoderOptions::FfmpegVp9,
                 ],
                 bearer_token,
-                whip_session_id_override,
+                endpoint_override,
             },
         };
 

--- a/compositor_pipeline/src/pipeline/webrtc/server.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server.rs
@@ -86,13 +86,13 @@ impl WhipWhepServer {
     ) {
         let app = Router::new()
             .route("/status", get((StatusCode::OK, axum::Json(json!({})))))
-            .route("/whip/:id", post(handle_create_whip_session))
+            .route("/whip/:endpoint_id", post(handle_create_whip_session))
             .route(
-                "/whip/:id/:session_id",
+                "/whip/:endpoint_id/:session_id",
                 patch(handle_new_whip_ice_candidates),
             )
             .route(
-                "/whip/:id/:session_id",
+                "/whip/:endpoint_id/:session_id",
                 delete(handle_terminate_whip_session),
             )
             .route("/whep/:id", post(handle_create_whep_session))

--- a/compositor_pipeline/src/pipeline/webrtc/server.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server.rs
@@ -87,8 +87,14 @@ impl WhipWhepServer {
         let app = Router::new()
             .route("/status", get((StatusCode::OK, axum::Json(json!({})))))
             .route("/whip/:id", post(handle_create_whip_session))
-            .route("/whip/:id", patch(handle_new_whip_ice_candidates))
-            .route("/whip/:id", delete(handle_terminate_whip_session))
+            .route(
+                "/whip/:id/:session_id",
+                patch(handle_new_whip_ice_candidates),
+            )
+            .route(
+                "/whip/:id/:session_id",
+                delete(handle_terminate_whip_session),
+            )
             .route("/whep/:id", post(handle_create_whep_session))
             .route(
                 "/whep/:id/:session_id",

--- a/compositor_pipeline/src/pipeline/webrtc/server/create_whip_session.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server/create_whip_session.rs
@@ -29,15 +29,15 @@ pub async fn handle_create_whip_session(
     headers: HeaderMap,
     offer: String,
 ) -> Result<Response<Body>, WhipWhepServerError> {
-    let session_id = Arc::from(id.clone());
+    let input_id = Arc::from(id.clone());
     trace!("SDP offer: {}", offer);
-    let inputs = state.inputs.clone();
+    let mut inputs = state.inputs.clone();
 
     validate_sdp_content_type(&headers)?;
-    inputs.validate_token(&session_id, &headers).await?;
+    inputs.validate_token(&input_id, &headers).await?;
 
     let video_preferences =
-        inputs.get_with(&session_id, |input| Ok(input.video_preferences.clone()))?;
+        inputs.get_with(&input_id, |input| Ok(input.video_preferences.clone()))?;
 
     let peer_connection = RecvonlyPeerConnection::new(&state.ctx, &video_preferences).await?;
 
@@ -58,11 +58,11 @@ pub async fn handle_create_whip_session(
     trace!("SDP answer: {}", sdp_answer.sdp);
 
     {
-        let session_id = session_id.clone();
+        let input_id = input_id.clone();
         let sync_point = RtpNtpSyncPoint::new(state.ctx.queue_sync_point);
         peer_connection.on_track(Box::new(move |track, _, transceiver| {
             debug!(
-                ?session_id,
+                ?input_id,
                 kind=?track.kind(),
                 "on_track called"
             );
@@ -75,7 +75,7 @@ pub async fn handle_create_whip_session(
                         process_audio_track(
                             sync_point.clone(),
                             state.clone(),
-                            session_id.clone(),
+                            input_id.clone(),
                             track,
                             transceiver,
                         )
@@ -87,7 +87,7 @@ pub async fn handle_create_whip_session(
                         process_video_track(
                             sync_point.clone(),
                             state.clone(),
-                            session_id.clone(),
+                            input_id.clone(),
                             track,
                             transceiver,
                             video_preferences.clone(),
@@ -103,18 +103,28 @@ pub async fn handle_create_whip_session(
             Box::pin(async {})
         }))
     };
+    let peer_connection_arc = Arc::new(peer_connection);
+    let session_id = inputs.add_session(&input_id, peer_connection_arc.clone())?;
 
     // It will fail if there is already connected peer connection
-    inputs.get_mut_with(&session_id, |input| {
-        input.maybe_replace_peer_connection(&session_id, peer_connection)
-    })?;
+    inputs.maybe_replace_peer_connection(&input_id, &session_id, peer_connection_arc)?; // TODO think about on which level of abstroction should be replace pc and what it exactly should do
+                                                                                        // inputs.get_mut_with(&input_id, |input| {
+                                                                                        //     input.maybe_replace_peer_connection(&input_id, peer_connection)
+                                                                                        // })?;
 
     let body = Body::from(sdp_answer.sdp.to_string());
     let response = Response::builder()
         .status(StatusCode::CREATED)
         .header("Content-Type", "application/sdp")
         .header("Access-Control-Expose-Headers", "Location")
-        .header("Location", format!("/whip/{}", urlencoding::encode(&id)))
+        .header(
+            "Location",
+            format!(
+                "/whip/{}/{}",
+                urlencoding::encode(&id),
+                urlencoding::encode(&input_id)
+            ),
+        )
         .body(body)?;
     Ok(response)
 }

--- a/compositor_pipeline/src/pipeline/webrtc/server/create_whip_session.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server/create_whip_session.rs
@@ -104,6 +104,7 @@ pub async fn handle_create_whip_session(
         }))
     };
 
+    // It will fail if there is already connected peer connection
     let session_id = inputs.get_mut_with(&input_id, |input| {
         input.maybe_replace_peer_connection(&input_id, peer_connection)
     })?;

--- a/compositor_pipeline/src/pipeline/webrtc/server/new_whip_ice_candidates.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server/new_whip_ice_candidates.rs
@@ -12,38 +12,40 @@ use std::sync::Arc;
 use tracing::info;
 
 pub async fn handle_new_whip_ice_candidates(
-    Path((id, session_id)): Path<(String, String)>,
+    Path((endpoint_id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
     sdp_fragment_content: String,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let input_id = Arc::from(id);
+    let endpoint_id = Arc::from(endpoint_id);
     let session_id = Arc::from(session_id);
 
     validate_content_type(&headers)?;
-    state.inputs.validate_token(&input_id, &headers).await?;
-    state.inputs.validate_session_id(&input_id, &session_id)?;
+    state.inputs.validate_token(&endpoint_id, &headers).await?;
+    state
+        .inputs
+        .validate_session_id(&endpoint_id, &session_id)?;
 
     let peer_connection = state
         .inputs
-        .get_with(&input_id, |input| Ok(input.peer_connection.clone()))?;
+        .get_with(&endpoint_id, |input| Ok(input.peer_connection.clone()))?;
 
     if let Some(peer_connection) = peer_connection {
         for candidate in ice_fragment_unmarshal(&sdp_fragment_content) {
             if let Err(err) = peer_connection.add_ice_candidate(candidate.clone()).await {
                 return Err(WhipWhepServerError::BadRequest(format!(
-                    "Cannot add ice_candidate {candidate:?} for session {input_id:?}: {err:?}"
+                    "Cannot add ice_candidate {candidate:?} for session {session_id:?} (endpoint {endpoint_id:?}): {err:?}"
                 )));
             }
             info!(
                 ?session_id,
-                ?input_id,
+                ?endpoint_id,
                 "Added ICE candidate for WHIP session"
             );
         }
     } else {
         return Err(WhipWhepServerError::InternalError(format!(
-            "None peer connection for {input_id:?}"
+            "None peer connection for {endpoint_id:?}"
         )));
     }
 

--- a/compositor_pipeline/src/pipeline/webrtc/server/new_whip_ice_candidates.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server/new_whip_ice_candidates.rs
@@ -9,34 +9,33 @@ use axum::{
     http::{HeaderMap, StatusCode},
 };
 use std::sync::Arc;
+use tracing::info;
 
 pub async fn handle_new_whip_ice_candidates(
-    Path(id): Path<String>,
+    Path((id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
     sdp_fragment_content: String,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let session_id = Arc::from(id);
+    let input_id = Arc::from(id);
+    let session_id = Arc::from(session_id);
 
     validate_content_type(&headers)?;
-    state.inputs.validate_token(&session_id, &headers).await?;
+    state.inputs.validate_token(&input_id, &headers).await?;
 
-    let peer_connection = state
-        .inputs
-        .get_with(&session_id, |input| Ok(input.peer_connection.clone()))?;
+    let peer_connection = state.inputs.get_session(&input_id, &session_id)?;
 
-    if let Some(peer_connection) = peer_connection {
-        for candidate in ice_fragment_unmarshal(&sdp_fragment_content) {
-            if let Err(err) = peer_connection.add_ice_candidate(candidate.clone()).await {
-                return Err(WhipWhepServerError::BadRequest(format!(
-                    "Cannot add ice_candidate {candidate:?} for session {session_id:?}: {err:?}"
-                )));
-            }
+    for candidate in ice_fragment_unmarshal(&sdp_fragment_content) {
+        if let Err(err) = peer_connection.add_ice_candidate(candidate.clone()).await {
+            return Err(WhipWhepServerError::BadRequest(format!(
+                "Cannot add ice_candidate {candidate:?} for session {input_id:?}: {err:?}"
+            )));
         }
-    } else {
-        return Err(WhipWhepServerError::InternalError(format!(
-            "None peer connection for {session_id:?}"
-        )));
+        info!(
+            ?session_id,
+            ?input_id,
+            "Added ICE candidate for WHIP session"
+        );
     }
 
     Ok(StatusCode::NO_CONTENT)

--- a/compositor_pipeline/src/pipeline/webrtc/server/terminate_whip_session.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server/terminate_whip_session.rs
@@ -15,11 +15,21 @@ pub async fn handle_terminate_whip_session(
     let session_id = Arc::from(session_id);
 
     state.inputs.validate_token(&input_id, &headers).await?;
+    state.inputs.validate_session_id(&input_id, &session_id)?;
 
-    let peer_connection = state.inputs.get_session(&input_id, &session_id)?;
+    let peer_connection = state
+        .inputs
+        .get_mut_with(&input_id, |input| Ok(input.peer_connection.take()))?;
 
-    peer_connection.close().await?;
+    match peer_connection {
+        Some(peer_connection) => peer_connection.close().await?,
+        None => {
+            return Err(WhipWhepServerError::InternalError(format!(
+                "None peer connection for {session_id:?}"
+            )));
+        }
+    }
 
-    info!(?session_id, ?input_id, "WHIP sessionterminated");
+    info!("WHIP session {session_id:?} terminated");
     Ok(StatusCode::OK)
 }

--- a/compositor_pipeline/src/pipeline/webrtc/server/terminate_whip_session.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/server/terminate_whip_session.rs
@@ -7,19 +7,21 @@ use std::sync::Arc;
 use tracing::info;
 
 pub async fn handle_terminate_whip_session(
-    Path((id, session_id)): Path<(String, String)>,
+    Path((endpoint_id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let input_id = Arc::from(id);
+    let endpoint_id = Arc::from(endpoint_id);
     let session_id = Arc::from(session_id);
 
-    state.inputs.validate_token(&input_id, &headers).await?;
-    state.inputs.validate_session_id(&input_id, &session_id)?;
+    state.inputs.validate_token(&endpoint_id, &headers).await?;
+    state
+        .inputs
+        .validate_session_id(&endpoint_id, &session_id)?;
 
     let peer_connection = state
         .inputs
-        .get_mut_with(&input_id, |input| Ok(input.peer_connection.take()))?;
+        .get_mut_with(&endpoint_id, |input| Ok(input.peer_connection.take()))?;
 
     match peer_connection {
         Some(peer_connection) => peer_connection.close().await?,

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
@@ -27,7 +27,7 @@ pub(super) use state::WhipInputsState;
 
 pub struct WhipInput {
     whip_inputs_state: WhipInputsState,
-    session_id: Arc<str>,
+    input_id: Arc<str>,
 }
 
 impl WhipInput {
@@ -40,13 +40,13 @@ impl WhipInput {
             return Err(InputInitError::WhipWhepServerNotRunning);
         };
 
-        let session_id = options.whip_session_id_override.unwrap_or(input_id.0);
+        let input_id = options.whip_session_id_override.unwrap_or(input_id.0);
         let (frame_sender, frame_receiver) = bounded(5);
         let (input_samples_sender, input_samples_receiver) = bounded(5);
 
         let bearer_token = options.bearer_token.unwrap_or_else(generate_token);
         state.inputs.add_input(
-            session_id.clone(),
+            input_id.clone(),
             WhipInputConnectionStateOptions {
                 bearer_token: bearer_token.clone(),
                 video_preferences: options.video_preferences,
@@ -58,7 +58,7 @@ impl WhipInput {
         Ok((
             Input::Whip(Self {
                 whip_inputs_state: state.inputs.clone(),
-                session_id: session_id.clone(),
+                input_id: input_id.clone(),
             }),
             InputInitInfo::Whip { bearer_token },
             QueueDataReceiver {
@@ -71,7 +71,7 @@ impl WhipInput {
 
 impl Drop for WhipInput {
     fn drop(&mut self) {
-        self.whip_inputs_state.ensure_input_closed(&self.session_id);
+        //self.whip_inputs_state.ensure_input_closed(&self.input_id); // TODO think how to handle it
     }
 }
 

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
@@ -46,7 +46,7 @@ impl WhipInput {
 
         let bearer_token = options.bearer_token.unwrap_or_else(generate_token);
         state.inputs.add_input(
-            endpoint_id.clone(),
+            &endpoint_id,
             WhipInputConnectionStateOptions {
                 bearer_token: bearer_token.clone(),
                 video_preferences: options.video_preferences,
@@ -58,7 +58,7 @@ impl WhipInput {
         Ok((
             Input::Whip(Self {
                 whip_inputs_state: state.inputs.clone(),
-                endpoint_id: endpoint_id.clone(),
+                endpoint_id,
             }),
             InputInitInfo::Whip { bearer_token },
             QueueDataReceiver {

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
@@ -27,7 +27,7 @@ pub(super) use state::WhipInputsState;
 
 pub struct WhipInput {
     whip_inputs_state: WhipInputsState,
-    input_id: Arc<str>,
+    endpoint_id: Arc<str>,
 }
 
 impl WhipInput {
@@ -40,13 +40,13 @@ impl WhipInput {
             return Err(InputInitError::WhipWhepServerNotRunning);
         };
 
-        let input_id = options.whip_session_id_override.unwrap_or(input_id.0);
+        let endpoint_id = options.endpoint_override.unwrap_or(input_id.0);
         let (frame_sender, frame_receiver) = bounded(5);
         let (input_samples_sender, input_samples_receiver) = bounded(5);
 
         let bearer_token = options.bearer_token.unwrap_or_else(generate_token);
         state.inputs.add_input(
-            input_id.clone(),
+            endpoint_id.clone(),
             WhipInputConnectionStateOptions {
                 bearer_token: bearer_token.clone(),
                 video_preferences: options.video_preferences,
@@ -58,7 +58,7 @@ impl WhipInput {
         Ok((
             Input::Whip(Self {
                 whip_inputs_state: state.inputs.clone(),
-                input_id: input_id.clone(),
+                endpoint_id: endpoint_id.clone(),
             }),
             InputInitInfo::Whip { bearer_token },
             QueueDataReceiver {
@@ -71,7 +71,8 @@ impl WhipInput {
 
 impl Drop for WhipInput {
     fn drop(&mut self) {
-        self.whip_inputs_state.ensure_input_closed(&self.input_id);
+        self.whip_inputs_state
+            .ensure_input_closed(&self.endpoint_id);
     }
 }
 

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input.rs
@@ -71,7 +71,7 @@ impl WhipInput {
 
 impl Drop for WhipInput {
     fn drop(&mut self) {
-        //self.whip_inputs_state.ensure_input_closed(&self.input_id); // TODO think how to handle it
+        self.whip_inputs_state.ensure_input_closed(&self.input_id);
     }
 }
 

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/connection_state.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/connection_state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use compositor_render::Frame;
@@ -24,7 +25,7 @@ pub(crate) struct WhipInputConnectionStateOptions {
 #[derive(Debug, Clone)]
 pub(crate) struct WhipInputConnectionState {
     pub bearer_token: Arc<str>,
-    pub peer_connection: Option<RecvonlyPeerConnection>,
+    pub sessions: HashMap<Arc<str>, Arc<RecvonlyPeerConnection>>,
     pub video_preferences: Vec<VideoDecoderOptions>,
     pub frame_sender: Sender<PipelineEvent<Frame>>,
     pub input_samples_sender: Sender<PipelineEvent<InputAudioSamples>>,
@@ -34,38 +35,38 @@ impl WhipInputConnectionState {
     pub fn new(options: WhipInputConnectionStateOptions) -> Self {
         WhipInputConnectionState {
             bearer_token: options.bearer_token,
-            peer_connection: None,
+            sessions: HashMap::new(),
             video_preferences: options.video_preferences,
             frame_sender: options.frame_sender,
             input_samples_sender: options.input_samples_sender,
         }
     }
 
-    pub fn maybe_replace_peer_connection(
-        &mut self,
-        session_id: &Arc<str>,
-        new_pc: RecvonlyPeerConnection,
-    ) -> Result<(), WhipWhepServerError> {
-        // Deleting previous peer_connection on this input which was not in Connected state
-        if let Some(peer_connection) = &self.peer_connection {
-            if peer_connection.connection_state() == RTCPeerConnectionState::Connected {
-                return Err(WhipWhepServerError::InternalError(format!(
-                      "Another stream is currently connected to the given session_id: {session_id:?}. \
-                      Disconnect the existing stream before starting a new one, or check if the session_id is correct."
-                  )));
-            }
-            if let Some(peer_connection) = self.peer_connection.take() {
-                let session_id = session_id.clone();
-                tokio::spawn(async move {
-                    if let Err(err) = peer_connection.close().await {
-                        warn!(
-                            "Error while closing previous peer connection {session_id:?}: {err:?}"
-                        )
-                    }
-                });
-            }
-        };
-        self.peer_connection = Some(new_pc);
-        Ok(())
-    }
+    // pub fn maybe_replace_peer_connection(
+    //     &mut self,
+    //     session_id: &Arc<str>,
+    //     new_pc: RecvonlyPeerConnection,
+    // ) -> Result<(), WhipWhepServerError> {
+    //     // Deleting previous peer_connection on this input which was not in Connected state
+    //     if let Some(peer_connection) = &self.peer_connection {
+    //         if peer_connection.connection_state() == RTCPeerConnectionState::Connected {
+    //             return Err(WhipWhepServerError::InternalError(format!(
+    //                   "Another stream is currently connected to the given session_id: {session_id:?}. \
+    //                   Disconnect the existing stream before starting a new one, or check if the session_id is correct."
+    //               )));
+    //         }
+    //         if let Some(peer_connection) = self.peer_connection.take() {
+    //             let session_id = session_id.clone();
+    //             tokio::spawn(async move {
+    //                 if let Err(err) = peer_connection.close().await {
+    //                     warn!(
+    //                         "Error while closing previous peer connection {session_id:?}: {err:?}"
+    //                     )
+    //                 }
+    //             });
+    //         }
+    //     };
+    //     self.peer_connection = Some(new_pc);
+    //     Ok(())
+    // }
 }

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
@@ -4,11 +4,14 @@ use std::{
 };
 
 use axum::http::HeaderMap;
-use tracing::error;
+use tracing::{error, warn};
+use uuid::Uuid;
+use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 
 use crate::pipeline::webrtc::{
     bearer_token::validate_token,
     error::WhipWhepServerError,
+    peer_connection_recvonly::RecvonlyPeerConnection,
     whip_input::connection_state::{WhipInputConnectionState, WhipInputConnectionStateOptions},
 };
 
@@ -55,31 +58,101 @@ impl WhipInputsState {
         guard.insert(session_id, WhipInputConnectionState::new(options));
     }
 
-    // called on drop (when input is unregistered)
-    pub fn ensure_input_closed(&self, session_id: &Arc<str>) {
+    pub fn add_session(
+        &self,
+        input_id: &Arc<str>,
+        peer_connection: Arc<RecvonlyPeerConnection>,
+    ) -> Result<Arc<str>, WhipWhepServerError> {
         let mut guard = self.0.lock().unwrap();
-        if let Some(input) = guard.remove(session_id) {
-            if let Some(peer_connection) = input.peer_connection {
-                let session_id = session_id.clone();
+        match guard.get_mut(input_id) {
+            Some(input) => {
+                let session_id: Arc<str> = Arc::from(Uuid::new_v4().to_string());
+                input.sessions.insert(session_id.clone(), peer_connection);
+                Ok(session_id)
+            }
+            None => Err(WhipWhepServerError::NotFound(format!(
+                "{input_id:?} not found"
+            ))),
+        }
+    }
+
+    pub fn get_session(
+        &self,
+        input_id: &Arc<str>,
+        session_id: &Arc<str>,
+    ) -> Result<Arc<RecvonlyPeerConnection>, WhipWhepServerError> {
+        let guard = self.0.lock().unwrap();
+        match guard.get(input_id) {
+            Some(input) => match input.sessions.get(session_id) {
+                Some(pc) => Ok(pc.clone()),
+                None => Err(WhipWhepServerError::NotFound(format!(
+                    "Session {session_id:?} not found for {input_id:?}"
+                ))),
+            },
+            None => Err(WhipWhepServerError::NotFound(format!(
+                "{input_id:?} not found"
+            ))),
+        }
+    }
+
+    pub fn maybe_replace_peer_connection(
+        &mut self,
+        input_id: &Arc<str>,
+        session_id: &Arc<str>,
+        new_pc: Arc<RecvonlyPeerConnection>,
+    ) -> Result<(), WhipWhepServerError> {
+        // Deleting previous peer_connection on this input which was not in Connected state
+        if let Ok(peer_connection) = &self.get_session(input_id, session_id) {
+            if peer_connection.connection_state() == RTCPeerConnectionState::Connected {
+                return Err(WhipWhepServerError::InternalError(format!(
+                      "Another stream is currently connected to the given session_id: {input_id:?}. \
+                      Disconnect the existing stream before starting a new one, or check if the session_id is correct."
+                  )));
+            }
+            let session_id = input_id.clone();
+            let pc_to_close = peer_connection.clone();
+
+            tokio::spawn(async move {
+                if let Err(err) = pc_to_close.close().await {
+                    warn!("Error while closing previous peer connection {session_id:?}: {err:?}")
+                }
+            });
+        };
+        self.get_mut_with(input_id, |input| {
+            if let Some(pc_slot) = input.sessions.get_mut(session_id) {
+                *pc_slot = new_pc;
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    // called on drop (when input is unregistered)
+    pub fn ensure_input_closed(&self, input_id: &Arc<str>, session_id: &Arc<str>) {
+        let mut guard = self.0.lock().unwrap();
+        if let Some(input) = guard.remove(input_id) {
+            if let Some(peer_connection) = input.sessions.get(session_id).cloned() {
+                let input_id = input_id.clone();
                 tokio::spawn(async move {
                     if let Err(err) = peer_connection.close().await {
-                        error!("Cannot close peer_connection for {session_id:?}: {err:?}");
+                        error!("Cannot close peer_connection for {input_id:?}: {err:?}");
                     };
                 });
             }
         }
     }
 
+    // TODO consider if one bearer_token per input is best approche
     pub async fn validate_token(
         &self,
-        session_id: &Arc<str>,
+        input_id: &Arc<str>,
         headers: &HeaderMap,
     ) -> Result<(), WhipWhepServerError> {
-        let bearer_token = match self.0.lock().unwrap().get_mut(session_id) {
+        let bearer_token = match self.0.lock().unwrap().get_mut(input_id) {
             Some(input) => input.bearer_token.clone(),
             None => {
                 return Err(WhipWhepServerError::NotFound(format!(
-                    "{session_id:?} not found"
+                    "{input_id:?} not found"
                 )))
             }
         };

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
@@ -75,18 +75,17 @@ impl WhipInputsState {
         input_id: &Arc<str>,
         session_id: &Arc<str>,
     ) -> Result<(), WhipWhepServerError> {
-        let mut guard = self.0.lock().unwrap();
-        if let Some(input) = guard.remove(input_id) {
-            if input.current_session_id != *session_id {
+        let guard = self.0.lock().unwrap();
+        if let Some(input) = guard.get(input_id) {
+            if input.current_session_id != Some(session_id.clone()) {
                 return Err(WhipWhepServerError::Unauthorized(format!(
-                    "Session_id {session_id} is not active now"
+                    "Session {session_id} is not active now"
                 )));
             }
         }
         Ok(())
     }
 
-    // TODO consider if one bearer_token per input is best approche
     pub async fn validate_token(
         &self,
         input_id: &Arc<str>,

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
@@ -4,14 +4,11 @@ use std::{
 };
 
 use axum::http::HeaderMap;
-use tracing::{error, warn};
-use uuid::Uuid;
-use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
+use tracing::error;
 
 use crate::pipeline::webrtc::{
     bearer_token::validate_token,
     error::WhipWhepServerError,
-    peer_connection_recvonly::RecvonlyPeerConnection,
     whip_input::connection_state::{WhipInputConnectionState, WhipInputConnectionStateOptions},
 };
 
@@ -58,80 +55,11 @@ impl WhipInputsState {
         guard.insert(session_id, WhipInputConnectionState::new(options));
     }
 
-    pub fn add_session(
-        &self,
-        input_id: &Arc<str>,
-        peer_connection: Arc<RecvonlyPeerConnection>,
-    ) -> Result<Arc<str>, WhipWhepServerError> {
-        let mut guard = self.0.lock().unwrap();
-        match guard.get_mut(input_id) {
-            Some(input) => {
-                let session_id: Arc<str> = Arc::from(Uuid::new_v4().to_string());
-                input.sessions.insert(session_id.clone(), peer_connection);
-                Ok(session_id)
-            }
-            None => Err(WhipWhepServerError::NotFound(format!(
-                "{input_id:?} not found"
-            ))),
-        }
-    }
-
-    pub fn get_session(
-        &self,
-        input_id: &Arc<str>,
-        session_id: &Arc<str>,
-    ) -> Result<Arc<RecvonlyPeerConnection>, WhipWhepServerError> {
-        let guard = self.0.lock().unwrap();
-        match guard.get(input_id) {
-            Some(input) => match input.sessions.get(session_id) {
-                Some(pc) => Ok(pc.clone()),
-                None => Err(WhipWhepServerError::NotFound(format!(
-                    "Session {session_id:?} not found for {input_id:?}"
-                ))),
-            },
-            None => Err(WhipWhepServerError::NotFound(format!(
-                "{input_id:?} not found"
-            ))),
-        }
-    }
-
-    pub fn maybe_replace_peer_connection(
-        &mut self,
-        input_id: &Arc<str>,
-        session_id: &Arc<str>,
-        new_pc: Arc<RecvonlyPeerConnection>,
-    ) -> Result<(), WhipWhepServerError> {
-        // Deleting previous peer_connection on this input which was not in Connected state
-        if let Ok(peer_connection) = &self.get_session(input_id, session_id) {
-            if peer_connection.connection_state() == RTCPeerConnectionState::Connected {
-                return Err(WhipWhepServerError::InternalError(format!(
-                      "Another stream is currently connected to the given session_id: {input_id:?}. \
-                      Disconnect the existing stream before starting a new one, or check if the session_id is correct."
-                  )));
-            }
-            let session_id = input_id.clone();
-            let pc_to_close = peer_connection.clone();
-
-            tokio::spawn(async move {
-                if let Err(err) = pc_to_close.close().await {
-                    warn!("Error while closing previous peer connection {session_id:?}: {err:?}")
-                }
-            });
-        };
-        self.get_mut_with(input_id, |input| {
-            if let Some(pc_slot) = input.sessions.get_mut(session_id) {
-                *pc_slot = new_pc;
-            }
-            Ok(())
-        })?;
-        Ok(())
-    }
-
     // called on drop (when input is unregistered)
-    pub fn ensure_input_closed(&self, input_id: &Arc<str>, session_id: &Arc<str>) {
+    pub fn ensure_input_closed(&self, input_id: &Arc<str>) {
         let mut guard = self.0.lock().unwrap();
         if let Some(input) = guard.remove(input_id) {
-            if let Some(peer_connection) = input.sessions.get(session_id).cloned() {
+            if let Some(peer_connection) = input.peer_connection {
                 let input_id = input_id.clone();
                 tokio::spawn(async move {
                     if let Err(err) = peer_connection.close().await {
@@ -140,6 +68,22 @@ impl WhipInputsState {
                 });
             }
         }
+    }
+
+    pub fn validate_session_id(
+        &self,
+        input_id: &Arc<str>,
+        session_id: &Arc<str>,
+    ) -> Result<(), WhipWhepServerError> {
+        let mut guard = self.0.lock().unwrap();
+        if let Some(input) = guard.remove(input_id) {
+            if input.current_session_id != *session_id {
+                return Err(WhipWhepServerError::Unauthorized(format!(
+                    "Session_id {session_id} is not active now"
+                )));
+            }
+        }
+        Ok(())
     }
 
     // TODO consider if one bearer_token per input is best approche

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/state.rs
@@ -50,9 +50,9 @@ impl WhipInputsState {
         }
     }
 
-    pub fn add_input(&self, session_id: Arc<str>, options: WhipInputConnectionStateOptions) {
+    pub fn add_input(&self, endpoint_id: &Arc<str>, options: WhipInputConnectionStateOptions) {
         let mut guard = self.0.lock().unwrap();
-        guard.insert(session_id, WhipInputConnectionState::new(options));
+        guard.insert(endpoint_id.clone(), WhipInputConnectionState::new(options));
     }
 
     // called on drop (when input is unregistered)

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/track_audio_thread.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/track_audio_thread.rs
@@ -31,7 +31,7 @@ use crate::prelude::*;
 pub async fn process_audio_track(
     sync_point: Arc<RtpNtpSyncPoint>,
     state: WhipWhepServerState,
-    session_id: Arc<str>,
+    endpoint_id: Arc<str>,
     track: Arc<TrackRemote>,
     transceiver: Arc<RTCRtpTransceiver>,
 ) -> Result<(), WhipWhepServerError> {
@@ -45,8 +45,8 @@ pub async fn process_audio_track(
 
     let WhipWhepServerState { inputs, ctx, .. } = state;
     let samples_sender =
-        inputs.get_with(&session_id, |input| Ok(input.input_samples_sender.clone()))?;
-    let handle = AudioTrackThread::spawn(&session_id, (ctx.clone(), samples_sender))?;
+        inputs.get_with(&endpoint_id, |input| Ok(input.input_samples_sender.clone()))?;
+    let handle = AudioTrackThread::spawn(&endpoint_id, (ctx.clone(), samples_sender))?;
 
     let mut timestamp_sync =
         RtpTimestampSync::new(&sync_point, 48_000, ctx.default_buffer_duration);

--- a/compositor_pipeline/src/pipeline/webrtc/whip_input/track_video_thread.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whip_input/track_video_thread.rs
@@ -37,7 +37,7 @@ use crate::prelude::*;
 pub async fn process_video_track(
     sync_point: Arc<RtpNtpSyncPoint>,
     state: WhipWhepServerState,
-    session_id: Arc<str>,
+    endpoint_id: Arc<str>,
     track: Arc<TrackRemote>,
     transceiver: Arc<RTCRtpTransceiver>,
     video_preferences: Vec<VideoDecoderOptions>,
@@ -53,9 +53,9 @@ pub async fn process_video_track(
     };
 
     let WhipWhepServerState { inputs, ctx, .. } = state;
-    let frame_sender = inputs.get_with(&session_id, |input| Ok(input.frame_sender.clone()))?;
+    let frame_sender = inputs.get_with(&endpoint_id, |input| Ok(input.frame_sender.clone()))?;
     let handle =
-        VideoTrackThread::spawn(&session_id, (ctx.clone(), negotiated_codecs, frame_sender))?;
+        VideoTrackThread::spawn(&endpoint_id, (ctx.clone(), negotiated_codecs, frame_sender))?;
 
     let mut timestamp_sync =
         RtpTimestampSync::new(&sync_point, 90_000, ctx.default_buffer_duration);

--- a/compositor_pipeline/src/protocols/webrtc.rs
+++ b/compositor_pipeline/src/protocols/webrtc.rs
@@ -12,7 +12,7 @@ use crate::{
 pub struct WhipInputOptions {
     pub video_preferences: Vec<VideoDecoderOptions>,
     pub bearer_token: Option<Arc<str>>,
-    pub whip_session_id_override: Option<Arc<str>>,
+    pub endpoint_override: Option<Arc<str>>,
 }
 
 #[derive(Debug, Clone)]

--- a/ts/smelter-core/src/api/input.ts
+++ b/ts/smelter-core/src/api/input.ts
@@ -112,7 +112,7 @@ function intoWhipRegisterInput(
     type: 'whip',
     video: input.video && intoInputWhipVideoOptions(input.video),
     bearer_token: input.bearerToken,
-    whip_session_id_override: inputId,
+    endpoint_override: inputId,
     required: input.required,
     offset_ms: input.offsetMs,
   };

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -83,7 +83,7 @@ export type RegisterInput =
       /**
        * Internal use only. Overrides whip session id which is used when referencing the input via whip server. If not provided, it defaults to input id.
        */
-      whip_session_id_override?: string | null;
+      endpoint_override?: string | null;
       /**
        * (**default=`false`**) If input is required and the stream is not delivered on time, then Smelter will delay producing output frames.
        */


### PR DESCRIPTION
Ensures WHIP sessions on a single input are uniquely identified, preventing a disconnected client from sending a `DELETE` that affects another active session.