### PR TITLE
[ts-sdk] Fix inputs with colons in the name

### DIFF
--- a/ts/smelter/src/types/refs/imageRef.ts
+++ b/ts/smelter/src/types/refs/imageRef.ts
@@ -31,13 +31,13 @@ export function parseImageRef(rawId: string): ImageRef {
   } else if (split[0] === 'global') {
     return {
       type: 'global',
-      id: split.slice(1).join(),
+      id: split.slice(1).join(':'),
     };
   } else if (split[0] === 'output-specific-image') {
     return {
       type: 'output-specific-image',
       id: Number(split[1]),
-      outputId: split.slice(2).join(),
+      outputId: split.slice(2).join(':'),
     };
   } else {
     throw new Error(`Unknown image type (${split[0]}).`);

--- a/ts/smelter/src/types/refs/inputRef.ts
+++ b/ts/smelter/src/types/refs/inputRef.ts
@@ -31,13 +31,13 @@ export function parseInputRef(rawId: string): InputRef {
   } else if (split[0] === 'global') {
     return {
       type: 'global',
-      id: split.slice(1).join(),
+      id: split.slice(1).join(':'),
     };
   } else if (split[0] === 'output-specific-input') {
     return {
       type: 'output-specific-input',
       id: Number(split[1]),
-      outputId: split.slice(2).join(),
+      outputId: split.slice(2).join(':'),
     };
   } else {
     throw new Error(`Unknown input type (${split[0]}).`);


### PR DESCRIPTION
Inputs with colons were not handled correctly because join by default was replacing `:` with `,`