### PR TITLE
Fix panic on negative component size

### DIFF
--- a/compositor_render/src/scene/types.rs
+++ b/compositor_render/src/scene/types.rs
@@ -107,7 +107,7 @@ impl BorderRadius {
     }
 
     pub fn clip_to_size(&self, size: Size) -> Self {
-        let max_radius = f32::min(size.width, size.height) / 2.0;
+        let max_radius = f32::max(0.0, f32::min(size.width, size.height) / 2.0);
         Self {
             top_left: f32::clamp(self.top_left, 0.0, max_radius),
             top_right: f32::clamp(self.top_right, 0.0, max_radius),


### PR DESCRIPTION
Closes #1265

A component can have a negative size if e.g.
```
View width=100
  View width =110
  View width = undefined  (it will be calculated to -10)
```