### PR TITLE
Update declink implementation for new queue sync mechanism

### DIFF
--- a/compositor_pipeline/src/pipeline/decklink/mod.rs
+++ b/compositor_pipeline/src/pipeline/decklink/mod.rs
@@ -53,9 +53,9 @@ impl DeckLink {
             .map_err(DeckLinkInputError::DecklinkError)?;
 
         let (callback, receivers) = ChannelCallbackAdapter::new(
+            &ctx,
             span,
             opts.enable_audio,
-            ctx.mixing_sample_rate,
             opts.pixel_format,
             Arc::<decklink::Input>::downgrade(&input),
             (


### PR DESCRIPTION
After the recent queue sync rework DeckLink implementation was not updated. This PR fixes the synchronization mechanism.

