### PR TITLE
[ts-sdk] Remove audio streams from context

### DIFF
--- a/ts/smelter/src/context/audioOutputContext.ts
+++ b/ts/smelter/src/context/audioOutputContext.ts
@@ -54,6 +54,13 @@ export class AudioContext {
     if (inputConfig) {
       // opt !== options compares objects by reference
       inputConfig.volumeComponents = inputConfig.volumeComponents.filter(opt => opt !== options);
+
+      if (inputConfig.volumeComponents.length === 0) {
+        this.audioMixerConfig = this.audioMixerConfig.filter(
+          config => !areRefsEqual(config.inputRef, inputRef)
+        );
+      }
+
       this.onChange();
     }
   }


### PR DESCRIPTION
Before this change, inputs were never removed. As a result update request included old (already unregistered inputs) with volume set to zero.

It's not causing any invalid behavior, but in time it could grow to large amount of data that needs to be sent on every update.