### PR TITLE
Fix returned sample rate value in resampler

### DIFF
--- a/compositor_pipeline/src/pipeline/resampler/dynamic_resampler.rs
+++ b/compositor_pipeline/src/pipeline/resampler/dynamic_resampler.rs
@@ -158,7 +158,7 @@ impl DynamicResampler {
                             DynamicResamplerBatch {
                                 samples: AudioSamples::Stereo(joined_samples.collect()),
                                 start_pts: l.start_pts,
-                                sample_rate: batch.sample_rate,
+                                sample_rate: self.output_sample_rate,
                             }
                         })
                         .collect())


### PR DESCRIPTION
The output sample rate was incorrect, resulting in the incorrect end_pts value for batches in the mixer. The audio mixer  mostly relies on the sample rate value globally defined, so even with this bug it worked in general because the end_pts value of the batch is not used for most of the calculations