### PR TITLE
[examples] Added error handling for register and unregister requests.

### DIFF
--- a/integration_tests/examples/demo/main.rs
+++ b/integration_tests/examples/demo/main.rs
@@ -68,28 +68,8 @@ fn run_demo() -> Result<()> {
             }
         };
 
-        match action_result {
-            Ok(_) => {}
-            Err(e) => {
-                if e.is::<InquireError>() {
-                    let inquire_err = e.downcast::<InquireError>()?;
-                    match inquire_err {
-                        InquireError::OperationCanceled | InquireError::OperationInterrupted => {
-                            println!("Operation interrupted, repeat the action to exit demo.");
-                        }
-                        _ => {
-                            error!("{inquire_err}");
-                            bail!("An error occured.");
-                        }
-                    }
-                } else {
-                    error!("{e}");
-                    let root_cause = e.root_cause();
-                    if root_cause.to_string() != "Request failed." {
-                        bail!("An error occured");
-                    }
-                }
-            }
+        if let Err(e) = action_result {
+            error!("{e}");
         }
     }
 

--- a/integration_tests/examples/demo/main.rs
+++ b/integration_tests/examples/demo/main.rs
@@ -1,4 +1,3 @@
-use anyhow::{bail, Result};
 use inquire::{InquireError, Select};
 use integration_tests::examples;
 use serde_json::json;
@@ -34,7 +33,7 @@ pub enum Action {
     Start,
 }
 
-fn run_demo() -> Result<()> {
+fn run_demo() {
     let mut state = SmelterState::new();
 
     let mut options = Action::iter().collect::<Vec<_>>();
@@ -50,7 +49,7 @@ fn run_demo() -> Result<()> {
                 }
                 _ => {
                     error!("{e}");
-                    bail!("An error occured.");
+                    continue;
                 }
             },
         };
@@ -62,9 +61,13 @@ fn run_demo() -> Result<()> {
             Action::RemoveOutput => state.unregister_output(),
             Action::Start => {
                 debug!("{state:#?}");
-                options.retain(|a| *a != Action::Start);
-                examples::post("start", &json!({}))?;
-                Ok(())
+                match examples::post("start", &json!({})) {
+                    Ok(_) => {
+                        options.retain(|a| *a != Action::Start);
+                        Ok(())
+                    }
+                    Err(e) => Err(e.context("Start request failed")),
+                }
             }
         };
 
@@ -72,11 +75,9 @@ fn run_demo() -> Result<()> {
             error!("{e}");
         }
     }
-
-    Ok(())
 }
 
-fn main() -> Result<()> {
+fn main() {
     let config = read_config();
     init_logger(config.logger.clone());
     run_demo()

--- a/integration_tests/examples/demo/smelter_state.rs
+++ b/integration_tests/examples/demo/smelter_state.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use inquire::Select;
 use integration_tests::examples;
 use serde_json::json;
@@ -73,11 +73,8 @@ impl SmelterState {
 
         debug!("Input register request: {input_json:#?}");
 
-        let register_result = examples::post(&input_route, &input_json);
-        if register_result.is_err() {
-            println!();
-            return Ok(());
-        }
+        examples::post(&input_route, &input_json)
+            .with_context(|| "Input registration failed.".to_string())?;
 
         input_handler.on_after_registration(player)?;
         self.inputs.push(input_handler);
@@ -87,7 +84,8 @@ impl SmelterState {
             let update_route = format!("output/{}/update", output.name());
             let update_json = output.serialize_update(&inputs);
             debug!("{update_json:#?}");
-            examples::post(&update_route, &update_json)?;
+            examples::post(&update_route, &update_json)
+                .with_context(|| "Output update failed".to_string())?;
         }
 
         Ok(())
@@ -132,11 +130,8 @@ impl SmelterState {
 
         debug!("Output register request: {output_json:#?}");
 
-        let register_result = examples::post(&output_route, &output_json);
-        if register_result.is_err() {
-            println!();
-            return Ok(());
-        }
+        examples::post(&output_route, &output_json)
+            .with_context(|| "Output registration failed".to_string())?;
 
         output_handler.on_after_registration(player)?;
 
@@ -171,16 +166,14 @@ impl SmelterState {
                 })
                 .collect::<Vec<_>>();
             let update_json = output.serialize_update(&inputs);
-            examples::post(&update_route, &update_json)?;
+            examples::post(&update_route, &update_json)
+                .with_context(|| "Output update failed".to_string())?;
         }
 
         let unregister_route = format!("input/{}/unregister", to_delete);
 
-        let unregister_result = examples::post(&unregister_route, &json!({}));
-        if unregister_result.is_err() {
-            println!();
-            return Ok(());
-        }
+        examples::post(&unregister_route, &json!({}))
+            .with_context(|| "Input unregistration failed".to_string())?;
 
         self.inputs.retain(|i| i.name() != to_delete);
 
@@ -201,11 +194,8 @@ impl SmelterState {
 
         let unregister_route = format!("output/{}/unregister", to_delete);
 
-        let unregister_result = examples::post(&unregister_route, &json!({}));
-        if unregister_result.is_err() {
-            println!();
-            return Ok(());
-        }
+        examples::post(&unregister_route, &json!({}))
+            .with_context(|| "Output unregistration failed".to_string())?;
 
         self.outputs.retain(|o| o.name() != to_delete);
 

--- a/integration_tests/examples/demo/smelter_state.rs
+++ b/integration_tests/examples/demo/smelter_state.rs
@@ -73,7 +73,12 @@ impl SmelterState {
 
         debug!("Input register request: {input_json:#?}");
 
-        examples::post(&input_route, &input_json)?;
+        let register_result = examples::post(&input_route, &input_json);
+        if register_result.is_err() {
+            println!();
+            return Ok(());
+        }
+
         input_handler.on_after_registration(player)?;
         self.inputs.push(input_handler);
 
@@ -127,7 +132,11 @@ impl SmelterState {
 
         debug!("Output register request: {output_json:#?}");
 
-        examples::post(&output_route, &output_json)?;
+        let register_result = examples::post(&output_route, &output_json);
+        if register_result.is_err() {
+            println!();
+            return Ok(());
+        }
 
         output_handler.on_after_registration(player)?;
 
@@ -166,7 +175,12 @@ impl SmelterState {
         }
 
         let unregister_route = format!("input/{}/unregister", to_delete);
-        examples::post(&unregister_route, &json!({}))?;
+
+        let unregister_result = examples::post(&unregister_route, &json!({}));
+        if unregister_result.is_err() {
+            println!();
+            return Ok(());
+        }
 
         self.inputs.retain(|i| i.name() != to_delete);
 
@@ -186,7 +200,12 @@ impl SmelterState {
         let to_delete = Select::new("Select output to remove:", output_names).prompt()?;
 
         let unregister_route = format!("output/{}/unregister", to_delete);
-        examples::post(&unregister_route, &json!({}))?;
+
+        let unregister_result = examples::post(&unregister_route, &json!({}));
+        if unregister_result.is_err() {
+            println!();
+            return Ok(());
+        }
 
         self.outputs.retain(|o| o.name() != to_delete);
 


### PR DESCRIPTION
Simple error handling for client requests.

Additionally handled situation when server is not running (inside of `examples.rs` file).