### PR TITLE
Added `debug!` logs to SDP offer and answer in `WHEP` output.

### DIFF
--- a/compositor_pipeline/src/pipeline/webrtc/whep_output/peer_connection.rs
+++ b/compositor_pipeline/src/pipeline/webrtc/whep_output/peer_connection.rs
@@ -187,9 +187,11 @@ impl PeerConnection {
         offer: String,
     ) -> Result<RTCSessionDescription, WhipWhepServerError> {
         let offer = RTCSessionDescription::offer(offer)?;
+        debug!("SDP offer: {}", offer.sdp);
         self.set_remote_description(offer).await?;
 
         let answer = self.create_answer().await?;
+        debug!("SDP answer: {}", answer.sdp);
         self.set_local_description(answer).await?;
 
         self.wait_for_ice_candidates(Duration::from_secs(1)).await?;


### PR DESCRIPTION
These debug logs are analogical to the ones in `whip_output/establish_peer_connection.rs`