### PR TITLE
Split HLS input logic (fix context panic on move)

### DIFF
--- a/compositor_pipeline/src/pipeline/hls/hls_input.rs
+++ b/compositor_pipeline/src/pipeline/hls/hls_input.rs
@@ -500,7 +500,7 @@ fn input_with_dictionary_and_interrupt<F>(
     interrupt_fn: F,
 ) -> Result<context::Input, ffmpeg_next::Error>
 where
-    F: FnMut() -> bool,
+    F: FnMut() -> bool + 'static,
 {
     unsafe {
         let mut ps = avformat_alloc_context();


### PR DESCRIPTION
In the past, we had trouble with ffmpeg context segfaulting on move. It looks like closure has to be defined with `move`, otherwise referenced variable leak.

This PR:
- Splits initialization from the demuxing loop. 
- We don't need a channel anymore that returns int result from thread