### PR TITLE
[integration-tests] Added new audio tests.

### DIFF
--- a/integration-tests/src/bin/generate_frequencies.rs
+++ b/integration-tests/src/bin/generate_frequencies.rs
@@ -1,6 +1,6 @@
-use std::process::Command;
+use std::{fs, process::Command};
 
-use integration_tests::paths::submodule_root_path;
+use integration_tests::paths::{integration_tests_root, submodule_root_path};
 
 enum Encoder {
     Aac,
@@ -27,7 +27,7 @@ fn main() {
     let encoders = vec![Encoder::Aac, Encoder::Opus];
     let notes = vec![("a", 440.0), ("c_sharp", 554.37), ("e", 659.26)];
 
-    let cmd_wd = submodule_root_path()
+    let snapshots_dir = submodule_root_path()
         .join("rtp_packet_dumps")
         .join("inputs");
 
@@ -43,18 +43,86 @@ fn main() {
             Command::new("bash")
                 .arg("-c")
                 .arg(cmd)
-                .current_dir(&cmd_wd)
+                .current_dir(&snapshots_dir)
                 .status()
                 .unwrap();
 
             Command::new("bash")
                 .arg("-c")
                 .arg(format!(
-                    "cargo run -p integration_tests --bin generate_rtp_from_file audio-{file_suffix} {file_name}"
+                    "cargo run -p integration-tests --bin generate_rtp_from_file audio-{file_suffix} {file_name}"
                 ))
-                .current_dir(&cmd_wd)
+                .current_dir(&snapshots_dir)
                 .status()
                 .unwrap();
         }
     }
+
+    let wav_a = "ffmpeg -y -f lavfi -i \"sine=frequency=440.0:sample_rate=48000:duration=5\" -af \"volume=3\" -c:a pcm_s16le -ac 2 -ar 48000 -vn a.wav";
+    let wav_c_sharp = "ffmpeg -y -f lavfi -i \"sine=frequency=554.37:sample_rate=48000:duration=15\" -af \"volume=3\" -c:a pcm_s16le -ac 2 -ar 48000 -vn c_sharp.wav";
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(wav_a)
+        .current_dir(integration_tests_root())
+        .status()
+        .unwrap();
+    Command::new("bash")
+        .arg("-c")
+        .arg(wav_c_sharp)
+        .current_dir(integration_tests_root())
+        .status()
+        .unwrap();
+
+    Command::new("bash")
+        .arg("-c")
+        .arg("sox a.wav c_sharp.wav variable_frequency.wav")
+        .current_dir(integration_tests_root())
+        .status()
+        .unwrap();
+
+    fs::remove_file(integration_tests_root().join("a.wav")).unwrap();
+    fs::remove_file(integration_tests_root().join("c_sharp.wav")).unwrap();
+
+    for encoder in encoders {
+        let file_suffix = encoder.file_name();
+        let encoder_name = encoder.name();
+
+        let file_name = format!("variable_frequency_{file_suffix}.mp4");
+
+        let cmd = format!("ffmpeg -y -i variable_frequency.wav -c:a {encoder_name} -ac 2 -ar 48000 -vn {file_name}");
+
+        Command::new("bash")
+            .arg("-c")
+            .arg(&cmd)
+            .current_dir(integration_tests_root())
+            .status()
+            .unwrap();
+
+        Command::new("bash")
+            .arg("-c")
+            .arg(format!(
+                "cargo run -p integration-tests --bin generate_rtp_from_file audio-{file_suffix} {file_name}"
+            ))
+            .current_dir(integration_tests_root())
+            .status()
+            .unwrap();
+
+        fs::rename(
+            integration_tests_root().join(&file_name),
+            snapshots_dir.join(&file_name),
+        )
+        .unwrap();
+    }
+    fs::remove_file(integration_tests_root().join("variable_frequency.wav")).unwrap();
+    fs::rename(
+        integration_tests_root().join("variable_frequency_aac_audio_aac.rtp"),
+        snapshots_dir.join("variable_frequency_aac_audio_aac.rtp"),
+    )
+    .unwrap();
+    fs::rename(
+        integration_tests_root().join("variable_frequency_opus_audio.rtp"),
+        snapshots_dir.join("variable_frequency_opus_audio.rtp"),
+    )
+    .unwrap();
 }

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -542,8 +542,9 @@ pub fn single_input_aac_mp4() -> Result<()> {
 }
 
 /// Single frequency input that changes after 5 seconds. Input starts streaming 2 seconds before
-/// start request with offset set to 2 seconds. This should result in 2 seconds of silence, 5
-/// seconds of lower frequency and higher frequency after that time.
+/// start request with offset set to 2 seconds. 
+///
+/// Play  2 seconds of silence, 5 seconds of lower frequency and higher frequency after that time.
 #[test]
 fn audio_offset_variable_frequency() -> Result<()> {
     const OUTPUT_DUMP_FILE: &str = "audio_offset_variable_frequency_output.rtp";
@@ -617,9 +618,10 @@ fn audio_offset_variable_frequency() -> Result<()> {
     Ok(())
 }
 
-/// Single frequency input that changes after 5 seconds. Input starts streaming 2 seconds before
-/// start request with no offset. This should result in approx. 3 seconds of lower frequency and
-/// higher frequency after that.
+/// Use input that changes frequency after 5 seconds. Input starts streaming 2 seconds before
+/// start request with no offset. 
+///
+/// Play approx. 3 seconds of lower frequency and higher frequency after that.
 #[test]
 fn audio_no_offset_variable_frequency() -> Result<()> {
     const OUTPUT_DUMP_FILE: &str = "audio_no_offset_variable_frequency_output.rtp";

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -546,8 +546,8 @@ pub fn single_input_aac_mp4() -> Result<()> {
 ///
 /// Play  2 seconds of silence, 5 seconds of lower frequency and higher frequency after that time.
 #[test]
-fn audio_offset_variable_frequency() -> Result<()> {
-    const OUTPUT_DUMP_FILE: &str = "audio_offset_variable_frequency_output.rtp";
+fn audio_early_streaming_with_offset() -> Result<()> {
+    const OUTPUT_DUMP_FILE: &str = "audio_early_streaming_with_offset_output.rtp";
     let instance = CompositorInstance::start(None);
     let input_1_port = instance.get_port();
     let output_port = instance.get_port();
@@ -624,8 +624,8 @@ fn audio_offset_variable_frequency() -> Result<()> {
 ///
 /// Play approx. 3 seconds of lower frequency and higher frequency after that.
 #[test]
-fn audio_no_offset_variable_frequency() -> Result<()> {
-    const OUTPUT_DUMP_FILE: &str = "audio_no_offset_variable_frequency_output.rtp";
+fn audio_early_streaming_no_offset() -> Result<()> {
+    const OUTPUT_DUMP_FILE: &str = "audio_early_streaming_no_offset_output.rtp";
     let instance = CompositorInstance::start(None);
     let input_1_port = instance.get_port();
     let output_port = instance.get_port();

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -213,7 +213,7 @@ pub fn audio_mixing_no_offset() -> Result<()> {
 /// Play audio for 20 seconds.
 #[test]
 pub fn audio_mixing_track_insertion_with_offset() -> Result<()> {
-    const OUTPUT_DUMP_FILE: &str = "audio_mixing_addition_with_offset_output.rtp";
+    const OUTPUT_DUMP_FILE: &str = "audio_mixing_track_insertion_with_offset_output.rtp";
     let instance = CompositorInstance::start(None);
     let input_1_port = instance.get_port();
     let input_2_port = instance.get_port();

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde_json::json;
-use std::{path::PathBuf, thread, time::Duration};
+use std::{thread, time::Duration};
 
 use crate::{
     audio::{self, AudioAnalyzeTolerance, AudioValidationConfig},

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -541,7 +541,9 @@ pub fn single_input_aac_mp4() -> Result<()> {
     Ok(())
 }
 
-// TODO: (@jbrs) Doc comment describing test
+/// Single frequency input that changes after 5 seconds. Input starts streaming 2 seconds before
+/// start request with offset set to 2 seconds. This should result in 2 seconds of silence, 5
+/// seconds of lower frequency and higher frequency after that time.
 #[test]
 fn audio_offset_variable_frequency() -> Result<()> {
     const OUTPUT_DUMP_FILE: &str = "audio_offset_variable_frequency_output.rtp";
@@ -615,7 +617,9 @@ fn audio_offset_variable_frequency() -> Result<()> {
     Ok(())
 }
 
-// TODO: (@jbrs) Doc comment describing test
+/// Single frequency input that changes after 5 seconds. Input starts streaming 2 seconds before
+/// start request with no offset. This should result in approx. 3 seconds of lower frequency and
+/// higher frequency after that.
 #[test]
 fn audio_no_offset_variable_frequency() -> Result<()> {
     const OUTPUT_DUMP_FILE: &str = "audio_no_offset_variable_frequency_output.rtp";

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -614,3 +614,76 @@ fn audio_offset_variable_frequency() -> Result<()> {
 
     Ok(())
 }
+
+// TODO: (@jbrs) Doc comment describing test
+#[test]
+fn audio_no_offset_variable_frequency() -> Result<()> {
+    const OUTPUT_DUMP_FILE: &str = "audio_no_offset_variable_frequency_output.rtp";
+    let instance = CompositorInstance::start(None);
+    let input_1_port = instance.get_port();
+    let output_port = instance.get_port();
+
+    instance.send_request(
+        "output/output_1/register",
+        json!({
+            "type": "rtp_stream",
+            "transport_protocol": "tcp_server",
+            "port": output_port,
+            "audio": {
+                "initial": {
+                    "inputs": [
+                        {
+                            "input_id": "input_1",
+                        },
+
+                    ]
+                },
+                "channels": "stereo",
+                "encoder": {
+                    "type": "opus",
+                }
+            },
+        }),
+    )?;
+
+    let output_receiver = OutputReceiver::start(output_port, CommunicationProtocol::Tcp)?;
+
+    instance.send_request(
+        "output/output_1/unregister",
+        json!({
+            "schedule_time_ms": 15000,
+        }),
+    )?;
+
+    instance.send_request(
+        "input/input_1/register",
+        json!({
+            "type": "rtp_stream",
+            "transport_protocol": "tcp_server",
+            "port": input_1_port,
+            "audio": {
+                "decoder": "opus"
+            },
+        }),
+    )?;
+
+    let audio_input_1 = input_dump_from_disk("variable_frequency_opus_audio.rtp")?;
+    let audio_sender = PacketSender::new(CommunicationProtocol::Tcp, input_1_port)?;
+
+    let audio_handle = audio_sender.send_non_blocking(audio_input_1);
+    thread::sleep(Duration::from_secs(2));
+    instance.send_request("start", json!({}))?;
+
+    audio_handle.join().unwrap();
+
+    let new_output_dump = output_receiver.wait_for_output()?;
+
+    compare_audio_dumps(
+        OUTPUT_DUMP_FILE,
+        &new_output_dump,
+        audio::ValidationMode::Artificial,
+        AudioValidationConfig::default(),
+    )?;
+
+    Ok(())
+}

--- a/integration-tests/src/pipeline_tests/audio_only.rs
+++ b/integration-tests/src/pipeline_tests/audio_only.rs
@@ -542,7 +542,7 @@ pub fn single_input_aac_mp4() -> Result<()> {
 }
 
 /// Single frequency input that changes after 5 seconds. Input starts streaming 2 seconds before
-/// start request with offset set to 2 seconds. 
+/// start request with offset set to 2 seconds.
 ///
 /// Play  2 seconds of silence, 5 seconds of lower frequency and higher frequency after that time.
 #[test]
@@ -551,6 +551,8 @@ fn audio_offset_variable_frequency() -> Result<()> {
     let instance = CompositorInstance::start(None);
     let input_1_port = instance.get_port();
     let output_port = instance.get_port();
+
+    let audio_input_1 = input_dump_from_disk("variable_frequency_opus_audio.rtp")?;
 
     instance.send_request(
         "output/output_1/register",
@@ -597,7 +599,6 @@ fn audio_offset_variable_frequency() -> Result<()> {
         }),
     )?;
 
-    let audio_input_1 = input_dump_from_disk("variable_frequency_opus_audio.rtp")?;
     let audio_sender = PacketSender::new(CommunicationProtocol::Tcp, input_1_port)?;
 
     let audio_handle = audio_sender.send_non_blocking(audio_input_1);
@@ -619,7 +620,7 @@ fn audio_offset_variable_frequency() -> Result<()> {
 }
 
 /// Use input that changes frequency after 5 seconds. Input starts streaming 2 seconds before
-/// start request with no offset. 
+/// start request with no offset.
 ///
 /// Play approx. 3 seconds of lower frequency and higher frequency after that.
 #[test]
@@ -628,6 +629,8 @@ fn audio_no_offset_variable_frequency() -> Result<()> {
     let instance = CompositorInstance::start(None);
     let input_1_port = instance.get_port();
     let output_port = instance.get_port();
+
+    let audio_input_1 = input_dump_from_disk("variable_frequency_opus_audio.rtp")?;
 
     instance.send_request(
         "output/output_1/register",
@@ -673,7 +676,6 @@ fn audio_no_offset_variable_frequency() -> Result<()> {
         }),
     )?;
 
-    let audio_input_1 = input_dump_from_disk("variable_frequency_opus_audio.rtp")?;
     let audio_sender = PacketSender::new(CommunicationProtocol::Tcp, input_1_port)?;
 
     let audio_handle = audio_sender.send_non_blocking(audio_input_1);


### PR DESCRIPTION
Closes #1243 

- [ ] Snapshots membraneframework-labs/video_compositor_snapshot_tests#65

- [x] Add new snapshot that changes frequency after some time to correctly test audio offsets.