### PR TITLE
[libcef] Fix crash caused by `mallinfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2504,9 +2504,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libcef"
@@ -2529,6 +2529,7 @@ dependencies = [
  "cmake",
  "dirs",
  "fs_extra",
+ "libc",
  "reqwest",
 ]
 

--- a/libcef/libcef-sys/Cargo.toml
+++ b/libcef/libcef-sys/Cargo.toml
@@ -8,6 +8,9 @@ license-file = "../../LICENSE"
 
 [dependencies]
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2.177"
+
 [build-dependencies]
 anyhow = { workspace = true }
 bindgen = "0.72.1"

--- a/libcef/libcef-sys/src/lib.rs
+++ b/libcef/libcef-sys/src/lib.rs
@@ -7,3 +7,5 @@
 
 pub mod bindings;
 pub use bindings::*;
+
+mod mallinfo;

--- a/libcef/libcef-sys/src/mallinfo.rs
+++ b/libcef/libcef-sys/src/mallinfo.rs
@@ -1,0 +1,65 @@
+/// Overrides glibc implementation of `mallinfo`.
+/// `mallinfo` stores information about memory allocations as `i32`
+/// which can result in negative numbers if we allocate enough memory.
+/// Chromium uses this internally and will crash if negative numbers are reported.
+/// This wrapper clamps values to `i32::MAX`.
+#[cfg(all(target_os = "linux", any(target_env = "gnu", target_env = "")))]
+#[unsafe(no_mangle)]
+#[inline(never)]
+unsafe extern "C" fn mallinfo() -> libc::mallinfo {
+    let (libc_major, libc_minor) = {
+        use std::ffi::CStr;
+
+        let version = unsafe { CStr::from_ptr(libc::gnu_get_libc_version()) };
+        let version = version.to_string_lossy();
+        let version_parts = version.split('.').collect::<Vec<_>>();
+        match version_parts.as_slice() {
+            [major, minor] => (
+                major.parse::<u32>().unwrap_or(0),
+                minor.parse::<u32>().unwrap_or(0),
+            ),
+            _ => (0, 0),
+        }
+    };
+
+    match (libc_major == 2 && libc_minor >= 33) || (libc_major >= 3) {
+        true => {
+            let info = unsafe { libc::mallinfo2() };
+            let mut arena = info.arena.min(i32::MAX as usize);
+            let mut hblkhd = info.hblkhd.min(i32::MAX as usize);
+
+            // Chromium adds those together. We need to scale them down accordingly.
+            let arena_hblkhd = arena + hblkhd;
+            if arena_hblkhd > i32::MAX as usize {
+                let scale = i32::MAX as f64 / arena_hblkhd as f64;
+                arena = (arena as f64 * scale) as usize;
+                hblkhd = (hblkhd as f64 * scale) as usize;
+            }
+
+            libc::mallinfo {
+                arena: arena as i32,
+                hblkhd: hblkhd as i32,
+                ordblks: info.ordblks.min(i32::MAX as usize) as i32,
+                smblks: info.smblks.min(i32::MAX as usize) as i32,
+                hblks: info.hblks.min(i32::MAX as usize) as i32,
+                usmblks: info.usmblks.min(i32::MAX as usize) as i32,
+                fsmblks: info.fsmblks.min(i32::MAX as usize) as i32,
+                uordblks: info.uordblks.min(i32::MAX as usize) as i32,
+                fordblks: info.fordblks.min(i32::MAX as usize) as i32,
+                keepcost: info.keepcost.min(i32::MAX as usize) as i32,
+            }
+        }
+        false => libc::mallinfo {
+            arena: 0,
+            hblkhd: 0,
+            ordblks: 0,
+            smblks: 0,
+            hblks: 0,
+            usmblks: 0,
+            fsmblks: 0,
+            uordblks: 0,
+            fordblks: 0,
+            keepcost: 0,
+        },
+    }
+}


### PR DESCRIPTION
Fixes: #1407 