### PR TITLE
Add proper linter options to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,9 @@ name = "process_helper"
 path = "src/bin/process_helper.rs"
 required-features = ["web-renderer"]
 
-[lints.clippy]
+[workspace.lints.clippy]
 todo = "warn"
 uninlined_format_args = "warn"
+
+[lints]
+workspace = true

--- a/decklink/Cargo.toml
+++ b/decklink/Cargo.toml
@@ -12,3 +12,6 @@ cxx = "1.0"
 
 [build-dependencies]
 cxx-build = "1.0"
+
+[lints]
+workspace = true

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -48,3 +48,6 @@ inquire = "0.7.5"
 strum = { version = "0.27", features = ["derive"] }
 fuzzy-matcher = "0.3.7"
 typetag = "0.2.20"
+
+[lints]
+workspace = true

--- a/libcef/Cargo.toml
+++ b/libcef/Cargo.toml
@@ -13,3 +13,6 @@ thiserror = { workspace = true }
 widestring = "1.0.2"
 anyhow = { workspace = true }
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/libcef/libcef-sys/Cargo.toml
+++ b/libcef/libcef-sys/Cargo.toml
@@ -18,3 +18,6 @@ cmake = "0.1.50"
 dirs = "5.0.1"
 fs_extra = "1.3.0"
 reqwest = { workspace = true }
+
+[lints]
+workspace = true

--- a/smelter-api/Cargo.toml
+++ b/smelter-api/Cargo.toml
@@ -21,3 +21,5 @@ itertools = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 smelter-core = { workspace = true }
 
+[lints]
+workspace = true

--- a/smelter-core/Cargo.toml
+++ b/smelter-core/Cargo.toml
@@ -45,3 +45,6 @@ pollster = { workspace = true }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 decklink = { path = "../decklink", optional = true }
+
+[lints]
+workspace = true

--- a/smelter-render-wasm/Cargo.toml
+++ b/smelter-render-wasm/Cargo.toml
@@ -43,3 +43,6 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true
+
+[lints]
+workspace = true

--- a/smelter-render/Cargo.toml
+++ b/smelter-render/Cargo.toml
@@ -26,3 +26,6 @@ rand = { workspace = true }
 tracing = { workspace = true }
 shared_memory = { workspace = true, optional = true }
 sys-locale = "0.3.1"
+
+[lints]
+workspace = true

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -32,3 +32,6 @@ tokio = { workspace = true }
 regex = { workspace = true }
 tar = "0.4.44"
 flate2 = "1.1.4"
+
+[lints]
+workspace = true

--- a/vk-video/Cargo.toml
+++ b/vk-video/Cargo.toml
@@ -36,3 +36,6 @@ winit = "0.29"
 
 [build-dependencies]
 cfg_aliases = "0.2.1"
+
+[lints]
+workspace = true


### PR DESCRIPTION
Last time I did it wrong, noticed it today. Now it is done the proper way. The same additional options that are added in CI are now present and working in all crates in the workspace just by using `cargo clippy --all-targets --workspace`