### PR TITLE
[vk-video] Command buffer pools

### DIFF
--- a/vk-video/src/device/queues.rs
+++ b/vk-video/src/device/queues.rs
@@ -24,14 +24,14 @@ impl Queue {
 
     pub(crate) fn submit_chain_semaphore<S>(
         &self,
-        buffer: &CommandBuffer,
-        tracker: &mut Tracker<S>,
+        buffer: RecordedCommandBuffer,
+        tracker: &mut SemaphoreTracker<S>,
         wait_stages: vk::PipelineStageFlags2,
         signal_stages: vk::PipelineStageFlags2,
         new_wait_state: S,
     ) -> Result<(), VulkanCommonError> {
         let buffer_submit_info =
-            [vk::CommandBufferSubmitInfo::default().command_buffer(buffer.buffer)];
+            [vk::CommandBufferSubmitInfo::default().command_buffer(buffer.buffer())];
 
         let signal_value = tracker.next_sem_value();
         let signal_info = vk::SemaphoreSubmitInfo::default()
@@ -64,6 +64,8 @@ impl Queue {
                 vk::Fence::null(),
             )?
         };
+
+        buffer.mark_submitted();
 
         tracker.wait_for = Some(TrackerWait {
             value: signal_value,

--- a/vk-video/src/vulkan_decoder/session_resources/images.rs
+++ b/vk-video/src/vulkan_decoder/session_resources/images.rs
@@ -6,7 +6,7 @@ use crate::{
     VulkanDecoderError,
     device::DecodingDevice,
     vulkan_decoder::Image,
-    wrappers::{CodingImageBundle, CommandBuffer, DecodedPicturesBuffer, H264DecodeProfileInfo},
+    wrappers::{CodingImageBundle, DecodedPicturesBuffer, H264DecodeProfileInfo},
 };
 
 pub(crate) struct DecodingImages<'a> {
@@ -43,7 +43,7 @@ impl<'a> DecodingImages<'a> {
 
     pub(crate) fn new(
         decoding_device: &DecodingDevice,
-        command_buffer: &CommandBuffer,
+        command_buffer: vk::CommandBuffer,
         profile: &H264DecodeProfileInfo,
         dpb_format: &vk::VideoFormatPropertiesKHR<'a>,
         dst_format: &Option<vk::VideoFormatPropertiesKHR<'a>>,

--- a/vk-video/src/wrappers/video.rs
+++ b/vk-video/src/wrappers/video.rs
@@ -4,7 +4,7 @@ use ash::vk;
 
 use crate::{VulkanCommonError, VulkanDevice, device::queues::Queue};
 
-use super::{CommandBuffer, Device, Image, ImageView, MemoryAllocation, VideoQueueExt};
+use super::{Device, Image, ImageView, MemoryAllocation, VideoQueueExt};
 
 pub(crate) struct VideoSessionParameters {
     pub(crate) parameters: vk::VideoSessionParametersKHR,
@@ -306,7 +306,7 @@ impl<'a> CodingImageBundle<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         vulkan_ctx: &VulkanDevice,
-        command_buffer: &CommandBuffer,
+        command_buffer: vk::CommandBuffer,
         format: &vk::VideoFormatPropertiesKHR<'a>,
         dimensions: vk::Extent2D,
         image_usage: vk::ImageUsageFlags,
@@ -396,7 +396,7 @@ impl<'a> CodingImageBundle<'a> {
 
             for image in &images {
                 image.lock().unwrap().transition_layout(
-                    **command_buffer,
+                    command_buffer,
                     stages.clone(),
                     accesses.clone(),
                     layout,
@@ -433,7 +433,7 @@ impl<'a> CodingImageBundle<'a> {
             )?;
 
             image.lock().unwrap().transition_layout(
-                **command_buffer,
+                command_buffer,
                 stages.clone(),
                 accesses.clone(),
                 layout,
@@ -474,7 +474,7 @@ impl<'a> DecodedPicturesBuffer<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         vulkan_ctx: &VulkanDevice,
-        command_buffer: &CommandBuffer,
+        command_buffer: vk::CommandBuffer,
         use_separate_images: bool,
         profile_info: &vk::VideoProfileInfoKHR,
         image_usage: vk::ImageUsageFlags,


### PR DESCRIPTION
Introduce command buffer pooling. We no longer have a single buffer (per [de|en]coder) for each submit. Buffers are allocated when necessary, and, more importantly, get cleaned up properly when an operation returns an error before submitting a buffer.