### PR TITLE
[vk-video] Implement safe image transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5780,6 +5780,7 @@ dependencies = [
  "derivative",
  "h264-reader",
  "memchr",
+ "rustc-hash 2.1.1",
  "thiserror 1.0.69",
  "tracing",
  "tracing-subscriber",

--- a/vk-video/Cargo.toml
+++ b/vk-video/Cargo.toml
@@ -22,6 +22,7 @@ bytes = "1"
 derivative = "2.2.0"
 h264-reader = { workspace = true }
 memchr = "2.7.4"
+rustc-hash = "2.1.1"
 thiserror = "1.0.59"
 tracing = "0.1.40"
 vk-mem = "0.4.0"

--- a/vk-video/src/lib.rs
+++ b/vk-video/src/lib.rs
@@ -98,6 +98,7 @@ pub use vulkan_decoder::VulkanDecoderError;
 pub use vulkan_encoder::{RateControl, VulkanEncoderError};
 
 use crate::vulkan_encoder::VulkanEncoder;
+use crate::wrappers::ImageKey;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DecoderError {
@@ -157,6 +158,15 @@ pub enum VulkanCommonError {
 
     #[error("Tried to create a semaphore submit that waits for an unsignaled value")]
     SemaphoreSubmitWaitOnUnsignaledValue,
+
+    #[error("Tried to register {0:x?} as a new image, while it already exists")]
+    RegisteredNewImageTwice(ImageKey),
+
+    #[error("Tried to access state of image {0:x?}, which does not exist")]
+    TriedToAccessNonexistentImageState(ImageKey),
+
+    #[error("Tried to unregister image {0:x?} that was not registered")]
+    UnregisteredNonexistentImage(ImageKey),
 }
 
 /// A profile in H264 is a set of codec features used while encoding a specific video.

--- a/vk-video/src/vulkan_decoder/session_resources.rs
+++ b/vk-video/src/vulkan_decoder/session_resources.rs
@@ -276,12 +276,13 @@ impl VideoSessionResources<'_> {
         profile: &H264DecodeProfileInfo,
         max_coded_extent: vk::Extent2D,
         max_dpb_slots: u32,
-        decode_buffer: OpenCommandBuffer,
+        mut decode_buffer: OpenCommandBuffer,
         tracker: &mut DecoderTracker,
     ) -> Result<DecodingImages<'a>, VulkanDecoderError> {
         let decoding_images = DecodingImages::new(
             decoding_device,
-            decode_buffer.buffer(),
+            &mut decode_buffer,
+            tracker.image_layout_tracker.clone(),
             profile,
             &decoding_device
                 .profile_capabilities
@@ -295,7 +296,7 @@ impl VideoSessionResources<'_> {
 
         decoding_device.h264_decode_queue.submit_chain_semaphore(
             decode_buffer.end()?,
-            &mut tracker.semaphore_tracker,
+            tracker,
             vk::PipelineStageFlags2::ALL_COMMANDS,
             vk::PipelineStageFlags2::ALL_COMMANDS,
             DecoderTrackerWaitState::NewDecodingImagesLayoutTransition,


### PR DESCRIPTION
This patch is meant to make it impossible to get into a situation like this:

1. early exit on error out of decoding/encding
2. some internal image was supposed to go through layout transitions A -> B -> A, but only A -> B was submitted
3. when [de|en]coding the next frame, the code expects the image to be in layout A, while it is in layout B and the program crashes

This is achieved in the following way:

- the `Tracker` now holds a global `Image -> Layout` map
- each command buffer holds it's local changes to image layouts
- on submits, these local changes get merged into the global tracker
- images no longer hold the layout they think they have. This allows us to replace `Arc<Mutex<Image>>` with just Arc<Image> everywhere
- no user-callable function depends on an `Image` being in any particular `Layout` now, all functions ask for the layout they want at the beginning
- no functions 'restore' the previous layout a picture had

(I hope I didn't omit anything and the last two points are true)

Closes #1438 