### PR TITLE
Fixed broken `pixel_format` option for `FFmpeg` `h264` and `vp9` encoders.

### DIFF
--- a/smelter-core/src/pipeline/encoder/ffmpeg_h264.rs
+++ b/smelter-core/src/pipeline/encoder/ffmpeg_h264.rs
@@ -6,7 +6,7 @@ use smelter_render::{Frame, OutputFrameFormat};
 use tracing::{error, info, trace, warn};
 
 use crate::pipeline::encoder::ffmpeg_utils::{
-    create_av_frame, encoded_chunk_from_av_packet, read_extradata,
+    create_av_frame, encoded_chunk_from_av_packet, into_ffmpeg_pixel_format, read_extradata,
 };
 use crate::pipeline::ffmpeg_utils::FfmpegOptions;
 use crate::prelude::*;
@@ -38,7 +38,7 @@ impl VideoEncoder for FfmpegH264Encoder {
         let pts_unit_secs = Rational::new(1, TIME_BASE);
         let framerate = ctx.output_framerate;
         encoder.set_time_base(pts_unit_secs);
-        encoder.set_format(options.pixel_format.into());
+        encoder.set_format(into_ffmpeg_pixel_format(options.pixel_format));
         encoder.set_width(options.resolution.width as u32);
         encoder.set_height(options.resolution.height as u32);
         encoder.set_frame_rate(Some((framerate.num as i32, framerate.den as i32)));

--- a/smelter-core/src/pipeline/encoder/ffmpeg_utils.rs
+++ b/smelter-core/src/pipeline/encoder/ffmpeg_utils.rs
@@ -122,7 +122,9 @@ pub(super) fn encoded_chunk_from_av_packet(
     })
 }
 
-pub(super) fn ffmpeg_pix_fmt(pixel_format: OutputPixelFormat) -> ffmpeg_next::format::Pixel {
+pub(super) fn into_ffmpeg_pixel_format(
+    pixel_format: OutputPixelFormat,
+) -> ffmpeg_next::format::Pixel {
     match pixel_format {
         OutputPixelFormat::YUV420P => ffmpeg_next::format::Pixel::YUV420P,
         OutputPixelFormat::YUV422P => ffmpeg_next::format::Pixel::YUV422P,

--- a/smelter-core/src/pipeline/encoder/ffmpeg_vp9.rs
+++ b/smelter-core/src/pipeline/encoder/ffmpeg_vp9.rs
@@ -9,7 +9,9 @@ use tracing::{error, info, trace, warn};
 
 use crate::pipeline::{
     PipelineCtx,
-    encoder::ffmpeg_utils::{create_av_frame, encoded_chunk_from_av_packet},
+    encoder::ffmpeg_utils::{
+        create_av_frame, encoded_chunk_from_av_packet, into_ffmpeg_pixel_format,
+    },
     ffmpeg_utils::FfmpegOptions,
 };
 use crate::prelude::*;
@@ -40,7 +42,7 @@ impl VideoEncoder for FfmpegVp9Encoder {
         let pts_unit_secs = Rational::new(1, TIME_BASE);
         let framerate = ctx.output_framerate;
         encoder.set_time_base(pts_unit_secs);
-        encoder.set_format(options.pixel_format.into());
+        encoder.set_format(into_ffmpeg_pixel_format(options.pixel_format));
         encoder.set_width(options.resolution.width as u32);
         encoder.set_height(options.resolution.height as u32);
         encoder.set_frame_rate(Some((framerate.num as i32, framerate.den as i32)));


### PR DESCRIPTION
`pixel_format` option was set only for renderer, but not for encoder which resulted in bad colours in the output.

---
- [ ] ~Handle case when encoder doesn't support specified `pixel_format`~