### PR TITLE
[ci] Updated deprecated `macos-13` builder.

### DIFF
--- a/.github/workflows/package_for_release.yml
+++ b/.github/workflows/package_for_release.yml
@@ -65,7 +65,7 @@ jobs:
                 path: tools/build/smelter_linux_aarch64.tar.gz
 
     binaries-macos-x86_64:
-        runs-on: macos-13
+        runs-on: macos-15-intel
         steps:
             - name: 🛠 Install system dependencies
               run: brew install ffmpeg
@@ -93,7 +93,7 @@ jobs:
                 path: tools/build/smelter_with_web_renderer_darwin_x86_64.tar.gz
 
     binaries-macos-aarch64:
-        runs-on: macos-14
+        runs-on: macos-15
         steps:
             - name: 🛠 Install system dependencies
               run: brew install ffmpeg

--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -29,7 +29,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.91.0
+                  toolchain: 1.91
 
             - name: 🔬 Install nextest
               uses: taiki-e/install-action@v2
@@ -77,7 +77,7 @@ jobs:
               run: cargo test --workspace --doc
 
     build_macos:
-        runs-on: macos-14
+        runs-on: macos-15
         steps:
             - name: 🛠 Install system dependencies
               run: brew install ffmpeg
@@ -85,7 +85,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.91.0
+                  toolchain: 1.91
                   components: rustfmt, clippy
 
             - name: 📥 Checkout repo
@@ -121,7 +121,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.91.0
+                  toolchain: 1.91
                   components: rustfmt, clippy
 
             - name: Install pnpm


### PR DESCRIPTION
When using `macos-13` machine, workflow throws a warning saying that `macos-15-intel` should be used.
Additionaly:
- Bumped `macos-14` to `macos-15`.
- Rust version is now `minor` and not `patch` specific.