### PR TITLE
[integration-tests] Left padded timestamps in  `render_tests` files

### DIFF
--- a/integration-tests/src/render_tests.rs
+++ b/integration-tests/src/render_tests.rs
@@ -48,8 +48,7 @@ impl TestRunner {
         self.cases.push(case)
     }
 
-    fn run(mut self) {
-        calculate_timestamps_lengths(&mut self.cases);
+    fn run(self) {
         check_test_names_uniqueness(&self.cases);
         check_unused_snapshots(&self.cases, &self.snapshot_dir);
         let has_only = self.cases.iter().any(|test| test.only);
@@ -100,11 +99,11 @@ fn check_test_names_uniqueness(tests: &[TestCase]) {
     }
 }
 
-fn snapshot_save_path(test_name: &str, pts: &Duration, longest_pts_length: usize) -> PathBuf {
-    let mut pts = pts.as_millis().to_string();
-    let left_padding = longest_pts_length - pts.len();
-    pts.insert_str(0, "0".repeat(left_padding).as_str());
-    let out_file_name = format!("{test_name}_{pts}_{OUTPUT_ID}.png");
+fn snapshot_save_path(test_name: &str, pts: &Duration) -> PathBuf {
+    let pts = pts.as_millis();
+
+    // Pad timestamp with 0s on the left to the summaric length of 5.
+    let out_file_name = format!("{test_name}_{pts:05}_{OUTPUT_ID}.png");
     render_snapshots_dir_path().join(out_file_name)
 }
 
@@ -134,11 +133,5 @@ fn check_unused_snapshots(tests: &[TestCase], snapshot_dir: &Path) {
         } else {
             panic!("Some snapshots were not used: {unused_snapshots:#?}")
         }
-    }
-}
-
-fn calculate_timestamps_lengths(tests: &mut [TestCase]) {
-    for test in tests.iter_mut() {
-        test.calculate_and_set_timestamp_length();
     }
 }

--- a/integration-tests/src/render_tests/snapshot.rs
+++ b/integration-tests/src/render_tests/snapshot.rs
@@ -16,12 +16,11 @@ pub(super) struct Snapshot {
     pub pts: Duration,
     pub resolution: Resolution,
     pub data: Vec<u8>,
-    pub timestamp_length: usize,
 }
 
 impl Snapshot {
     pub(super) fn save_path(&self) -> PathBuf {
-        snapshot_save_path(&self.test_name, &self.pts, self.timestamp_length)
+        snapshot_save_path(&self.test_name, &self.pts)
     }
 
     pub(super) fn diff_with_saved(&self) -> f32 {

--- a/integration-tests/src/render_tests/test_case.rs
+++ b/integration-tests/src/render_tests/test_case.rs
@@ -35,7 +35,6 @@ pub(super) struct TestCase {
     pub allowed_error: f32,
     pub resolution: Resolution,
     pub output_format: OutputFrameFormat,
-    pub timestamp_length: usize,
 }
 
 impl Default for TestCase {
@@ -52,7 +51,6 @@ impl Default for TestCase {
                 height: 360,
             },
             output_format: OutputFrameFormat::PlanarYuv420Bytes,
-            timestamp_length: 0,
         }
     }
 }
@@ -160,9 +158,7 @@ impl TestCase {
         self.steps
             .iter()
             .flat_map(|step| match step {
-                Step::RenderWithSnapshot(pts) => {
-                    Some(snapshot_save_path(self.name, pts, self.timestamp_length))
-                }
+                Step::RenderWithSnapshot(pts) => Some(snapshot_save_path(self.name, pts)),
                 _ => None,
             })
             .collect()
@@ -176,7 +172,6 @@ impl TestCase {
             pts,
             resolution: output_frame.resolution,
             data: new_snapshot,
-            timestamp_length: self.timestamp_length,
         })
     }
 
@@ -198,19 +193,5 @@ impl TestCase {
             .remove(&OutputId(OUTPUT_ID.into()))
             .expect("No scene update provided before render");
         Ok(output_frame)
-    }
-
-    pub fn calculate_and_set_timestamp_length(&mut self) {
-        let longest_timestamp_length = self
-            .steps
-            .iter()
-            .filter_map(|step| match step {
-                Step::RenderWithSnapshot(pts) => Some(pts.as_millis().to_string().len()),
-                _ => None,
-            })
-            .max();
-        if let Some(timestamp_length) = longest_timestamp_length {
-            self.timestamp_length = timestamp_length;
-        }
     }
 }


### PR DESCRIPTION
Timestamps in filenames are left padded so files are correctly ordered.

---

- Snapshots smelter-labs/smelter-snapshot-tests#70