### PR TITLE
Detect missing frames in `ffmpeg_h264`

### DIFF
--- a/smelter-core/src/pipeline/decoder.rs
+++ b/smelter-core/src/pipeline/decoder.rs
@@ -18,6 +18,7 @@ pub(super) use dynamic_stream::{
 };
 pub(super) use static_stream::{AudioDecoderStream, VideoDecoderStream};
 
+mod au_splitter;
 mod ffmpeg_utils;
 
 pub mod ffmpeg_h264;

--- a/smelter-core/src/pipeline/decoder/au_splitter.rs
+++ b/smelter-core/src/pipeline/decoder/au_splitter.rs
@@ -1,0 +1,119 @@
+use std::time::Duration;
+
+use bytes::BytesMut;
+use tracing::debug;
+use vk_video::parser::h264::{AccessUnit, H264Parser, ParsedNalu, nal_types::slice::SliceFamily};
+
+use crate::prelude::*;
+
+#[derive(Default)]
+pub struct AUSplitter {
+    parser: H264Parser,
+    prev_ref_frame_num: u16,
+    detected_missed_frames: bool,
+}
+
+impl AUSplitter {
+    pub fn put_chunk(
+        &mut self,
+        chunk: EncodedInputChunk,
+    ) -> Result<Vec<EncodedInputChunk>, AUSplitterError> {
+        if MediaKind::Video(VideoCodec::H264) != chunk.kind {
+            return Err(AUSplitterError::UnsupportedMediaKind(chunk.kind));
+        }
+
+        let access_units = self
+            .parser
+            .parse(&chunk.data, Some(chunk.pts.as_micros() as u64))?;
+
+        let mut chunks = Vec::new();
+        for au in access_units {
+            self.verify_access_unit(&au)?;
+
+            let mut data = BytesMut::new();
+            let pts = match au.0.first().and_then(|nalu| nalu.pts) {
+                Some(pts) => pts,
+                None => {
+                    debug!("Expected access unit with pts. Skipping the access unit");
+                    continue;
+                }
+            };
+
+            // Parser returns nalus which may not start with a start code
+            // but each nalu always ends with the start code of the next nalu,
+            // so we have to make sure that there is a start code in the beginning
+            const START_CODES: [&[u8]; 2] = [&[0, 0, 0, 1], &[0, 0, 1]];
+            if let Some(first_nalu) = au.0.first() {
+                let has_start_code = START_CODES
+                    .iter()
+                    .any(|code| first_nalu.raw_bytes.starts_with(code));
+                if !has_start_code {
+                    data.extend_from_slice(&[0, 0, 1]);
+                }
+            }
+
+            for nalu in au.0.iter() {
+                data.extend_from_slice(&nalu.raw_bytes);
+            }
+
+            chunks.push(EncodedInputChunk {
+                data: data.freeze(),
+                pts: Duration::from_micros(pts),
+                dts: None,
+                kind: MediaKind::Video(VideoCodec::H264),
+            });
+        }
+
+        Ok(chunks)
+    }
+
+    fn verify_access_unit(&mut self, au: &AccessUnit) -> Result<(), AUSplitterError> {
+        let Some(ParsedNalu::Slice(slice)) =
+            au.0.iter()
+                .map(|nalu| &nalu.parsed)
+                .find(|nalu| matches!(nalu, ParsedNalu::Slice(_)))
+        else {
+            return Err(AUSplitterError::InvalidAccessUnit);
+        };
+
+        match slice.header.slice_type.family {
+            SliceFamily::P | SliceFamily::B => {
+                let sps = &slice.sps;
+                let frame_num = slice.header.frame_num;
+                let max_frame_num = 1i64 << sps.log2_max_frame_num();
+
+                let is_expected_frame_num = !sps.gaps_in_frame_num_value_allowed_flag
+                    && frame_num != self.prev_ref_frame_num
+                    && frame_num != ((self.prev_ref_frame_num as i64 + 1) % max_frame_num) as u16;
+                if is_expected_frame_num || self.detected_missed_frames {
+                    debug!("AUSplitter detected missing frame");
+                    self.detected_missed_frames = true;
+                    return Err(AUSplitterError::MissingReferenceFrame);
+                }
+
+                self.prev_ref_frame_num = frame_num;
+            }
+            SliceFamily::I => {
+                self.prev_ref_frame_num = 0;
+                self.detected_missed_frames = false;
+            }
+            SliceFamily::SP | SliceFamily::SI => {} // Not supported
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AUSplitterError {
+    #[error("Missing reference frame")]
+    MissingReferenceFrame,
+
+    #[error("Could not parse H264 chunk: {0}")]
+    ParserError(#[from] vk_video::parser::h264::H264ParserError),
+
+    #[error("Invalid access unit")]
+    InvalidAccessUnit,
+
+    #[error("Unsupported media kind {0:?}")]
+    UnsupportedMediaKind(MediaKind),
+}

--- a/smelter-core/src/pipeline/rtp/depayloader.rs
+++ b/smelter-core/src/pipeline/rtp/depayloader.rs
@@ -39,7 +39,7 @@ pub fn new_depayloader(options: DepayloaderOptions) -> Box<dyn Depayloader> {
     info!(?options, "Initialize RTP depayloader");
     match options {
         DepayloaderOptions::H264 => {
-            BufferedDepayloader::<H264Packet>::new_boxed(MediaKind::Video(VideoCodec::H264))
+            SimpleDepayloader::<H264Packet>::new_boxed(MediaKind::Video(VideoCodec::H264))
         }
         DepayloaderOptions::Vp8 => {
             BufferedDepayloader::<Vp8Packet>::new_boxed(MediaKind::Video(VideoCodec::Vp8))
@@ -134,6 +134,10 @@ impl<T: Depacketizer + Default + 'static> Depayloader for SimpleDepayloader<T> {
     ) -> Result<Vec<EncodedInputChunk>, DepayloadingError> {
         trace!(?packet, "RTP depayloader received new packet");
         let data = self.depayloader.depacketize(&packet.packet.payload)?;
+        if data.is_empty() {
+            return Ok(vec![]);
+        }
+
         let chunk = EncodedInputChunk {
             data,
             pts: packet.timestamp,


### PR DESCRIPTION
Depends on: 
- https://github.com/software-mansion/smelter/pull/1534
- https://github.com/software-mansion/smelter/pull/1535

In this PR I added access unit splitter for `ffmpeg_h264` decoder.

The access units are checked for missing frames. It only checks the frame nums of nalus and will not work if multiple nalus have the same frame num.

The buffering in the depayloader was disabled because its access unit detection will not work if marker packet is lost