### PR TITLE
[integration-tests] Increased tolerance for flaky test.

### DIFF
--- a/integration-tests/src/pipeline_tests/required_inputs.rs
+++ b/integration-tests/src/pipeline_tests/required_inputs.rs
@@ -643,7 +643,7 @@ pub fn optional_inputs_no_offset_flaky() -> Result<()> {
         &new_output_dump,
         VideoValidationConfig {
             validation_intervals: vec![Duration::ZERO..Duration::from_secs(18)],
-            allowed_invalid_frames: 10,
+            allowed_invalid_frames: 15,
             ..Default::default()
         },
     )?;


### PR DESCRIPTION
One flaky test is sometimes failing going 1 frame over allowed error margin. Margin was increased.

- Followup to #1537 