### PR TITLE
Fix H264 AU spliter (set correct frame_num on keyframe)

### DIFF
--- a/smelter-core/src/pipeline/utils/h264_au_splitter.rs
+++ b/smelter-core/src/pipeline/utils/h264_au_splitter.rs
@@ -113,7 +113,7 @@ impl H264AuSplitter {
                 self.prev_ref_frame_num = frame_num;
             }
             SliceFamily::I => {
-                self.prev_ref_frame_num = 0;
+                self.prev_ref_frame_num = slice.header.frame_num;
                 self.detected_missed_frames = false;
             }
             SliceFamily::SP | SliceFamily::SI => {} // Not supported


### PR DESCRIPTION
From what I observe, key frames sometimes reset `frame_num` to zero, but it is not always the case.