### PR TITLE
[ts-sdk] Fix README for NPM packages

### DIFF
--- a/ts/create-smelter-app/README.md
+++ b/ts/create-smelter-app/README.md
@@ -5,3 +5,9 @@ To start new project using Smelter run:
 ```
 npx create-smelter-app
 ```
+
+## Smelter is created by Software Mansion
+
+[![swm](https://logo.swmansion.com/logo?color=white&variant=desktop&width=150&tag=smelter-github 'Software Mansion')](https://swmansion.com)
+
+Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps as well as complex multimedia solutions. We are Core React Native Contributors and experts in live streaming and broadcasting technologies. We can help you build your next dream product – [Hire us](https://swmansion.com/contact/projects?utm_source=smelter&utm_medium=readme).

--- a/ts/smelter-node/README.md
+++ b/ts/smelter-node/README.md
@@ -24,11 +24,9 @@ async function run() {
 
   // register input/outputs/images/shaders/...
 
-  await smelter.registerOutput('example_output', <ExampleApp />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+  await smelter.registerOutput('example_output', <SmelterApp />, {
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:8000/'
     video: {
       encoder: { type: 'ffmpeg_h264', preset: 'ultrafast' },
       resolution: { width: 1920, height: 1080 },
@@ -42,6 +40,9 @@ async function run() {
 }
 run();
 ```
+
+Before running above code start listening on port 8000 for incoming RTMP stream
+e.g. `ffmpeg -f flv -listen 1 -i rtmp://0.0.0.0:8000 -vcodec copy  -f flv - | ffplay -f flv -i -`.
 
 See our [docs](https://smelter.dev/docs) to learn more.
 

--- a/ts/smelter-web-client/README.md
+++ b/ts/smelter-web-client/README.md
@@ -1,6 +1,6 @@
 # `@swmansion/smelter-web-client`
 
-Provides API to connect to Smelter instance from a web browser.
+Provides API to manage a Smelter instance from a web browser.
 
 When you call `registerOutput` on the Smelter instance, you can pass a `ReactElement` that represents a component tree built from components included in `@swmansion/smelter` package. Those components will define what will be rendered on the output stream.
 
@@ -28,20 +28,14 @@ function BrowserApp() {
 }
 
 async function startSmelter() {
-  const smelter = new Smelter({
-    ip: '192.168.1.30',
-    port: 8080,
-    protocol: 'http',
-  });
+  const smelter = new Smelter({ url: "http://127.0.0.1:8081" });
   await smelter.init();
 
   // register input/outputs/images/shaders/...
 
   await smelter.registerOutput('example_output', <SmelterApp />, {
-    type: 'rtp_stream',
-    port: 8001,
-    ip: '127.0.0.1',
-    transportProtocol: 'udp',
+    type: 'rtmp_client',
+    url: 'rtmp://127.0.0.1:8000/'
     video: {
       encoder: { type: 'ffmpeg_h264', preset: 'ultrafast' },
       resolution: { width: 1920, height: 1080 },
@@ -55,9 +49,13 @@ async function startSmelter() {
 }
 ```
 
+Before running above code:
+- Start smelter server on port 8081.
+- Listen on port 8000 for incoming RTMP stream e.g. `ffmpeg -f flv -listen 1 -i rtmp://0.0.0.0:8000 -vcodec copy  -f flv - | ffplay -f flv -i -`,
+
 ## License
 
-`@swmansion/smelter-web-client` is MIT licensed, but internally it is using Smelter server that is licensed under a [custom license](https://github.com/software-mansion/smelter/blob/master/LICENSE).
+`@swmansion/smelter-web-client` is MIT licensed, but it is managing Smelter server that is licensed under a [custom license](https://github.com/software-mansion/smelter/blob/master/LICENSE).
 
 ## Smelter is created by Software Mansion
 

--- a/ts/smelter/README.md
+++ b/ts/smelter/README.md
@@ -9,7 +9,7 @@ Smelter components should not be mixed with other React or React Native componen
 To try smelter, generate a new project by running:
 
 ```
-npm create smelter-app
+npx create-smelter-app
 ```
 
 ## Usage
@@ -29,7 +29,12 @@ function ExampleApp() {
 }
 ```
 
-Check out [@swmansion/smelter-node](https://www.npmjs.com/package/@swmansion/smelter-node) to learn how to use those components for video composition.
+Check out:
+- [@swmansion/smelter-node](https://www.npmjs.com/package/@swmansion/smelter-node)
+- [@swmansion/smelter-web-client](https://www.npmjs.com/package/@swmansion/smelter-web-client)
+- [@swmansion/smelter-web-wasm](https://www.npmjs.com/package/@swmansion/smelter-web-wasm)
+
+to learn how to use it in different environments.
 
 See our [docs](https://smelter.dev/docs) to learn more.
 


### PR DESCRIPTION
web-client readme had incorrect example, some of the other were a bit outdated, missing some information