### PR TITLE
[ts-sdk] Fix build errors for `smelter-web-wasm`

### DIFF
--- a/ts/smelter-browser-render/src/renderer.ts
+++ b/ts/smelter-browser-render/src/renderer.ts
@@ -27,7 +27,7 @@ export type InputFrame = {
 
 export type OutputFrame = {
   resolution: Api.Resolution;
-  data: Uint8ClampedArray;
+  data: Uint8ClampedArray<ArrayBuffer>;
 };
 
 export class Renderer {
@@ -56,7 +56,15 @@ export class Renderer {
     });
     return {
       ptsMs: output.ptsMs,
-      frames: Object.fromEntries(output.frames.map(({ outputId, ...value }) => [outputId, value])),
+      frames: Object.fromEntries(
+        output.frames.map(({ outputId, resolution, data }) => [
+          outputId,
+          {
+            resolution,
+            data: data as Uint8ClampedArray<ArrayBuffer>,
+          },
+        ])
+      ),
     };
   }
 


### PR DESCRIPTION
Typescript 5.7 added generic type to `Uint8ClampedArray` with a default type, but in our case the compiler can't properly infer the generic type so it has to be specified explicitly 