### PR TITLE
[ts-sdk] Fix relative URL

### DIFF
--- a/ts/smelter-node/src/fetch.ts
+++ b/ts/smelter-node/src/fetch.ts
@@ -3,6 +3,7 @@ import http from 'http';
 import https from 'https';
 import { Stream } from 'stream';
 import { promisify } from 'util';
+import path from 'path';
 
 import fetch from 'node-fetch';
 import type FormData from 'form-data';
@@ -13,7 +14,7 @@ const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 
 export async function sendRequest(baseUrl: string | URL, request: ApiRequest): Promise<object> {
-  const response = await fetch(new URL(request.route, baseUrl), {
+  const response = await fetch(joinUrl(baseUrl, request.route), {
     method: request.method,
     body: request.body && JSON.stringify(request.body),
     headers: {
@@ -24,11 +25,7 @@ export async function sendRequest(baseUrl: string | URL, request: ApiRequest): P
   if (response.status >= 400) {
     const err: any = new Error(`Request to Smelter server failed.`);
     err.response = response;
-    try {
-      err.body = await response.json();
-    } catch {
-      err.body = await response.text();
-    }
+    err.body = await readErrorBody(response);
     throw err;
   }
   return (await response.json()) as object;
@@ -38,7 +35,7 @@ export async function sendMultipartRequest(
   baseUrl: string | URL,
   request: MultipartRequest
 ): Promise<object> {
-  const response = await fetch(new URL(request.route, baseUrl), {
+  const response = await fetch(joinUrl(baseUrl, request.route), {
     method: request.method,
     body: request.body as FormData,
     agent: url => (url.protocol === 'http:' ? httpAgent : httpsAgent),
@@ -46,11 +43,7 @@ export async function sendMultipartRequest(
   if (response.status >= 400) {
     const err: any = new Error(`Request to Smelter server failed.`);
     err.response = response;
-    try {
-      err.body = await response.json();
-    } catch {
-      err.body = await response.text();
-    }
+    err.body = await readErrorBody(response);
     throw err;
   }
   return (await response.json()) as object;
@@ -67,5 +60,24 @@ export async function download(url: string, destination: string): Promise<void> 
     await pipeline(response.body, fs.createWriteStream(destination));
   } else {
     throw Error(`Response with empty body.`);
+  }
+}
+
+/*
+ * new URL(relative, base) overrides pathname part of base URL, this function
+ * appends instead
+ */
+export function joinUrl(base: URL | string, relative: string): URL {
+  const url = new URL(base);
+  url.pathname = path.join(url.pathname, relative);
+  return url;
+}
+
+async function readErrorBody(response: fetch.Response): Promise<object | string> {
+  const body = await response.text();
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
   }
 }

--- a/ts/smelter-node/src/manager/existingInstance.ts
+++ b/ts/smelter-node/src/manager/existingInstance.ts
@@ -5,7 +5,7 @@ import type {
   SetupInstanceOptions,
 } from '@swmansion/smelter-core';
 
-import { sendRequest, sendMultipartRequest } from '../fetch';
+import { sendRequest, sendMultipartRequest, joinUrl } from '../fetch';
 import { retry, sleep } from '../utils';
 import { WebSocketConnection } from '../ws';
 import { getSmelterStatus } from '../getSmelterStatus';
@@ -35,7 +35,7 @@ class ExistingInstanceManager implements SmelterManager {
 
     this.url = url;
 
-    const wsUrl = new URL('ws', url);
+    const wsUrl = joinUrl(url, 'ws');
     wsUrl.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
     this.wsConnection = new WebSocketConnection(wsUrl);
   }
@@ -69,16 +69,12 @@ class ExistingInstanceManager implements SmelterManager {
       return smelterStatus;
     }, 10);
 
-    try {
-      await this.sendRequest({
-        method: 'POST',
-        route: '/api/reset',
-        body: {},
-      });
-      opts.logger.info('Sent reset request to existing Smelter instance.');
-    } catch (err) {
-      opts.logger.warn({ err }, 'Failed to reset existing Smelter instance.');
-    }
+    await this.sendRequest({
+      method: 'POST',
+      route: '/api/reset',
+      body: {},
+    });
+    opts.logger.info('Sent reset request to the Smelter instance.');
 
     await this.wsConnection.connect(opts.logger);
   }

--- a/ts/smelter-web-client/src/fetch.ts
+++ b/ts/smelter-web-client/src/fetch.ts
@@ -1,7 +1,7 @@
 import type { ApiRequest, MultipartRequest } from '@swmansion/smelter-core';
 
 export async function sendRequest(baseUrl: URL, request: ApiRequest): Promise<object> {
-  const response = await fetch(new URL(request.route, baseUrl), {
+  const response = await fetch(joinUrl(baseUrl, request.route), {
     method: request.method,
     body: request.body && JSON.stringify(request.body),
     headers: {
@@ -11,11 +11,7 @@ export async function sendRequest(baseUrl: URL, request: ApiRequest): Promise<ob
   if (response.status >= 400) {
     const err: any = new Error(`Request to Smelter server failed.`);
     err.response = response;
-    try {
-      err.body = await response.json();
-    } catch {
-      err.body = await response.text();
-    }
+    err.body = await readErrorBody(response);
     throw err;
   }
   return (await response.json()) as object;
@@ -25,19 +21,42 @@ export async function sendMultipartRequest(
   baseUrl: URL,
   request: MultipartRequest
 ): Promise<object> {
-  const response = await fetch(new URL(request.route, baseUrl), {
+  const response = await fetch(joinUrl(baseUrl, request.route), {
     method: request.method,
     body: request.body as FormData,
   });
   if (response.status >= 400) {
     const err: any = new Error(`Request to Smelter server failed.`);
     err.response = response;
-    try {
-      err.body = await response.json();
-    } catch {
-      err.body = await response.text();
-    }
+    err.body = await readErrorBody(response);
     throw err;
   }
   return (await response.json()) as object;
+}
+
+/*
+ * new URL(relative, base) overrides pathname part of base URL, this function
+ * appends instead
+ */
+export function joinUrl(base: URL | string, relative: string): URL {
+  const url = new URL(base);
+
+  if (url.pathname.endsWith('/') != relative.startsWith('/')) {
+    url.pathname = url.pathname + relative;
+  } else if (url.pathname.endsWith('/') && relative.startsWith('/')) {
+    url.pathname = url.pathname + relative.slice(1);
+  } else {
+    url.pathname = url.pathname + '/' + relative;
+  }
+
+  return url;
+}
+
+async function readErrorBody(response: Response): Promise<object | string> {
+  const body = await response.text();
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
+  }
 }

--- a/ts/smelter-web-client/src/manager.ts
+++ b/ts/smelter-web-client/src/manager.ts
@@ -5,7 +5,7 @@ import type {
   SetupInstanceOptions,
 } from '@swmansion/smelter-core';
 
-import { sendRequest, sendMultipartRequest } from './fetch';
+import { sendRequest, sendMultipartRequest, joinUrl } from './fetch';
 import { retry, sleep } from './utils';
 import { WebSocketConnection } from './ws';
 import { getSmelterStatus } from './getSmelterStatus';
@@ -32,7 +32,7 @@ class RemoteInstanceManager implements SmelterManager {
 
     this.url = url;
 
-    const wsUrl = new URL('ws', url);
+    const wsUrl = joinUrl(url, 'ws');
     wsUrl.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
     this.wsConnection = new WebSocketConnection(wsUrl);
   }
@@ -57,16 +57,12 @@ class RemoteInstanceManager implements SmelterManager {
       return smelterStatus;
     }, 10);
 
-    try {
-      await this.sendRequest({
-        method: 'POST',
-        route: '/api/reset',
-        body: {},
-      });
-      opts.logger.info('Sent reset request to existing Smelter instance.');
-    } catch (err) {
-      opts.logger.warn({ err }, 'Failed to reset existing Smelter instance.');
-    }
+    await this.sendRequest({
+      method: 'POST',
+      route: '/api/reset',
+      body: {},
+    });
+    opts.logger.info('Sent reset request to the Smelter instance.');
 
     await this.wsConnection.connect(opts.logger);
   }


### PR DESCRIPTION
Old version worked for deploying on `/`, but if you want to hos smelter under `https://example.com/<path prefix>` and prefix all routes then `new URL`  would override that path prefix and send request to wrong url.

Tested on node version, not tested the browser version