### PR TITLE
[vk-video] Fix non-IDR frames causing decoding errors

### DIFF
--- a/vk-video/src/parser/reference_manager.rs
+++ b/vk-video/src/parser/reference_manager.rs
@@ -129,11 +129,12 @@ impl ReferenceContext {
         let pps = slices.last().unwrap().0.pps.clone();
         let pts = slices.last().unwrap().1;
 
-        let is_ref_frame = matches!(
-            header.slice_type.family,
-            h264_reader::nal::slice::SliceFamily::P | h264_reader::nal::slice::SliceFamily::B
+        let is_ref_frame = header.dec_ref_pic_marking.is_some();
+        let is_idr = matches!(
+            &header.dec_ref_pic_marking,
+            Some(DecRefPicMarking::Idr { .. })
         );
-        if is_ref_frame && self.missed_frame_handling == MissedFrameHandling::Strict {
+        if is_ref_frame && !is_idr && self.missed_frame_handling == MissedFrameHandling::Strict {
             self.verify_frame_num(&sps, &header)?;
         }
 


### PR DESCRIPTION
# Problem
Pull request #1482 introduced a bug causing some videos to not be decoded properly anymore. The symptoms are gaps of several seconds with missing frames. With the following logs:
```sh
DEBUG smelter_core::pipeline::decoder::vulkan_h264: Vulkan H264 decoder detected a missing frame.
DEBUG smelter_core::pipeline::decoder::vulkan_h264: Vulkan H264 decoder detected a missing frame.
DEBUG smelter_core::pipeline::decoder::vulkan_h264: Vulkan H264 decoder detected a missing frame.
```

The vk-video code only updated PrevRefFrameNum for P/B frames :
```rs
// Line 132
let is_ref_frame = matches!(
    header.slice_type.family,
    h264_reader::nal::slice::SliceFamily::P | h264_reader::nal::slice::SliceFamily::B
// Line 202
if is_ref_frame {
    self.PrevRefFrameNum = header.frame_num;
}
```
But non-IDR I frames should also update PrevRefFrameNum. This caused the newly added frame gap detection to trigger and drop subsequent frames.

# Fix
I referred to the H.264 spec which requires tracking all reference pictures based on nal_ref_idc != 0.
  - Changed is_ref_frame to reference status (dec_ref_pic_marking.is_some())
  - Added is_idr check to exclude IDR frames from gap detection (handled by reset_state())
  - The corrected is_ref_frame can now update non-IDR I frames 


# Testing
A reproduction project is available here:
https://github.com/one-click-studio/smelter-vulkan-2