### PR TITLE
[rtmp/flv] Added handling of more `amf0` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]

--- a/rtmp/Cargo.toml
+++ b/rtmp/Cargo.toml
@@ -6,11 +6,13 @@ edition = "2024"
 [dependencies]
 bytes = "1"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.20"
 thiserror = "1.0.40"
 url = "2.5.2"
 rand = "0.9.2"
 flv = { path = "flv" }
+
+[dev-dependencies]
+tracing-subscriber = "0.3.20"
 
 [lints]
 workspace = true

--- a/rtmp/flv/Cargo.toml
+++ b/rtmp/flv/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-thiserror = { workspace = true }
-bytes = { workspace = true }
+thiserror = "1.0.40"
+bytes = "1"
+tracing = "0.1.40"
 
 [lints]
 workspace = true

--- a/rtmp/flv/src/amf0/decoding.rs
+++ b/rtmp/flv/src/amf0/decoding.rs
@@ -1,17 +1,23 @@
 use bytes::{Buf, Bytes};
 use std::collections::HashMap;
 use thiserror::Error;
+use tracing::warn;
 
-use crate::amf0::AmfValue;
+use crate::amf0::*;
 
 #[derive(Error, Debug)]
 pub enum DecodingError {
     #[error("Unknown data type: {0}")]
     UnknownType(u8),
+
     #[error("Insufficient data")]
     InsufficientData,
+
     #[error("Invalid UTF-8 string")]
     InvalidUtf8,
+
+    #[error("Complex type reference out of bounds")]
+    OutOfBoundsReference,
 }
 
 const OBJECT_END_MARKER: [u8; 3] = [0x00, 0x00, 0x09];
@@ -19,114 +25,214 @@ const OBJECT_END_MARKER: [u8; 3] = [0x00, 0x00, 0x09];
 pub fn decode_amf_values(rtmp_msg_payload: &[u8]) -> Result<Vec<AmfValue>, DecodingError> {
     let mut buf = Bytes::copy_from_slice(rtmp_msg_payload);
     let mut result = Vec::new();
+    let mut decoder = Decoder::new();
 
     while buf.has_remaining() {
-        let (value, remaining) = decode_value(buf)?;
+        let value = decoder.decode_value(&mut buf)?;
         result.push(value);
-        buf = remaining;
     }
 
     Ok(result)
 }
 
-fn decode_value(mut buf: Bytes) -> Result<(AmfValue, Bytes), DecodingError> {
-    if !buf.has_remaining() {
-        return Err(DecodingError::InsufficientData);
-    }
-
-    let marker = buf.get_u8();
-
-    match marker {
-        // number
-        0x00 => {
-            if buf.remaining() < 8 {
-                return Err(DecodingError::InsufficientData);
-            }
-            let number = buf.get_f64();
-            Ok((AmfValue::Number(number), buf))
-        }
-        // bool
-        0x01 => {
-            if buf.remaining() < 1 {
-                return Err(DecodingError::InsufficientData);
-            }
-            let boolean = buf.get_u8() == 1;
-            Ok((AmfValue::Boolean(boolean), buf))
-        }
-        // string
-        0x02 => {
-            if buf.remaining() < 2 {
-                return Err(DecodingError::InsufficientData);
-            }
-            let size = buf.get_u16() as usize;
-            if buf.remaining() < size {
-                return Err(DecodingError::InsufficientData);
-            }
-            let string_bytes = buf.copy_to_bytes(size);
-            let string =
-                String::from_utf8(string_bytes.to_vec()).map_err(|_| DecodingError::InvalidUtf8)?;
-            Ok((AmfValue::String(string), buf))
-        }
-        // object
-        0x03 => {
-            let (pairs, remaining) = decode_object_pairs(buf)?;
-            Ok((AmfValue::Object(pairs), remaining))
-        }
-        // null
-        0x05 => Ok((AmfValue::Null, buf)),
-        // ECMA array
-        0x08 => {
-            if buf.remaining() < 4 {
-                return Err(DecodingError::InsufficientData);
-            }
-            let _array_size = buf.get_u32();
-            let (pairs, remaining) = decode_object_pairs(buf)?;
-            Ok((AmfValue::EcmaArray(pairs), remaining))
-        }
-        // strict array
-        0x0A => {
-            if buf.remaining() < 4 {
-                return Err(DecodingError::InsufficientData);
-            }
-            let size = buf.get_u32() as usize;
-            let mut array = Vec::with_capacity(size);
-            let mut current_buf = buf;
-
-            for _ in 0..size {
-                let (value, remaining) = decode_value(current_buf)?;
-                array.push(value);
-                current_buf = remaining;
-            }
-
-            Ok((AmfValue::Array(array), current_buf))
-        }
-        // TODO add switch to AMF3 (0x11)
-        _ => Err(DecodingError::UnknownType(marker)),
-    }
+#[derive(Default)]
+struct Decoder {
+    // According to spec (https://rtmp.veriskope.com/pdf/amf0-file-format-specification.pdf),
+    // complex types are Object, ECMA Array, Strict Array and Typed Objext.
+    complexes: Vec<AmfValue>,
 }
 
-fn decode_object_pairs(
-    mut buf: Bytes,
-) -> Result<(HashMap<String, AmfValue>, Bytes), DecodingError> {
-    let mut pairs = HashMap::new();
+impl Decoder {
+    fn new() -> Self {
+        Self::default()
+    }
 
-    loop {
-        if buf.remaining() < 3 {
+    fn decode_value(&mut self, buf: &mut Bytes) -> Result<AmfValue, DecodingError> {
+        if !buf.has_remaining() {
             return Err(DecodingError::InsufficientData);
         }
-        if buf[..3] == OBJECT_END_MARKER {
-            buf.advance(3);
-            return Ok((pairs, buf));
-        }
-        let key_size = buf.get_u16() as usize;
-        if buf.remaining() < key_size {
+
+        let marker = buf.get_u8();
+
+        let amf_value = match marker {
+            NUMBER => AmfValue::Number(self.decode_number(buf)?),
+            BOOLEAN => AmfValue::Boolean(self.decode_boolean(buf)?),
+            STRING => AmfValue::String(self.decode_string(buf)?),
+            OBJECT => AmfValue::Object(self.decode_object(buf)?),
+            NULL => AmfValue::Null,
+            UNDEFINED => AmfValue::Undefined,
+            REFERENCE => self.decode_reference(buf)?,
+            ECMA_ARRAY => AmfValue::EcmaArray(self.decode_ecma_array(buf)?),
+            STRICT_ARRAY => AmfValue::StrictArray(self.decode_strict_array(buf)?),
+            DATE => {
+                let (unix_time, timezone_offset) = self.decode_date(buf)?;
+                AmfValue::Date {
+                    unix_time,
+                    timezone_offset,
+                }
+            }
+            LONG_STRING => AmfValue::LongString(self.decode_long_string(buf)?),
+            TYPED_OBJECT => {
+                let (class_name, pairs) = self.decode_typed_object(buf)?;
+                AmfValue::TypedObject(class_name, pairs)
+            }
+
+            // TODO add switch to AMF3 (0x11)
+            _ => return Err(DecodingError::UnknownType(marker)),
+        };
+        Ok(amf_value)
+    }
+
+    fn decode_number(&mut self, buf: &mut Bytes) -> Result<f64, DecodingError> {
+        if buf.remaining() < 8 {
             return Err(DecodingError::InsufficientData);
         }
-        let key_bytes: Bytes = buf.copy_to_bytes(key_size);
-        let key = String::from_utf8(key_bytes.to_vec()).map_err(|_| DecodingError::InvalidUtf8)?;
+        let number = buf.get_f64();
+        Ok(number)
+    }
 
-        let (value, remaining) = decode_value(buf)?;
-        pairs.insert(key, value);
-        buf = remaining;
+    fn decode_boolean(&mut self, buf: &mut Bytes) -> Result<bool, DecodingError> {
+        if buf.remaining() < 1 {
+            return Err(DecodingError::InsufficientData);
+        }
+        let boolean = buf.get_u8() == 1;
+        Ok(boolean)
+    }
+
+    fn decode_string(&mut self, buf: &mut Bytes) -> Result<String, DecodingError> {
+        if buf.remaining() < 2 {
+            return Err(DecodingError::InsufficientData);
+        }
+        let size = buf.get_u16() as usize;
+        if buf.remaining() < size {
+            return Err(DecodingError::InsufficientData);
+        }
+        let string_bytes = buf.copy_to_bytes(size);
+        let string =
+            String::from_utf8(string_bytes.to_vec()).map_err(|_| DecodingError::InvalidUtf8)?;
+        Ok(string)
+    }
+
+    fn decode_object(
+        &mut self,
+        buf: &mut Bytes,
+    ) -> Result<HashMap<String, AmfValue>, DecodingError> {
+        let pairs = self.decode_object_pairs(buf)?;
+        self.complexes.push(AmfValue::Object(pairs.clone()));
+        Ok(pairs)
+    }
+
+    fn decode_reference(&mut self, buf: &mut Bytes) -> Result<AmfValue, DecodingError> {
+        if buf.remaining() < 2 {
+            return Err(DecodingError::InsufficientData);
+        }
+
+        let idx = buf.get_u16() as usize;
+        let complex = match self.complexes.get(idx) {
+            Some(c) => c.clone(),
+            None => return Err(DecodingError::OutOfBoundsReference),
+        };
+        Ok(complex)
+    }
+
+    fn decode_ecma_array(
+        &mut self,
+        buf: &mut Bytes,
+    ) -> Result<HashMap<String, AmfValue>, DecodingError> {
+        if buf.remaining() < 4 {
+            return Err(DecodingError::InsufficientData);
+        }
+        let _array_size = buf.get_u32();
+        let pairs = self.decode_object_pairs(buf)?;
+        self.complexes.push(AmfValue::EcmaArray(pairs.clone()));
+        Ok(pairs)
+    }
+
+    fn decode_strict_array(&mut self, buf: &mut Bytes) -> Result<Vec<AmfValue>, DecodingError> {
+        if buf.remaining() < 4 {
+            return Err(DecodingError::InsufficientData);
+        }
+        let size = buf.get_u32() as usize;
+        let mut array = Vec::with_capacity(size);
+
+        for _ in 0..size {
+            let value = self.decode_value(buf)?;
+            array.push(value);
+        }
+
+        self.complexes.push(AmfValue::StrictArray(array.clone()));
+        Ok(array)
+    }
+
+    fn decode_date(&mut self, buf: &mut Bytes) -> Result<(f64, i16), DecodingError> {
+        if buf.remaining() < 10 {
+            return Err(DecodingError::InsufficientData);
+        }
+
+        let unix_time = buf.get_f64();
+        let timezone_offset = buf.get_i16();
+        if timezone_offset != 0x00_00 {
+            warn!("Timezone offset is not zero.");
+        }
+
+        Ok((unix_time, timezone_offset))
+    }
+
+    fn decode_long_string(&mut self, buf: &mut Bytes) -> Result<String, DecodingError> {
+        if buf.remaining() < 4 {
+            return Err(DecodingError::InsufficientData);
+        }
+
+        let size = buf.get_u32() as usize;
+        if buf.remaining() < size {
+            return Err(DecodingError::InsufficientData);
+        }
+        let string_bytes = buf.copy_to_bytes(size);
+        let string =
+            String::from_utf8(string_bytes.to_vec()).map_err(|_| DecodingError::InvalidUtf8)?;
+        Ok(string)
+    }
+
+    fn decode_typed_object(
+        &mut self,
+        buf: &mut Bytes,
+    ) -> Result<(String, HashMap<String, AmfValue>), DecodingError> {
+        if buf.remaining() < 2 {
+            return Err(DecodingError::InsufficientData);
+        }
+
+        let class_name = self.decode_string(buf)?;
+        let pairs = self.decode_object_pairs(buf)?;
+
+        self.complexes
+            .push(AmfValue::TypedObject(class_name.clone(), pairs.clone()));
+        Ok((class_name, pairs))
+    }
+
+    fn decode_object_pairs(
+        &mut self,
+        buf: &mut Bytes,
+    ) -> Result<HashMap<String, AmfValue>, DecodingError> {
+        let mut pairs = HashMap::new();
+
+        loop {
+            if buf.remaining() < 3 {
+                return Err(DecodingError::InsufficientData);
+            }
+            if buf[..3] == OBJECT_END_MARKER {
+                buf.advance(3);
+                return Ok(pairs);
+            }
+            let key_size = buf.get_u16() as usize;
+            if buf.remaining() < key_size {
+                return Err(DecodingError::InsufficientData);
+            }
+            let key_bytes: Bytes = buf.copy_to_bytes(key_size);
+            let key =
+                String::from_utf8(key_bytes.to_vec()).map_err(|_| DecodingError::InvalidUtf8)?;
+
+            let value = self.decode_value(buf)?;
+            pairs.insert(key, value);
+        }
     }
 }

--- a/rtmp/flv/src/amf0/encoding.rs
+++ b/rtmp/flv/src/amf0/encoding.rs
@@ -1,8 +1,9 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use std::collections::HashMap;
 use thiserror::Error;
+use tracing::warn;
 
-use crate::amf0::AmfValue;
+use crate::amf0::*;
 
 #[derive(Error, Debug)]
 pub enum EncodingError {
@@ -28,19 +29,26 @@ fn encode_value(buf: &mut BytesMut, value: &AmfValue) -> Result<(), EncodingErro
         AmfValue::String(s) => put_string(buf, s)?,
         AmfValue::Object(map) => put_object(buf, map)?,
         AmfValue::Null => put_null(buf),
-        AmfValue::Array(arr) => put_array(buf, arr)?,
+        AmfValue::Undefined => put_undefined(buf),
         AmfValue::EcmaArray(map) => put_ecma_array(buf, map)?,
+        AmfValue::StrictArray(arr) => put_strict_array(buf, arr)?,
+        AmfValue::Date {
+            unix_time,
+            timezone_offset,
+        } => put_date(buf, *unix_time, *timezone_offset),
+        AmfValue::LongString(s) => put_long_string(buf, s)?,
+        AmfValue::TypedObject(_name, _map) => unimplemented!(),
     };
     Ok(())
 }
 
 fn put_number(buf: &mut BytesMut, n: f64) {
-    buf.put_u8(0x00);
+    buf.put_u8(NUMBER);
     buf.put_f64(n);
 }
 
 fn put_bool(buf: &mut BytesMut, b: bool) {
-    buf.put_u8(0x01);
+    buf.put_u8(BOOLEAN);
     buf.put_u8(b as u8);
 }
 
@@ -48,21 +56,41 @@ fn put_string(buf: &mut BytesMut, s: &str) -> Result<(), EncodingError> {
     if s.len() > u16::MAX as usize {
         return Err(EncodingError::StringTooLong(s.len()));
     }
-    buf.put_u8(0x02);
+    buf.put_u8(STRING);
     buf.put_u16(s.len() as u16);
     buf.put_slice(s.as_bytes());
     Ok(())
 }
 
-fn put_null(buf: &mut BytesMut) {
-    buf.put_u8(0x05);
+fn put_object(buf: &mut BytesMut, map: &HashMap<String, AmfValue>) -> Result<(), EncodingError> {
+    buf.put_u8(OBJECT);
+    put_keyval_map(buf, map)?;
+    Ok(())
 }
 
-fn put_array(buf: &mut BytesMut, arr: &[AmfValue]) -> Result<(), EncodingError> {
+fn put_null(buf: &mut BytesMut) {
+    buf.put_u8(NULL);
+}
+
+fn put_undefined(buf: &mut BytesMut) {
+    buf.put_u8(UNDEFINED);
+}
+
+fn put_ecma_array(
+    buf: &mut BytesMut,
+    map: &HashMap<String, AmfValue>,
+) -> Result<(), EncodingError> {
+    buf.put_u8(ECMA_ARRAY);
+    buf.put_u32(map.len() as u32);
+    put_keyval_map(buf, map)?;
+    Ok(())
+}
+
+fn put_strict_array(buf: &mut BytesMut, arr: &[AmfValue]) -> Result<(), EncodingError> {
     if arr.len() > u32::MAX as usize {
         return Err(EncodingError::ArrayTooLong(arr.len()));
     }
-    buf.put_u8(0x0A);
+    buf.put_u8(STRICT_ARRAY);
     buf.put_u32(arr.len() as u32);
     for value in arr {
         encode_value(buf, value)?;
@@ -70,19 +98,22 @@ fn put_array(buf: &mut BytesMut, arr: &[AmfValue]) -> Result<(), EncodingError> 
     Ok(())
 }
 
-fn put_object(buf: &mut BytesMut, map: &HashMap<String, AmfValue>) -> Result<(), EncodingError> {
-    buf.put_u8(0x03);
-    put_keyval_map(buf, map)?;
-    Ok(())
+fn put_date(buf: &mut BytesMut, unix_time: f64, timezone_offset: i16) {
+    buf.put_u8(DATE);
+    buf.put_f64(unix_time);
+    if timezone_offset != 0x00_00 {
+        warn!("Timezone offset is not zero.");
+    }
+    buf.put_i16(timezone_offset);
 }
 
-fn put_ecma_array(
-    buf: &mut BytesMut,
-    map: &HashMap<String, AmfValue>,
-) -> Result<(), EncodingError> {
-    buf.put_u8(0x08);
-    buf.put_u32(map.len() as u32);
-    put_keyval_map(buf, map)?;
+fn put_long_string(buf: &mut BytesMut, s: &str) -> Result<(), EncodingError> {
+    if s.len() > u32::MAX as usize {
+        return Err(EncodingError::StringTooLong(s.len()));
+    }
+    buf.put_u8(LONG_STRING);
+    buf.put_u32(s.len() as u32);
+    buf.put_slice(s.as_bytes());
     Ok(())
 }
 

--- a/rtmp/flv/src/amf0/mod.rs
+++ b/rtmp/flv/src/amf0/mod.rs
@@ -3,6 +3,19 @@ use std::collections::HashMap;
 pub mod decoding;
 pub mod encoding;
 
+const NUMBER: u8 = 0x00;
+const BOOLEAN: u8 = 0x01;
+const STRING: u8 = 0x02;
+const OBJECT: u8 = 0x03;
+const NULL: u8 = 0x05;
+const UNDEFINED: u8 = 0x06;
+const REFERENCE: u8 = 0x07;
+const ECMA_ARRAY: u8 = 0x08;
+const STRICT_ARRAY: u8 = 0x0A;
+const DATE: u8 = 0x0B;
+const LONG_STRING: u8 = 0x0C;
+const TYPED_OBJECT: u8 = 0x10;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum AmfValue {
     Number(f64),
@@ -10,6 +23,13 @@ pub enum AmfValue {
     String(String),
     Object(HashMap<String, AmfValue>),
     Null,
-    Array(Vec<AmfValue>),
+    Undefined,
     EcmaArray(HashMap<String, AmfValue>),
+    StrictArray(Vec<AmfValue>),
+    Date {
+        unix_time: f64,
+        timezone_offset: i16,
+    },
+    LongString(String),
+    TypedObject(String, HashMap<String, AmfValue>),
 }

--- a/rtmp/src/error.rs
+++ b/rtmp/src/error.rs
@@ -26,8 +26,8 @@ pub enum RtmpError {
     #[error("Stream not registered")]
     StreamNotRegistered,
 
-    #[error("Socket closed")]
-    SocketClosed,
+    #[error("Channel closed")]
+    ChannelClosed,
 
     #[error("Missing previous chunk header for CSID {0}")]
     MissingHeader(u32),

--- a/rtmp/src/handle_client.rs
+++ b/rtmp/src/handle_client.rs
@@ -54,13 +54,13 @@ pub(crate) fn handle_client(
                 let audio_data = parse_audio(msg)?;
                 sender
                     .send(audio_data)
-                    .map_err(|_| RtmpError::SocketClosed)?;
+                    .map_err(|_| RtmpError::ChannelClosed)?;
             }
             MessageType::Video => {
                 let video_data = parse_video(msg)?;
                 sender
                     .send(video_data)
-                    .map_err(|_| RtmpError::SocketClosed)?;
+                    .map_err(|_| RtmpError::ChannelClosed)?;
             }
             _ => {} // possible metadata
         }

--- a/rtmp/src/negotiation.rs
+++ b/rtmp/src/negotiation.rs
@@ -29,7 +29,7 @@ pub(crate) fn negotiate_rtmp_session(
         let msg = match reader.next() {
             Some(Ok(m)) => m,
             Some(Err(e)) => return Err(e),
-            None => return Err(RtmpError::SocketClosed),
+            None => return Err(RtmpError::ChannelClosed),
         };
 
         match msg.msg_type {

--- a/rtmp/src/protocol/mod.rs
+++ b/rtmp/src/protocol/mod.rs
@@ -15,6 +15,8 @@ pub enum MessageType {
 
     Audio,
     Video,
+    DataMessageAmf0,
+
     CommandMessageAmf0,
 }
 
@@ -29,6 +31,7 @@ impl MessageType {
             6 => Ok(MessageType::SetPeerBandwidth),
             8 => Ok(MessageType::Audio),
             9 => Ok(MessageType::Video),
+            18 => Ok(MessageType::DataMessageAmf0),
             20 => Ok(MessageType::CommandMessageAmf0),
             _ => Err(RtmpError::UnsuportedMessageType(id)),
         }
@@ -44,6 +47,7 @@ impl MessageType {
             MessageType::SetPeerBandwidth => 6,
             MessageType::Audio => 8,
             MessageType::Video => 9,
+            MessageType::DataMessageAmf0 => 18,
             MessageType::CommandMessageAmf0 => 20,
         }
     }


### PR DESCRIPTION
Added handling of all types mentioned in `flv` spec. Most importantly added handling of the `Reference` message type for comples objects.

Additionally refactored the amf code, so decoding functions are now reusable inside of each other.