### PR TITLE
[rtmp] Add missing RTMP message types

### DIFF
--- a/rtmp/src/message/mod.rs
+++ b/rtmp/src/message/mod.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+
 use crate::{RtmpEvent, amf0::Amf0Value};
 
 mod event;
@@ -6,6 +8,18 @@ mod serialize;
 
 #[derive(Debug)]
 pub(crate) enum RtmpMessage {
+    SetChunkSize {
+        chunk_size: u32,
+    },
+    AbortMessage {
+        chunk_stream_id: u32,
+    },
+    Acknowledgement {
+        sequence_number: u32,
+    },
+    UserControl {
+        event: UserControlEvent,
+    },
     WindowAckSize {
         window_size: u32,
     },
@@ -13,10 +27,11 @@ pub(crate) enum RtmpMessage {
         bandwidth: u32,
         limit_type: u8,
     },
-    StreamBegin {
+    // Audio/Video/Metadata events
+    Event {
+        event: RtmpEvent,
         stream_id: u32,
     },
-
     // Explanation why it is a sequence of amf0 values and not amf3 values:
     // https://zenomt.github.io/rtmp-errata-addenda/rtmp-errata-addenda.html#name-object-encoding-3-2
     CommandMessageAmf3 {
@@ -27,11 +42,63 @@ pub(crate) enum RtmpMessage {
         values: Vec<Amf0Value>,
         stream_id: u32,
     },
-    SetChunkSize {
-        chunk_size: u32,
+    SharedObjectAmf0 {
+        name: String,
+        version: u32,
+        persistent: bool,
+        events: Vec<SharedObjectEvent>,
     },
-    Event {
-        event: RtmpEvent,
+    SharedObjectAmf3 {
+        name: String,
+        version: u32,
+        persistent: bool,
+        events: Vec<SharedObjectEvent>,
+    },
+    AggregateMessage {
+        stream_id: u32,
+        messages: Vec<RtmpMessage>,
+    },
+}
+
+// https://rtmp.veriskope.com/docs/spec/#717user-control-message-events
+#[derive(Debug)]
+pub(crate) enum UserControlEvent {
+    StreamBegin {
         stream_id: u32,
     },
+    StreamEof {
+        stream_id: u32,
+    },
+    StreamDry {
+        stream_id: u32,
+    },
+    SetBufferLength {
+        stream_id: u32,
+        buffer_length_ms: u32,
+    },
+    StreamIsRecorded {
+        stream_id: u32,
+    },
+    PingRequest {
+        timestamp: u32,
+    },
+    PingResponse {
+        timestamp: u32,
+    },
+    // fallback for unrecognised event types.
+    Unknown {
+        event_type: u16,
+        data: Bytes,
+    },
+}
+
+/// A single event entry inside a Shared Object message.
+/// `data` is raw bytes whose encoding (AMF0 or AMF3) depends on the parent message type.
+#[derive(Debug, Clone)]
+pub(crate) struct SharedObjectEvent {
+    /// Event type code (1 = Use, 2 = Release, 3 = RequestChange, 4 = Change,
+    /// 5 = Success, 6 = SendMessage, 7 = Status, 8 = ClearData,
+    /// 9 = DeleteData, 10 = RequestRemove, 11 = UseSuccess).
+    pub event_type: u8,
+    pub data: Bytes,
 }

--- a/rtmp/src/message/parse.rs
+++ b/rtmp/src/message/parse.rs
@@ -1,10 +1,10 @@
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 
 use crate::{
     AmfDecodingError, ParseError, RtmpEvent, ScriptData,
     amf0::decode_amf0_values,
     message::{
-        RtmpMessage,
+        RtmpMessage, SharedObjectEvent, UserControlEvent,
         event::{audio_event_from_raw, video_event_from_raw},
     },
     protocol::{MessageType, RawMessage},
@@ -35,10 +35,23 @@ impl RtmpMessage {
 
             MessageType::SetChunkSize if msg.payload.len() >= 4 => {
                 let chunk_size = u32::from_be_bytes([p[0] & 0x7F, p[1], p[2], p[3]]);
-                // TODO: double check p[0] or p[3]
                 RtmpMessage::SetChunkSize { chunk_size }
             }
             MessageType::SetChunkSize => return Err(ParseError::NotEnoughData),
+
+            MessageType::AbortMessage if msg.payload.len() >= 4 => RtmpMessage::AbortMessage {
+                chunk_stream_id: u32::from_be_bytes([p[0], p[1], p[2], p[3]]),
+            },
+            MessageType::AbortMessage => return Err(ParseError::NotEnoughData),
+
+            MessageType::Acknowledgement if msg.payload.len() >= 4 => {
+                RtmpMessage::Acknowledgement {
+                    sequence_number: u32::from_be_bytes([p[0], p[1], p[2], p[3]]),
+                }
+            }
+            MessageType::Acknowledgement => return Err(ParseError::NotEnoughData),
+
+            MessageType::UserControl => parse_user_control(msg.payload)?,
 
             MessageType::WindowAckSize if msg.payload.len() >= 4 => RtmpMessage::WindowAckSize {
                 window_size: u32::from_be_bytes([p[0], p[1], p[2], p[3]]),
@@ -68,16 +81,222 @@ impl RtmpMessage {
                 stream_id: msg.stream_id,
             },
 
-            MessageType::Acknowledgement => {
-                return Err(ParseError::UnsupportedMessageType(msg.msg_type));
-            }
-            MessageType::AbortMessage => {
-                return Err(ParseError::UnsupportedMessageType(msg.msg_type));
-            }
-            MessageType::UserControl => {
-                return Err(ParseError::UnsupportedMessageType(msg.msg_type));
-            }
+            // SharedObjectAmf3 does not have a format-selector prefix; its event data
+            // bytes are AMF3 encoded (callers decode as needed).
+            MessageType::SharedObjectAmf3 => parse_shared_object(msg.payload, true)?,
+            MessageType::SharedObjectAmf0 => parse_shared_object(msg.payload, false)?,
+
+            MessageType::AggregateMessage => parse_aggregate_message(msg.stream_id, msg.payload)?,
         };
         Ok(result)
     }
+}
+
+/// Parse a User Control message (type 4).
+fn parse_user_control(mut payload: Bytes) -> Result<RtmpMessage, ParseError> {
+    if payload.remaining() < 2 {
+        return Err(ParseError::NotEnoughData);
+    }
+    let event_type = payload.get_u16();
+
+    let event = match event_type {
+        // StreamBegin – stream_id (4 bytes)
+        0 => {
+            if payload.remaining() < 4 {
+                return Err(ParseError::NotEnoughData);
+            }
+            UserControlEvent::StreamBegin {
+                stream_id: payload.get_u32(),
+            }
+        }
+        // StreamEof – stream_id (4 bytes)
+        1 => {
+            if payload.remaining() < 4 {
+                return Err(ParseError::NotEnoughData);
+            }
+            UserControlEvent::StreamEof {
+                stream_id: payload.get_u32(),
+            }
+        }
+        // StreamDry – stream_id (4 bytes)
+        2 => {
+            if payload.remaining() < 4 {
+                return Err(ParseError::NotEnoughData);
+            }
+            UserControlEvent::StreamDry {
+                stream_id: payload.get_u32(),
+            }
+        }
+        // SetBufferLength – stream_id (4 bytes) + buffer_length_ms (4 bytes)
+        3 => {
+            if payload.remaining() < 8 {
+                return Err(ParseError::NotEnoughData);
+            }
+            let stream_id = payload.get_u32();
+            let buffer_length_ms = payload.get_u32();
+            UserControlEvent::SetBufferLength {
+                stream_id,
+                buffer_length_ms,
+            }
+        }
+        // StreamIsRecorded – stream_id (4 bytes)
+        4 => {
+            if payload.remaining() < 4 {
+                return Err(ParseError::NotEnoughData);
+            }
+            UserControlEvent::StreamIsRecorded {
+                stream_id: payload.get_u32(),
+            }
+        }
+        // PingRequest – timestamp (4 bytes)
+        6 => {
+            if payload.remaining() < 4 {
+                return Err(ParseError::NotEnoughData);
+            }
+            UserControlEvent::PingRequest {
+                timestamp: payload.get_u32(),
+            }
+        }
+        // PingResponse – timestamp (4 bytes)
+        7 => {
+            if payload.remaining() < 4 {
+                return Err(ParseError::NotEnoughData);
+            }
+            UserControlEvent::PingResponse {
+                timestamp: payload.get_u32(),
+            }
+        }
+        // Unknown event type – preserve raw bytes for forward compatibility
+        _ => UserControlEvent::Unknown {
+            event_type,
+            data: payload,
+        },
+    };
+    Ok(RtmpMessage::UserControl { event })
+}
+
+/// Parse a Shared Object message (types 19 = AMF0, 16 = AMF3).
+///
+/// Both variants share the same outer binary structure:
+///   2 bytes  – object name length
+///   N bytes  – object name (UTF-8)
+///   4 bytes  – current version
+///   4 bytes  – flags (bit 0 = persistent)
+///   Repeated until end of payload:
+///     1 byte  – event type
+///     4 bytes – event data length
+///     N bytes – event data (AMF0 or AMF3 encoded)
+fn parse_shared_object(mut payload: Bytes, amf3: bool) -> Result<RtmpMessage, ParseError> {
+    if payload.remaining() < 2 {
+        return Err(ParseError::NotEnoughData);
+    }
+    let name_len = payload.get_u16() as usize;
+
+    if payload.remaining() < name_len + 8 {
+        return Err(ParseError::NotEnoughData);
+    }
+    let name_bytes = payload.copy_to_bytes(name_len);
+    let name = String::from_utf8(name_bytes.to_vec()).map_err(|_| AmfDecodingError::InvalidUtf8)?;
+
+    let version = payload.get_u32();
+    let flags = payload.get_u32();
+    let persistent = flags & 1 != 0;
+
+    let mut events = Vec::new();
+    while payload.remaining() >= 5 {
+        let event_type = payload.get_u8();
+        let event_data_len = payload.get_u32() as usize;
+        if payload.remaining() < event_data_len {
+            break;
+        }
+        let data = payload.copy_to_bytes(event_data_len);
+        events.push(SharedObjectEvent { event_type, data });
+    }
+
+    if amf3 {
+        Ok(RtmpMessage::SharedObjectAmf3 {
+            name,
+            version,
+            persistent,
+            events,
+        })
+    } else {
+        Ok(RtmpMessage::SharedObjectAmf0 {
+            name,
+            version,
+            persistent,
+            events,
+        })
+    }
+}
+
+/// Parse an Aggregate message (type 22).
+///
+/// The payload is a sequence of FLV-style tagged sub-messages:
+///   1 byte  – message type ID
+///   3 bytes – payload length (big-endian)
+///   3 bytes – timestamp low 24 bits (big-endian)
+///   1 byte  – timestamp high 8 bits (extends to 32-bit timestamp)
+///   3 bytes – stream ID (little-endian, per FLV spec; typically ignored)
+///   N bytes – sub-message payload
+///   4 bytes – back pointer (size of the entire preceding entry incl. header)
+///
+/// Sub-messages inherit the aggregate message's `stream_id`. Unknown or
+/// unparseable sub-message types are silently skipped to maximise compatibility
+/// with real-world streams that embed proprietary data in aggregates.
+fn parse_aggregate_message(stream_id: u32, mut payload: Bytes) -> Result<RtmpMessage, ParseError> {
+    let mut messages = Vec::new();
+
+    while payload.remaining() >= 11 {
+        let type_id = payload.get_u8();
+
+        // 3-byte big-endian payload length
+        let d0 = payload.get_u8() as u32;
+        let d1 = payload.get_u8() as u32;
+        let d2 = payload.get_u8() as u32;
+        let data_size = (d0 << 16) | (d1 << 8) | d2;
+
+        // 4-byte timestamp: 3 low bytes then 1 high byte
+        let t0 = payload.get_u8() as u32;
+        let t1 = payload.get_u8() as u32;
+        let t2 = payload.get_u8() as u32;
+        let t_ext = payload.get_u8() as u32;
+        let timestamp = (t_ext << 24) | (t0 << 16) | (t1 << 8) | t2;
+
+        // 3-byte stream ID (little-endian) – we use the aggregate's stream_id instead.
+        payload.advance(3);
+
+        let data_size = data_size as usize;
+        // Need payload bytes + 4-byte back pointer
+        if payload.remaining() < data_size + 4 {
+            break;
+        }
+
+        let sub_payload = payload.copy_to_bytes(data_size);
+        let _back_pointer = payload.get_u32();
+
+        let msg_type = match MessageType::try_from_raw(type_id) {
+            Ok(t) => t,
+            // Skip sub-messages with unrecognised type IDs.
+            Err(_) => continue,
+        };
+
+        let raw = RawMessage {
+            msg_type,
+            stream_id,
+            timestamp,
+            payload: sub_payload,
+        };
+
+        match RtmpMessage::from_raw(raw) {
+            Ok(m) => messages.push(m),
+            // Skip sub-messages that fail to parse (e.g. proprietary extensions).
+            Err(_) => continue,
+        }
+    }
+
+    Ok(RtmpMessage::AggregateMessage {
+        stream_id,
+        messages,
+    })
 }

--- a/rtmp/src/message/serialize.rs
+++ b/rtmp/src/message/serialize.rs
@@ -1,20 +1,39 @@
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{
     SerializationError,
     amf0::{encode_amf0_values, encode_avmplus_values},
-    message::{RtmpMessage, event::event_into_raw},
-    protocol::{MessageType, RawMessage, UserControlMessageEvent},
+    message::{RtmpMessage, UserControlEvent, event::event_into_raw},
+    protocol::{MessageType, RawMessage},
 };
 
 impl RtmpMessage {
     pub fn into_raw(self) -> Result<RawMessage, SerializationError> {
         let result = match self {
+            RtmpMessage::SetChunkSize { chunk_size } => RawMessage {
+                msg_type: MessageType::SetChunkSize,
+                stream_id: 0, // TODO: not sure if zero
+                timestamp: 0,
+                payload: Bytes::copy_from_slice(&chunk_size.to_be_bytes()),
+            },
+            RtmpMessage::AbortMessage { chunk_stream_id } => RawMessage {
+                msg_type: MessageType::AbortMessage,
+                stream_id: 0,
+                timestamp: 0,
+                payload: Bytes::copy_from_slice(&chunk_stream_id.to_be_bytes()),
+            },
+            RtmpMessage::Acknowledgement { sequence_number } => RawMessage {
+                msg_type: MessageType::Acknowledgement,
+                stream_id: 0,
+                timestamp: 0,
+                payload: Bytes::copy_from_slice(&sequence_number.to_be_bytes()),
+            },
+            RtmpMessage::UserControl { event } => serialize_user_control(event),
             RtmpMessage::WindowAckSize { window_size } => RawMessage {
                 msg_type: MessageType::WindowAckSize,
                 stream_id: 0,
                 timestamp: 0,
-                payload: Bytes::copy_from_slice(&window_size.to_be_bytes()[..]),
+                payload: Bytes::copy_from_slice(&window_size.to_be_bytes()),
             },
             RtmpMessage::SetPeerBandwidth {
                 bandwidth,
@@ -24,18 +43,6 @@ impl RtmpMessage {
                 stream_id: 0,
                 timestamp: 0,
                 payload: Bytes::from([&bandwidth.to_be_bytes()[..], &[limit_type]].concat()),
-            },
-            RtmpMessage::StreamBegin { stream_id } => RawMessage {
-                msg_type: MessageType::UserControl,
-                stream_id: 0,
-                timestamp: 0,
-                payload: Bytes::from(
-                    [
-                        &(UserControlMessageEvent::StreamBegin as u16).to_be_bytes()[..],
-                        &stream_id.to_be_bytes(),
-                    ]
-                    .concat(),
-                ),
             },
             RtmpMessage::CommandMessageAmf3 { values, stream_id } => RawMessage {
                 msg_type: MessageType::CommandMessageAmf3,
@@ -49,14 +56,157 @@ impl RtmpMessage {
                 timestamp: 0,
                 payload: encode_amf0_values(&values)?,
             },
-            RtmpMessage::SetChunkSize { chunk_size } => RawMessage {
-                msg_type: MessageType::SetChunkSize,
-                stream_id: 0, // TODO: not sure if zero
-                timestamp: 0,
-                payload: Bytes::copy_from_slice(&chunk_size.to_be_bytes()[..]),
-            },
             RtmpMessage::Event { event, stream_id } => event_into_raw(event, stream_id)?,
+            RtmpMessage::SharedObjectAmf0 {
+                name,
+                version,
+                persistent,
+                events,
+            } => serialize_shared_object(name, version, persistent, events, false),
+
+            RtmpMessage::SharedObjectAmf3 {
+                name,
+                version,
+                persistent,
+                events,
+            } => serialize_shared_object(name, version, persistent, events, true),
+            RtmpMessage::AggregateMessage {
+                stream_id,
+                messages,
+            } => serialize_aggregate_message(stream_id, messages)?,
         };
         Ok(result)
     }
+}
+
+/// Serialize a User Control message (type 4).
+/// Layout: 2-byte event type | event-specific payload.
+fn serialize_user_control(event: UserControlEvent) -> RawMessage {
+    let (event_type_u16, data): (u16, Vec<u8>) = match event {
+        UserControlEvent::StreamBegin { stream_id } => (0, stream_id.to_be_bytes().into()),
+        UserControlEvent::StreamEof { stream_id } => (1, stream_id.to_be_bytes().into()),
+        UserControlEvent::StreamDry { stream_id } => (2, stream_id.to_be_bytes().into()),
+        UserControlEvent::SetBufferLength {
+            stream_id,
+            buffer_length_ms,
+        } => {
+            let mut d = stream_id.to_be_bytes().to_vec();
+            d.extend_from_slice(&buffer_length_ms.to_be_bytes());
+            (3, d)
+        }
+        UserControlEvent::StreamIsRecorded { stream_id } => (4, stream_id.to_be_bytes().into()),
+        UserControlEvent::PingRequest { timestamp } => (6, timestamp.to_be_bytes().into()),
+        UserControlEvent::PingResponse { timestamp } => (7, timestamp.to_be_bytes().into()),
+        UserControlEvent::Unknown { event_type, data } => (event_type, data.to_vec()),
+    };
+
+    let payload = [&event_type_u16.to_be_bytes()[..], data.as_slice()].concat();
+    RawMessage {
+        msg_type: MessageType::UserControl,
+        stream_id: 0,
+        timestamp: 0,
+        payload: Bytes::from(payload),
+    }
+}
+
+/// Serialize a Shared Object message (AMF0 = type 19, AMF3 = type 16).
+///
+/// Wire format:
+///   2 bytes  – name length
+///   N bytes  – name (UTF-8)
+///   4 bytes  – version
+///   4 bytes  – flags  (bit 0 = persistent)
+///   For each event:
+///     1 byte  – event type
+///     4 bytes – event data length
+///     N bytes – event data
+fn serialize_shared_object(
+    name: String,
+    version: u32,
+    persistent: bool,
+    events: Vec<crate::message::SharedObjectEvent>,
+    amf3: bool,
+) -> RawMessage {
+    let name_bytes = name.as_bytes();
+    let flags: u32 = if persistent { 1 } else { 0 };
+
+    let capacity =
+        2 + name_bytes.len() + 4 + 4 + events.iter().map(|e| 1 + 4 + e.data.len()).sum::<usize>();
+    let mut buf = BytesMut::with_capacity(capacity);
+
+    buf.put_u16(name_bytes.len() as u16);
+    buf.put_slice(name_bytes);
+    buf.put_u32(version);
+    buf.put_u32(flags);
+
+    for event in events {
+        buf.put_u8(event.event_type);
+        buf.put_u32(event.data.len() as u32);
+        buf.put_slice(&event.data);
+    }
+
+    RawMessage {
+        msg_type: if amf3 {
+            MessageType::SharedObjectAmf3
+        } else {
+            MessageType::SharedObjectAmf0
+        },
+        stream_id: 0,
+        timestamp: 0,
+        payload: buf.freeze(),
+    }
+}
+
+/// Serialize an Aggregate message (type 22).
+///
+/// Each sub-message is written in FLV tag format:
+///   1 byte  – message type ID
+///   3 bytes – payload length (big-endian)
+///   3 bytes – timestamp low 24 bits (big-endian)
+///   1 byte  – timestamp high 8 bits
+///   3 bytes – stream ID (written as 0; inherited from aggregate header)
+///   N bytes – payload
+///   4 bytes – back pointer (header size 11 + payload length)
+fn serialize_aggregate_message(
+    stream_id: u32,
+    messages: Vec<RtmpMessage>,
+) -> Result<RawMessage, SerializationError> {
+    let mut buf = BytesMut::new();
+    let mut first_timestamp: Option<u32> = None;
+
+    for msg in messages {
+        let raw = msg.into_raw()?;
+        let ts = raw.timestamp;
+        first_timestamp.get_or_insert(ts);
+
+        let data_size = raw.payload.len() as u32;
+        let back_pointer: u32 = 11 + data_size;
+
+        // type ID
+        buf.put_u8(raw.msg_type.into_raw());
+        // 3-byte payload length
+        buf.put_u8(((data_size >> 16) & 0xFF) as u8);
+        buf.put_u8(((data_size >> 8) & 0xFF) as u8);
+        buf.put_u8((data_size & 0xFF) as u8);
+        // 4-byte timestamp: low 3 bytes then high byte
+        buf.put_u8(((ts >> 16) & 0xFF) as u8);
+        buf.put_u8(((ts >> 8) & 0xFF) as u8);
+        buf.put_u8((ts & 0xFF) as u8);
+        buf.put_u8(((ts >> 24) & 0xFF) as u8);
+        // 3-byte stream ID (always 0 in the FLV body; real stream_id is in chunk header)
+        buf.put_u8(0);
+        buf.put_u8(0);
+        buf.put_u8(0);
+        // payload
+        buf.put_slice(&raw.payload);
+        // back pointer
+        buf.put_u32(back_pointer);
+    }
+
+    Ok(RawMessage {
+        msg_type: MessageType::AggregateMessage,
+        stream_id,
+        timestamp: first_timestamp.unwrap_or(0),
+        payload: buf.freeze(),
+    })
 }

--- a/rtmp/src/protocol/mod.rs
+++ b/rtmp/src/protocol/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod handshake;
 pub(crate) mod message_reader;
 pub(crate) mod message_writer;
 
+#[derive(Debug)]
 pub(crate) struct RawMessage {
     pub msg_type: MessageType,
     pub stream_id: u32,
@@ -19,20 +20,24 @@ pub(crate) struct RawMessage {
 pub enum MessageType {
     // https://rtmp.veriskope.com/docs/spec/#54-protocol-control-messages
     // Protocol Control Messages (1-6)
-    SetChunkSize,
-    AbortMessage,
-    Acknowledgement,
-    UserControl,
-    WindowAckSize,
-    SetPeerBandwidth,
+    SetChunkSize,     // 1
+    AbortMessage,     // 2
+    Acknowledgement,  // 3
+    UserControl,      // 4
+    WindowAckSize,    // 5
+    SetPeerBandwidth, // 6
 
-    Audio,
-    Video,
-    DataMessageAmf3,
-    DataMessageAmf0,
+    Audio, // 8
+    Video, // 9
 
-    CommandMessageAmf3,
-    CommandMessageAmf0,
+    DataMessageAmf3,    // 15 (0x0F)
+    SharedObjectAmf3,   // 16 (0x10)
+    CommandMessageAmf3, // 17 (0x11)
+    DataMessageAmf0,    // 18 (0x12)
+    SharedObjectAmf0,   // 19 (0x13)
+    CommandMessageAmf0, // 20 (0x14)
+
+    AggregateMessage, // 22 (0x16)
 }
 
 impl MessageType {
@@ -47,9 +52,12 @@ impl MessageType {
             8 => Ok(MessageType::Audio),
             9 => Ok(MessageType::Video),
             15 => Ok(MessageType::DataMessageAmf3),
+            16 => Ok(MessageType::SharedObjectAmf3),
             17 => Ok(MessageType::CommandMessageAmf3),
             18 => Ok(MessageType::DataMessageAmf0),
+            19 => Ok(MessageType::SharedObjectAmf0),
             20 => Ok(MessageType::CommandMessageAmf0),
+            22 => Ok(MessageType::AggregateMessage),
             _ => Err(ParseError::UnknownMessageType(value)),
         }
     }
@@ -65,28 +73,12 @@ impl MessageType {
             MessageType::Audio => 8,
             MessageType::Video => 9,
             MessageType::DataMessageAmf3 => 15,
+            MessageType::SharedObjectAmf3 => 16,
             MessageType::CommandMessageAmf3 => 17,
             MessageType::DataMessageAmf0 => 18,
+            MessageType::SharedObjectAmf0 => 19,
             MessageType::CommandMessageAmf0 => 20,
+            MessageType::AggregateMessage => 22,
         }
     }
-}
-
-// https://rtmp.veriskope.com/docs/spec/#717user-control-message-events
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(unused)]
-pub enum UserControlMessageEvent {
-    StreamBegin = 0,
-    #[allow(unused)]
-    StreamEof = 1,
-    #[allow(unused)]
-    StreamDry = 2,
-    #[allow(unused)]
-    SetBufferLength = 3,
-    #[allow(unused)]
-    StreamIsRecorded = 4,
-    #[allow(unused)]
-    PingRequest = 6,
-    #[allow(unused)]
-    PingResponse = 7,
 }

--- a/rtmp/src/server/negotiation.rs
+++ b/rtmp/src/server/negotiation.rs
@@ -1,7 +1,7 @@
 use crate::{
     amf0::Amf0Value,
     error::RtmpError,
-    message::RtmpMessage,
+    message::{RtmpMessage, UserControlEvent},
     protocol::{message_reader::RtmpMessageReader, message_writer::RtmpMessageWriter},
 };
 use std::collections::HashMap;
@@ -91,7 +91,9 @@ fn handle_command_message(
                 bandwidth: PEER_BANDWIDTH,
                 limit_type: 0,
             })?;
-            writer.write(RtmpMessage::StreamBegin { stream_id: 0 })?;
+            writer.write(RtmpMessage::UserControl {
+                event: UserControlEvent::StreamBegin { stream_id: 0 },
+            })?;
 
             // _result - connect response
             let props = HashMap::from([
@@ -142,8 +144,10 @@ fn handle_command_message(
             })?;
             trace!(stream_id = current_stream_id, "Sent createStream _result");
 
-            writer.write(RtmpMessage::StreamBegin {
-                stream_id: current_stream_id,
+            writer.write(RtmpMessage::UserControl {
+                event: UserControlEvent::StreamBegin {
+                    stream_id: current_stream_id,
+                },
             })?;
             trace!(
                 stream_id = current_stream_id,


### PR DESCRIPTION
Not sure if those parser/serializer for SharedObjectMessage and AggregateMessage works properly. As far as I know they are not commonly used nowadays.