### PR TITLE
[vk-video] Add transcoders

### DIFF
--- a/vk-video/CHANGELOG.md
+++ b/vk-video/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 💥 Breaking changes
 
 ### ✨ New features
+- One-to-many transcoders via `VulkanDevice::create_transcoder`
 
 ### 🐛 Bug fixes
 - Fix `vkBindVideoSessionMemoryKHR` validation errors on Mesa drivers

--- a/vk-video/examples/transcode.rs
+++ b/vk-video/examples/transcode.rs
@@ -1,0 +1,92 @@
+#[cfg(vulkan)]
+fn main() {
+    use std::{
+        fs::File,
+        io::{Read, Write},
+        num::NonZeroU32,
+        time::Duration,
+    };
+
+    use vk_video::{
+        EncodedInputChunk,
+        parameters::{RateControl, VideoParameters},
+    };
+
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to initialize tracing");
+
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.len() != 4 {
+        print_usage_and_exit(&args[0]);
+    }
+
+    let input_file = &args[1];
+    let Ok(output_width) = args[2].parse::<NonZeroU32>() else {
+        print_usage_and_exit(&args[0]);
+    };
+    let Ok(output_height) = args[3].parse::<NonZeroU32>() else {
+        print_usage_and_exit(&args[0]);
+    };
+
+    let instance = vk_video::VulkanInstance::new().unwrap();
+    let adapter = instance.create_adapter(None).unwrap();
+    let device = adapter
+        .create_device(Default::default(), Default::default(), Default::default())
+        .unwrap();
+
+    let params = device
+        .encoder_parameters_high_quality(
+            VideoParameters {
+                width: output_width,
+                height: output_height,
+                target_framerate: 30.into(),
+            },
+            RateControl::VariableBitrate {
+                average_bitrate: 10_000_000,
+                max_bitrate: 12_000_000,
+                virtual_buffer_size: Duration::from_secs(2),
+            },
+        )
+        .unwrap();
+
+    let mut transcoder = device.create_transcoder(&[params]).unwrap();
+
+    let mut input_file = File::open(input_file).unwrap();
+    let mut output_file = File::create("output.h264").unwrap();
+
+    let mut buffer = vec![0; 4096];
+    while let Ok(n) = input_file.read(&mut buffer)
+        && n > 0
+    {
+        let input = EncodedInputChunk {
+            data: &buffer[..n],
+            pts: None,
+        };
+        let output = transcoder.transcode(input).unwrap();
+
+        for output in output {
+            output_file.write_all(&output[0].data).unwrap();
+        }
+    }
+
+    let flushed = transcoder.flush().unwrap();
+    for output in flushed {
+        output_file.write_all(&output[0].data).unwrap();
+    }
+}
+
+#[cfg(vulkan)]
+fn print_usage_and_exit(executable_name: &str) -> ! {
+    eprintln!("usage: {executable_name} INPUT OUT_WIDTH OUT_HEIGHT");
+    std::process::exit(1);
+}
+
+#[cfg(not(vulkan))]
+fn main() {
+    println!(
+        "This crate doesn't work on your operating system, because it does not support vulkan"
+    );
+}

--- a/vk-video/src/device.rs
+++ b/vk-video/src/device.rs
@@ -16,8 +16,9 @@ use crate::parameters::{
     EncoderContentFlags, EncoderTuningMode, EncoderUsageFlags, H264Profile, RateControl,
 };
 use crate::parser::{h264::H264Parser, reference_manager::ReferenceContext};
-use crate::vulkan_decoder::{FrameSorter, VulkanDecoder};
+use crate::vulkan_decoder::{FrameSorter, ImageModifiers, VulkanDecoder};
 use crate::vulkan_encoder::{FullEncoderParameters, VulkanEncoder};
+use crate::vulkan_transcoder::{Transcoder, TranscoderError};
 use crate::{
     BytesDecoder, BytesEncoder, DecoderError, RawFrameData, VulkanDecoderError, VulkanEncoderError,
     VulkanInitError, VulkanInstance, WgpuTexturesDecoder, WgpuTexturesEncoder, wrappers::*,
@@ -196,6 +197,9 @@ impl VulkanDevice {
         let mut vk_video_maintenance1_feature =
             vk::PhysicalDeviceVideoMaintenance1FeaturesKHR::default().video_maintenance1(true);
 
+        let mut vk_descriptor_feature = vk::PhysicalDeviceDescriptorIndexingFeatures::default()
+            .descriptor_binding_partially_bound(true);
+
         let device_create_info = vk::DeviceCreateInfo::default()
             .queue_create_infos(&queue_create_infos)
             .enabled_extension_names(&required_extensions_as_ptrs);
@@ -203,7 +207,8 @@ impl VulkanDevice {
         let device_create_info = wgpu_physical_device_features
             .add_to_device_create(device_create_info)
             .push_next(&mut vk_synch_2_feature)
-            .push_next(&mut vk_video_maintenance1_feature);
+            .push_next(&mut vk_video_maintenance1_feature)
+            .push_next(&mut vk_descriptor_feature);
 
         let device = unsafe {
             instance
@@ -218,11 +223,16 @@ impl VulkanDevice {
         let video_encode_queue_ext =
             ash::khr::video_encode_queue::Device::new(&instance.instance, &device);
 
+        #[cfg(feature = "vk_validation")]
+        let debug_utils_ext = ash::ext::debug_utils::Device::new(&instance.instance, &device);
+
         let device = Arc::new(Device {
             device,
             video_queue_ext,
             video_decode_queue_ext,
             video_encode_queue_ext,
+            #[cfg(feature = "vk_validation")]
+            debug_utils_ext,
             _instance: instance.instance.clone(),
         });
 
@@ -306,19 +316,14 @@ impl VulkanDevice {
         })
     }
 
-    pub fn create_wgpu_textures_decoder(
-        self: &Arc<Self>,
-        parameters: DecoderParameters,
-    ) -> Result<WgpuTexturesDecoder, DecoderError> {
+    pub(crate) fn decoding_device(self: &Arc<Self>) -> Result<DecodingDevice, VulkanDecoderError> {
         let decode_caps = self
             .native_decode_capabilities
             .as_ref()
             .ok_or(VulkanDecoderError::VulkanDecoderUnsupported)?;
         let max_profile = decode_caps.max_profile();
 
-        let parser = H264Parser::default();
-        let reference_ctx = ReferenceContext::new(parameters.missed_frame_handling);
-        let decoding_device = DecodingDevice {
+        Ok(DecodingDevice {
             vulkan_device: self.clone(),
             h264_decode_queues: self
                 .queues
@@ -329,9 +334,25 @@ impl VulkanDevice {
                 .profile(max_profile)
                 .cloned()
                 .ok_or(VulkanDecoderError::VulkanDecoderUnsupported)?,
-        };
+        })
+    }
 
-        let vulkan_decoder = VulkanDecoder::new(Arc::new(decoding_device), parameters.usage_flags)?;
+    pub fn create_wgpu_textures_decoder(
+        self: &Arc<Self>,
+        parameters: DecoderParameters,
+    ) -> Result<WgpuTexturesDecoder, DecoderError> {
+        let parser = H264Parser::default();
+        let reference_ctx = ReferenceContext::new(parameters.missed_frame_handling);
+
+        let vulkan_decoder = VulkanDecoder::new(
+            Arc::new(self.decoding_device()?),
+            parameters.usage_flags,
+            ImageModifiers {
+                additional_queue_index: self.queues.transfer.family_index,
+                create_flags: Default::default(),
+                usage_flags: Default::default(),
+            },
+        )?;
         let frame_sorter = FrameSorter::<wgpu::Texture>::new();
 
         Ok(WgpuTexturesDecoder {
@@ -346,28 +367,18 @@ impl VulkanDevice {
         self: &Arc<Self>,
         parameters: DecoderParameters,
     ) -> Result<BytesDecoder, DecoderError> {
-        let decode_caps = self
-            .native_decode_capabilities
-            .as_ref()
-            .ok_or(VulkanDecoderError::VulkanDecoderUnsupported)?;
-        let max_profile = decode_caps.max_profile();
-
         let parser = H264Parser::default();
         let reference_ctx = ReferenceContext::new(parameters.missed_frame_handling);
-        let decoding_device = DecodingDevice {
-            vulkan_device: self.clone(),
-            h264_decode_queues: self
-                .queues
-                .h264_decode
-                .clone()
-                .ok_or(VulkanDecoderError::VulkanDecoderUnsupported)?,
-            profile_capabilities: decode_caps
-                .profile(max_profile)
-                .cloned()
-                .ok_or(VulkanDecoderError::VulkanDecoderUnsupported)?,
-        };
 
-        let vulkan_decoder = VulkanDecoder::new(Arc::new(decoding_device), parameters.usage_flags)?;
+        let vulkan_decoder = VulkanDecoder::new(
+            Arc::new(self.decoding_device()?),
+            parameters.usage_flags,
+            ImageModifiers {
+                additional_queue_index: self.queues.transfer.family_index,
+                create_flags: Default::default(),
+                usage_flags: Default::default(),
+            },
+        )?;
         let frame_sorter = FrameSorter::<RawFrameData>::new();
 
         Ok(BytesDecoder {
@@ -376,6 +387,15 @@ impl VulkanDevice {
             vulkan_decoder,
             frame_sorter,
         })
+    }
+
+    /// Create a single-input multiple-output transcoder.
+    /// Each item in `parameters` corresponds to one output.
+    pub fn create_transcoder(
+        self: &Arc<Self>,
+        parameters: &[EncoderParameters],
+    ) -> Result<Transcoder, TranscoderError> {
+        Transcoder::new(self.clone(), parameters.into())
     }
 
     pub fn wgpu_device(&self) -> wgpu::Device {
@@ -390,12 +410,8 @@ impl VulkanDevice {
         self.wgpu_adapter.clone()
     }
 
-    pub fn create_bytes_encoder(
-        self: &Arc<Self>,
-        parameters: EncoderParameters,
-    ) -> Result<BytesEncoder, VulkanEncoderError> {
-        let parameters = self.validate_and_fill_encoder_parameters(parameters)?;
-        let encoding_device = EncodingDevice {
+    pub(crate) fn encoding_device(self: &Arc<Self>) -> Result<EncodingDevice, VulkanEncoderError> {
+        Ok(EncodingDevice {
             vulkan_device: self.clone(),
             h264_encode_queues: self
                 .queues
@@ -406,8 +422,16 @@ impl VulkanDevice {
                 .native_encode_capabilities
                 .clone()
                 .ok_or(VulkanEncoderError::VulkanEncoderUnsupported)?,
-        };
-        let encoder = VulkanEncoder::new(Arc::new(encoding_device), parameters)?;
+        })
+    }
+
+    pub fn create_bytes_encoder(
+        self: &Arc<Self>,
+        parameters: EncoderParameters,
+    ) -> Result<BytesEncoder, VulkanEncoderError> {
+        let parameters = self.validate_and_fill_encoder_parameters(parameters)?;
+        let encoder = VulkanEncoder::new(Arc::new(self.encoding_device()?), parameters)?;
+
         Ok(BytesEncoder {
             vulkan_encoder: encoder,
         })
@@ -493,7 +517,7 @@ impl VulkanDevice {
         })
     }
 
-    fn validate_and_fill_encoder_parameters(
+    pub(crate) fn validate_and_fill_encoder_parameters(
         &self,
         encoder_parameters: EncoderParameters,
     ) -> Result<FullEncoderParameters, VulkanEncoderError> {

--- a/vk-video/src/device/queues.rs
+++ b/vk-video/src/device/queues.rs
@@ -36,26 +36,13 @@ impl Queue {
         let buffer_submit_info =
             [vk::CommandBufferSubmitInfo::default().command_buffer(buffer.buffer())];
 
-        let signal_value = tracker.semaphore_tracker.next_sem_value();
-        let signal_info = vk::SemaphoreSubmitInfo::default()
-            .semaphore(tracker.semaphore_tracker.semaphore.semaphore)
-            .value(signal_value.0)
-            .stage_mask(signal_stages);
-
-        let wait_info = match tracker.semaphore_tracker.wait_for.take() {
-            Some(wait_for) => Some(
-                vk::SemaphoreSubmitInfo::default()
-                    .semaphore(tracker.semaphore_tracker.semaphore.semaphore)
-                    .value(wait_for.value.0)
-                    .stage_mask(wait_stages),
-            ),
-            _ => None,
-        };
+        let semaphore_submit_info = tracker.semaphore_tracker.next_submit_info(new_wait_state);
+        let signal_info = semaphore_submit_info.signal_info(signal_stages);
+        let wait_info = semaphore_submit_info.wait_info(wait_stages);
 
         let mut submit_info = vk::SubmitInfo2::default()
             .signal_semaphore_infos(std::slice::from_ref(&signal_info))
             .command_buffer_infos(&buffer_submit_info);
-
         if let Some(wait_info) = wait_info.as_ref() {
             submit_info = submit_info.wait_semaphore_infos(std::slice::from_ref(wait_info));
         }
@@ -68,14 +55,10 @@ impl Queue {
             )?
         };
 
-        buffer.mark_submitted(&mut tracker.image_layout_tracker.lock().unwrap(), signal_value);
-
-        tracker.semaphore_tracker.wait_for = Some(TrackerWait {
-            value: signal_value,
-            _state: new_wait_state,
-        });
-
-        Ok(signal_value)
+        let value = semaphore_submit_info.signal_value();
+        buffer.mark_submitted(value);
+        semaphore_submit_info.mark_submitted();
+        Ok(value)
     }
 }
 
@@ -187,7 +170,7 @@ impl VideoQueues {
         wait_stages: vk::PipelineStageFlags2,
         signal_stages: vk::PipelineStageFlags2,
         new_wait_state: K::WaitState,
-    ) -> Result<(), VulkanCommonError> {
+    ) -> Result<SemaphoreWaitValue, VulkanCommonError> {
         let queue = self.next_queue();
         queue.submit_chain_semaphore(buffer, tracker, wait_stages, signal_stages, new_wait_state)
     }

--- a/vk-video/src/instance.rs
+++ b/vk-video/src/instance.rs
@@ -62,11 +62,7 @@ impl VulkanInstance {
             .map(|layer| layer.as_ptr())
             .collect::<Vec<_>>();
 
-        let extensions = if cfg!(debug_assertions) {
-            vec![vk::EXT_DEBUG_UTILS_NAME]
-        } else {
-            Vec::new()
-        };
+        let extensions = vec![vk::EXT_DEBUG_UTILS_NAME];
 
         let wgpu_extensions = wgpu::hal::vulkan::Instance::desired_extensions(
             &entry,

--- a/vk-video/src/lib.rs
+++ b/vk-video/src/lib.rs
@@ -11,6 +11,8 @@ mod vulkan_decoder;
 #[cfg(vulkan)]
 mod vulkan_encoder;
 #[cfg(vulkan)]
+mod vulkan_transcoder;
+#[cfg(vulkan)]
 pub(crate) mod wrappers;
 
 #[cfg(vulkan)]

--- a/vk-video/src/parser/reference_manager.rs
+++ b/vk-video/src/parser/reference_manager.rs
@@ -914,7 +914,7 @@ impl ReferenceContext {
             .iter()
             .enumerate()
             .find(|(_, pic)| match pic.LongTermPicNum {
-                Some(num) => num == picture_to_shift.into(),
+                Some(num) => num == picture_to_shift as u64,
                 None => false,
             })
             .map(|(i, _)| i)

--- a/vk-video/src/vulkan_decoder.rs
+++ b/vk-video/src/vulkan_decoder.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use ash::vk;
 
 use h264_reader::nal::{pps::PicParameterSet, sps::SeqParameterSet};
+use rustc_hash::FxHashMap;
 use session_resources::VideoSessionResources;
 use wgpu::hal::api::Vulkan as VkApi;
 
@@ -23,19 +24,28 @@ pub(crate) use frame_sorter::FrameSorter;
 
 pub struct VulkanDecoder<'a> {
     video_session_resources: Option<VideoSessionResources<'a>>,
-    tracker: DecoderTracker,
-    reference_id_to_dpb_slot_index: std::collections::HashMap<ReferenceId, usize>,
+    pub(crate) tracker: DecoderTracker,
+    reference_id_to_dpb_slot_index: FxHashMap<ReferenceId, usize>,
     decoding_device: Arc<DecodingDevice>,
     usage_info: vk::VideoDecodeUsageInfoKHR<'a>,
+    image_modifiers: ImageModifiers,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ImageModifiers {
+    pub(crate) create_flags: vk::ImageCreateFlags,
+    pub(crate) usage_flags: vk::ImageUsageFlags,
+    pub(crate) additional_queue_index: usize,
 }
 
 pub(crate) enum DecoderTrackerWaitState {
     NewDecodingImagesLayoutTransition,
     Decode,
     DownloadImageToBuffer,
+    ExternalProcessing,
 }
 
-struct DecoderTrackerKind {}
+pub(crate) struct DecoderTrackerKind {}
 
 impl TrackerKind for DecoderTrackerKind {
     type WaitState = DecoderTrackerWaitState;
@@ -43,7 +53,7 @@ impl TrackerKind for DecoderTrackerKind {
     type CommandBufferPools = DecoderCommandBufferPools;
 }
 
-struct DecoderCommandBufferPools {
+pub(crate) struct DecoderCommandBufferPools {
     decode: CommandBufferPool,
     transfer: CommandBufferPool,
 }
@@ -55,18 +65,55 @@ impl CommandBufferPoolStorage for DecoderCommandBufferPools {
     }
 }
 
-type DecoderTracker = Tracker<DecoderTrackerKind>;
+pub(crate) type DecoderTracker = Tracker<DecoderTrackerKind>;
 
-/// this cannot outlive the image and semaphore it borrows, but it seems very hard to encode that
-/// in the lifetimes
-struct DecodeSubmission {
-    image: Arc<Image>,
-    dimensions: vk::Extent2D,
-    layer: u32,
-    picture_order_cnt: i32,
-    max_num_reorder_frames: u64,
-    is_idr: bool,
-    pts: Option<u64>,
+pub(crate) struct DecodeSubmissionImageInfo {
+    pub(crate) image: Arc<Image>,
+    pub(crate) layer: u32,
+}
+
+pub(crate) struct DecodeResultMetadata {
+    pub(crate) pts: Option<u64>,
+    pub(crate) pic_order_cnt: i32,
+    pub(crate) max_num_reorder_frames: u64,
+    pub(crate) is_idr: bool,
+}
+
+pub(crate) struct DecodeResult<T> {
+    pub(crate) frame: T,
+    pub(crate) metadata: DecodeResultMetadata,
+}
+
+pub(crate) struct DecodeSubmission<'borrow, 'decoder> {
+    pub(crate) decode_result: DecodeResult<DecodeSubmissionImageInfo>,
+    pub(crate) semaphore_wait_value: SemaphoreWaitValue,
+    pub(crate) decoder: &'borrow mut VulkanDecoder<'decoder>,
+}
+
+impl<'a, 'b> DecodeSubmission<'a, 'b> {
+    fn download_output(self) -> Result<DecodeResult<RawFrameData>, VulkanDecoderError> {
+        let raw_frame_data = self.decoder.download_output(&self.decode_result.frame)?;
+
+        Ok(DecodeResult {
+            frame: RawFrameData {
+                frame: raw_frame_data,
+                width: self.decode_result.frame.image.extent.width,
+                height: self.decode_result.frame.image.extent.height,
+            },
+            metadata: self.decode_result.metadata,
+        })
+    }
+
+    fn output_to_wgpu_texture(self) -> Result<DecodeResult<wgpu::Texture>, VulkanDecoderError> {
+        let wgpu_texture = self
+            .decoder
+            .output_to_wgpu_texture(&self.decode_result.frame)?;
+
+        Ok(DecodeResult {
+            frame: wgpu_texture,
+            metadata: self.decode_result.metadata,
+        })
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -104,6 +151,7 @@ impl VulkanDecoder<'_> {
     pub fn new(
         decoding_device: Arc<DecodingDevice>,
         usage_flags: crate::parameters::DecoderUsageFlags,
+        image_modifiers: ImageModifiers,
     ) -> Result<Self, VulkanDecoderError> {
         let command_buffer_pools = DecoderCommandBufferPools {
             transfer: CommandBufferPool::new(
@@ -119,6 +167,7 @@ impl VulkanDecoder<'_> {
         let tracker = Tracker::new(
             decoding_device.vulkan_device.device.clone(),
             command_buffer_pools,
+            Some("decoder"),
         )?;
 
         let usage_info = vk::VideoDecodeUsageInfoKHR::default().video_usage_hints(usage_flags);
@@ -129,19 +178,12 @@ impl VulkanDecoder<'_> {
             tracker,
             reference_id_to_dpb_slot_index: Default::default(),
             usage_info,
+            image_modifiers,
         })
     }
 }
 
-pub(crate) struct DecodeResult<T> {
-    frame: T,
-    pts: Option<u64>,
-    pic_order_cnt: i32,
-    max_num_reorder_frames: u64,
-    is_idr: bool,
-}
-
-impl VulkanDecoder<'_> {
+impl<'a> VulkanDecoder<'a> {
     pub fn decode_to_bytes(
         &mut self,
         decoder_instructions: &[DecoderInstruction],
@@ -149,17 +191,7 @@ impl VulkanDecoder<'_> {
         let mut result = Vec::new();
         for instruction in decoder_instructions {
             if let Some(output) = self.decode(instruction)? {
-                result.push(DecodeResult {
-                    pts: output.pts,
-                    is_idr: output.is_idr,
-                    max_num_reorder_frames: output.max_num_reorder_frames,
-                    pic_order_cnt: output.picture_order_cnt,
-                    frame: RawFrameData {
-                        width: output.dimensions.width,
-                        height: output.dimensions.height,
-                        frame: self.download_output(output)?,
-                    },
-                })
+                result.push(output.download_output()?);
             }
         }
 
@@ -173,23 +205,17 @@ impl VulkanDecoder<'_> {
         let mut result = Vec::new();
         for instruction in decoder_instructions {
             if let Some(output) = self.decode(instruction)? {
-                result.push(DecodeResult {
-                    pts: output.pts,
-                    is_idr: output.is_idr,
-                    max_num_reorder_frames: output.max_num_reorder_frames,
-                    pic_order_cnt: output.picture_order_cnt,
-                    frame: self.output_to_wgpu_texture(output)?,
-                })
+                result.push(output.output_to_wgpu_texture()?);
             }
         }
 
         Ok(result)
     }
 
-    fn decode(
-        &mut self,
+    pub(crate) fn decode<'b>(
+        &'b mut self,
         instruction: &DecoderInstruction,
-    ) -> Result<Option<DecodeSubmission>, VulkanDecoderError> {
+    ) -> Result<Option<DecodeSubmission<'b, 'a>>, VulkanDecoderError> {
         match instruction {
             DecoderInstruction::Decode {
                 decode_info,
@@ -239,6 +265,7 @@ impl VulkanDecoder<'_> {
                     sps.clone(),
                     self.usage_info,
                     &mut self.tracker,
+                    self.image_modifiers,
                 )?)
             }
         }
@@ -263,29 +290,29 @@ impl VulkanDecoder<'_> {
         }
     }
 
-    fn process_idr(
-        &mut self,
+    fn process_idr<'b>(
+        &'b mut self,
         decode_information: &DecodeInformation,
         reference_id: ReferenceId,
-    ) -> Result<DecodeSubmission, VulkanDecoderError> {
+    ) -> Result<DecodeSubmission<'b, 'a>, VulkanDecoderError> {
         self.do_decode(decode_information, reference_id, true, true)
     }
 
-    fn process_reference_frame(
-        &mut self,
+    fn process_reference_frame<'b>(
+        &'b mut self,
         decode_information: &DecodeInformation,
         reference_id: ReferenceId,
-    ) -> Result<DecodeSubmission, VulkanDecoderError> {
+    ) -> Result<DecodeSubmission<'b, 'a>, VulkanDecoderError> {
         self.do_decode(decode_information, reference_id, false, true)
     }
 
-    fn do_decode(
-        &mut self,
-        decode_information: &DecodeInformation,
+    fn do_decode<'b>(
+        &'b mut self,
+        decode_information: &'_ DecodeInformation,
         reference_id: ReferenceId,
         is_idr: bool,
         is_reference: bool,
-    ) -> Result<DecodeSubmission, VulkanDecoderError> {
+    ) -> Result<DecodeSubmission<'b, 'a>, VulkanDecoderError> {
         let video_session_resources = self
             .video_session_resources
             .as_mut()
@@ -545,13 +572,14 @@ impl VulkanDecoder<'_> {
                 )
         };
 
-        self.decoding_device
+        let semaphore_wait_value = self
+            .decoding_device
             .h264_decode_queues
             .submit_chain_semaphore(
                 cmd_buffer.end()?,
                 &mut self.tracker,
-                vk::PipelineStageFlags2::VIDEO_DECODE_KHR,
-                vk::PipelineStageFlags2::VIDEO_DECODE_KHR,
+                vk::PipelineStageFlags2::ALL_COMMANDS,
+                vk::PipelineStageFlags2::ALL_COMMANDS,
                 DecoderTrackerWaitState::Decode,
             )?;
 
@@ -559,27 +587,29 @@ impl VulkanDecoder<'_> {
         self.reference_id_to_dpb_slot_index
             .insert(reference_id, new_reference_slot_index);
 
-        let sps = video_session_resources
-            .sps
-            .get(&decode_information.sps_id)
-            .ok_or(VulkanDecoderError::NoSession)?;
-
-        let dimensions = sps.size()?;
-
         Ok(DecodeSubmission {
-            image: target_image,
-            layer: target_layer as u32,
-            dimensions,
-            picture_order_cnt: decode_information.picture_info.PicOrderCnt_for_decoding[0],
-            max_num_reorder_frames: video_session_resources.parameters.max_num_reorder_frames,
-            is_idr,
-            pts: decode_information.pts,
+            decode_result: DecodeResult {
+                frame: DecodeSubmissionImageInfo {
+                    image: target_image,
+                    layer: target_layer as u32,
+                },
+                metadata: DecodeResultMetadata {
+                    pic_order_cnt: decode_information.picture_info.PicOrderCnt_for_decoding[0],
+                    max_num_reorder_frames: video_session_resources
+                        .parameters
+                        .max_num_reorder_frames,
+                    is_idr,
+                    pts: decode_information.pts,
+                },
+            },
+            semaphore_wait_value,
+            decoder: self,
         })
     }
 
     fn output_to_wgpu_texture(
         &mut self,
-        decode_output: DecodeSubmission,
+        decode_output: &DecodeSubmissionImageInfo,
     ) -> Result<wgpu::Texture, VulkanDecoderError> {
         let wgpu_device = unsafe {
             self.decoding_device
@@ -588,8 +618,8 @@ impl VulkanDecoder<'_> {
                 .unwrap()
         };
         let copy_extent = vk::Extent3D {
-            width: decode_output.dimensions.width,
-            height: decode_output.dimensions.height,
+            width: decode_output.image.extent.width,
+            height: decode_output.image.extent.height,
             depth: 1,
         };
 
@@ -698,9 +728,8 @@ impl VulkanDecoder<'_> {
             0,
         )?;
 
-        // TODO: why?? will something weaker, such as PipelineStageFlags2::TRANSFER suffice? this
-        // just needs a test
-        self.decoding_device
+        let semaphore_wait_value = self
+            .decoding_device
             .queues
             .transfer
             .submit_chain_semaphore(
@@ -711,7 +740,7 @@ impl VulkanDecoder<'_> {
                 DecoderTrackerWaitState::DownloadImageToBuffer,
             )?;
 
-        self.tracker.wait_for_all(u64::MAX)?;
+        self.tracker.wait_for(semaphore_wait_value, u64::MAX)?;
 
         let result = self
             .video_session_resources
@@ -785,20 +814,20 @@ impl VulkanDecoder<'_> {
 
     fn download_output(
         &mut self,
-        decode_output: DecodeSubmission,
+        decode_output: &DecodeSubmissionImageInfo,
     ) -> Result<Vec<u8>, VulkanDecoderError> {
-        let mut dst_buffer = self.copy_image_to_buffer(
+        let (mut dst_buffer, wait_value) = self.copy_image_to_buffer(
             &decode_output.image,
-            decode_output.dimensions,
+            decode_output.image.extent,
             decode_output.layer,
         )?;
 
-        self.tracker.wait_for_all(u64::MAX)?;
+        self.tracker.wait_for(wait_value, u64::MAX)?;
 
         let output = unsafe {
             dst_buffer.download_data_from_buffer(
-                decode_output.dimensions.width as usize
-                    * decode_output.dimensions.height as usize
+                decode_output.image.extent.width as usize
+                    * decode_output.image.extent.height as usize
                     * 3
                     / 2,
             )?
@@ -828,13 +857,13 @@ impl VulkanDecoder<'_> {
             .collect::<Vec<_>>()
     }
 
-    fn prepare_reference_list_slot_info<'a>(
-        reference_id_to_dpb_slot_index: &std::collections::HashMap<ReferenceId, usize>,
-        reference_slots: &'a [vk::VideoReferenceSlotInfoKHR<'a>],
-        references_dpb_slot_info: &'a mut [vk::VideoDecodeH264DpbSlotInfoKHR<'a>],
-        decode_information: &'a DecodeInformation,
-    ) -> Result<Vec<vk::VideoReferenceSlotInfoKHR<'a>>, VulkanDecoderError> {
-        let mut pic_reference_slots: Vec<vk::VideoReferenceSlotInfoKHR<'a>> = Vec::new();
+    fn prepare_reference_list_slot_info<'b>(
+        reference_id_to_dpb_slot_index: &FxHashMap<ReferenceId, usize>,
+        reference_slots: &'b [vk::VideoReferenceSlotInfoKHR<'b>],
+        references_dpb_slot_info: &'b mut [vk::VideoDecodeH264DpbSlotInfoKHR<'b>],
+        decode_information: &'b DecodeInformation,
+    ) -> Result<Vec<vk::VideoReferenceSlotInfoKHR<'b>>, VulkanDecoderError> {
+        let mut pic_reference_slots: Vec<vk::VideoReferenceSlotInfoKHR<'b>> = Vec::new();
         for (ref_info, dpb_slot_info) in decode_information
             .reference_list_l0
             .iter()
@@ -870,9 +899,9 @@ impl VulkanDecoder<'_> {
     fn copy_image_to_buffer(
         &mut self,
         image: &Image,
-        dimensions: vk::Extent2D,
+        dimensions: vk::Extent3D,
         layer: u32,
-    ) -> Result<Buffer, VulkanDecoderError> {
+    ) -> Result<(Buffer, SemaphoreWaitValue), VulkanDecoderError> {
         let mut cmd_buffer = self.tracker.command_buffer_pools.transfer.begin_buffer()?;
 
         image.transition_layout_single_layer(
@@ -939,18 +968,18 @@ impl VulkanDecoder<'_> {
                 )
         };
 
-        // TODO: test if just putting COPY here works as well
-        self.decoding_device
+        let wait_value = self
+            .decoding_device
             .queues
             .transfer
             .submit_chain_semaphore(
                 cmd_buffer.end()?,
                 &mut self.tracker,
-                vk::PipelineStageFlags2::COPY,
+                vk::PipelineStageFlags2::ALL_COMMANDS,
                 vk::PipelineStageFlags2::ALL_COMMANDS,
                 DecoderTrackerWaitState::DownloadImageToBuffer,
             )?;
 
-        Ok(dst_buffer)
+        Ok((dst_buffer, wait_value))
     }
 }

--- a/vk-video/src/vulkan_decoder/frame_sorter.rs
+++ b/vk-video/src/vulkan_decoder/frame_sorter.rs
@@ -6,7 +6,9 @@ use super::DecodeResult;
 
 impl<T> PartialEq for DecodeResult<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.pic_order_cnt.eq(&other.pic_order_cnt)
+        self.metadata
+            .pic_order_cnt
+            .eq(&other.metadata.pic_order_cnt)
     }
 }
 
@@ -20,7 +22,10 @@ impl<T> PartialOrd for DecodeResult<T> {
 
 impl<T> Ord for DecodeResult<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.pic_order_cnt.cmp(&other.pic_order_cnt).reverse()
+        self.metadata
+            .pic_order_cnt
+            .cmp(&other.metadata.pic_order_cnt)
+            .reverse()
     }
 }
 
@@ -36,8 +41,8 @@ impl<T> FrameSorter<T> {
     }
 
     pub(crate) fn put(&mut self, frame: DecodeResult<T>) -> Vec<Frame<T>> {
-        let max_num_reorder_frames = frame.max_num_reorder_frames as usize;
-        let is_idr = frame.is_idr;
+        let max_num_reorder_frames = frame.metadata.max_num_reorder_frames as usize;
+        let is_idr = frame.metadata.is_idr;
         let mut result = Vec::new();
 
         if is_idr {
@@ -46,13 +51,13 @@ impl<T> FrameSorter<T> {
 
                 result.push(Frame {
                     data: frame.frame,
-                    pts: frame.pts,
+                    pts: frame.metadata.pts,
                 });
             }
 
             result.push(Frame {
                 data: frame.frame,
-                pts: frame.pts,
+                pts: frame.metadata.pts,
             });
         } else {
             self.frames.push(frame);
@@ -62,7 +67,7 @@ impl<T> FrameSorter<T> {
 
                 result.push(Frame {
                     data: frame.frame,
-                    pts: frame.pts,
+                    pts: frame.metadata.pts,
                 });
             }
         }
@@ -87,7 +92,7 @@ impl<T> FrameSorter<T> {
             let frame = self.frames.pop().unwrap();
             result.push(Frame {
                 data: frame.frame,
-                pts: frame.pts,
+                pts: frame.metadata.pts,
             });
         }
 

--- a/vk-video/src/vulkan_decoder/session_resources.rs
+++ b/vk-video/src/vulkan_decoder/session_resources.rs
@@ -7,11 +7,12 @@ use h264_reader::nal::{
 };
 use images::DecodingImages;
 use parameters::{SessionParams, VideoSessionParametersManager};
+use rustc_hash::FxHashMap;
 
 use crate::{
     VulkanDecoderError,
     device::DecodingDevice,
-    vulkan_decoder::{DecoderTracker, DecoderTrackerWaitState},
+    vulkan_decoder::{DecoderTracker, DecoderTrackerWaitState, ImageModifiers},
     wrappers::{
         DecodeInputBuffer, DecodingQueryPool, H264DecodeProfileInfo, OpenCommandBuffer,
         SeqParameterSetExt, VideoSession, h264_level_idc_to_max_dpb_mbs, vk_to_h264_level_idc,
@@ -26,11 +27,12 @@ pub(super) struct VideoSessionResources<'a> {
     pub(crate) parameters: SessionParams<'a>,
     pub(crate) parameters_manager: VideoSessionParametersManager,
     pub(crate) decoding_images: DecodingImages<'a>,
-    pub(crate) sps: HashMap<u8, SeqParameterSet>,
-    pub(crate) pps: HashMap<(u8, u8), PicParameterSet>,
+    pub(crate) sps: FxHashMap<u8, SeqParameterSet>,
+    pub(crate) pps: FxHashMap<(u8, u8), PicParameterSet>,
     pub(crate) decode_query_pool: Option<DecodingQueryPool>,
     pub(crate) decode_buffer: DecodeInputBuffer,
     parameters_scheduled_for_reset: Option<SessionParams<'a>>,
+    image_modifiers: ImageModifiers,
 }
 
 fn calculate_max_num_reorder_frames(sps: &SeqParameterSet) -> Result<u64, VulkanDecoderError> {
@@ -45,7 +47,6 @@ fn calculate_max_num_reorder_frames(sps: &SeqParameterSet) -> Result<u64, Vulkan
         h264_level_idc_to_max_dpb_mbs(sps.level_idc)?
             / ((sps.pic_width_in_mbs_minus1 as u64 + 1)
                 * (sps.pic_height_in_map_units_minus1 as u64 + 1))
-                .min(16)
     };
 
     let max_num_reorder_frames = sps
@@ -53,7 +54,8 @@ fn calculate_max_num_reorder_frames(sps: &SeqParameterSet) -> Result<u64, Vulkan
         .as_ref()
         .and_then(|v| v.bitstream_restrictions.as_ref())
         .map(|b| b.max_num_reorder_frames as u64)
-        .unwrap_or(fallback_max_num_reorder_frames);
+        .unwrap_or(fallback_max_num_reorder_frames)
+        .min(16);
 
     Ok(max_num_reorder_frames)
 }
@@ -65,6 +67,7 @@ impl<'a> VideoSessionResources<'a> {
         sps: SeqParameterSet,
         usage_info: vk::VideoDecodeUsageInfoKHR<'a>,
         tracker: &mut DecoderTracker,
+        image_modifiers: ImageModifiers,
     ) -> Result<Self, VulkanDecoderError> {
         let profile_info = Arc::new(H264DecodeProfileInfo::from_sps_decode(&sps, usage_info)?);
 
@@ -114,6 +117,7 @@ impl<'a> VideoSessionResources<'a> {
             max_dpb_slots,
             decode_buffer,
             tracker,
+            image_modifiers,
         )?;
 
         let sps = HashMap::from_iter([(sps.id().id(), sps)]);
@@ -147,10 +151,11 @@ impl<'a> VideoSessionResources<'a> {
             parameters_manager,
             decoding_images,
             sps,
-            pps: HashMap::new(),
+            pps: FxHashMap::default(),
             decode_query_pool,
             decode_buffer,
             parameters_scheduled_for_reset: None,
+            image_modifiers,
         })
     }
 
@@ -263,6 +268,7 @@ impl<'a> VideoSessionResources<'a> {
             self.video_session.max_dpb_slots,
             decode_buffer,
             tracker,
+            self.image_modifiers,
         )?;
 
         self.parameters = new_params;
@@ -282,20 +288,39 @@ impl<'a> VideoSessionResources<'a> {
         max_dpb_slots: u32,
         mut decode_buffer: OpenCommandBuffer,
         tracker: &mut DecoderTracker,
+        image_modifiers: ImageModifiers,
     ) -> Result<DecodingImages<'a>, VulkanDecoderError> {
+        let mut dpb_format = decoding_device
+            .profile_capabilities
+            .h264_dpb_format_properties;
+        // image modifiers are only applied to the output picture, which is the dst_image if it
+        // exists, dpb otherwise
+        if decoding_device
+            .profile_capabilities
+            .h264_dst_format_properties
+            .is_none()
+        {
+            dpb_format.image_create_flags |= image_modifiers.create_flags;
+            dpb_format.image_usage_flags |= image_modifiers.usage_flags;
+        }
+        let dst_format = decoding_device
+            .profile_capabilities
+            .h264_dst_format_properties
+            .map(|p| {
+                p.image_create_flags(p.image_create_flags | image_modifiers.create_flags)
+                    .image_usage_flags(p.image_usage_flags | image_modifiers.usage_flags)
+            });
+
         let decoding_images = DecodingImages::new(
             decoding_device,
             &mut decode_buffer,
             tracker.image_layout_tracker.clone(),
             profile,
-            &decoding_device
-                .profile_capabilities
-                .h264_dpb_format_properties,
-            &decoding_device
-                .profile_capabilities
-                .h264_dst_format_properties,
+            &dpb_format,
+            &dst_format,
             max_coded_extent,
             max_dpb_slots,
+            image_modifiers.additional_queue_index as u32,
         )?;
 
         decoding_device.h264_decode_queues.submit_chain_semaphore(

--- a/vk-video/src/vulkan_decoder/session_resources/images.rs
+++ b/vk-video/src/vulkan_decoder/session_resources/images.rs
@@ -51,6 +51,7 @@ impl<'a> DecodingImages<'a> {
         dst_format: &Option<vk::VideoFormatPropertiesKHR<'a>>,
         dimensions: vk::Extent2D,
         max_dpb_slots: u32,
+        additional_queue_index: u32,
     ) -> Result<Self, VulkanDecoderError> {
         let dpb_image_usage = if dst_format.is_some() {
             dpb_format.image_usage_flags & vk::ImageUsageFlags::VIDEO_DECODE_DPB_KHR
@@ -58,11 +59,12 @@ impl<'a> DecodingImages<'a> {
             dpb_format.image_usage_flags
                 & (vk::ImageUsageFlags::VIDEO_DECODE_DPB_KHR
                     | vk::ImageUsageFlags::VIDEO_DECODE_DST_KHR
-                    | vk::ImageUsageFlags::TRANSFER_SRC)
+                    | vk::ImageUsageFlags::TRANSFER_SRC
+                    | vk::ImageUsageFlags::STORAGE)
         };
 
         let queue_indices = [
-            decoding_device.queues.transfer.family_index as u32,
+            additional_queue_index,
             decoding_device.h264_decode_queues.family_index as u32,
         ];
 
@@ -88,7 +90,8 @@ impl<'a> DecodingImages<'a> {
             .map(|dst_format| {
                 let dst_image_usage = dst_format.image_usage_flags
                     & (vk::ImageUsageFlags::VIDEO_DECODE_DST_KHR
-                        | vk::ImageUsageFlags::TRANSFER_SRC);
+                        | vk::ImageUsageFlags::TRANSFER_SRC
+                        | vk::ImageUsageFlags::STORAGE);
                 CodingImageBundle::new(
                     decoding_device,
                     command_buffer,

--- a/vk-video/src/vulkan_encoder.rs
+++ b/vk-video/src/vulkan_encoder.rs
@@ -12,7 +12,12 @@ use crate::{
     EncodedOutputChunk, Frame, RawFrameData, VulkanCommonError,
     device::{EncodingDevice, Rational},
     parameters::H264Profile,
-    wrappers::{Buffer, CommandBufferPool, CommandBufferPoolStorage, DecodedPicturesBuffer, Image, ImageLayoutTracker, ImageView, OpenCommandBuffer, ProfileInfo, QueryPool, SemaphoreWaitValue, Tracker, TrackerKind, TrackerWait, VideoEncodeQueueExt, VideoQueueExt, VideoSession, VideoSessionParameters},
+    wrappers::{
+        Buffer, CommandBufferPool, CommandBufferPoolStorage, DecodedPicturesBuffer, Image,
+        ImageLayoutTracker, ImageView, OpenCommandBuffer, ProfileInfo, QueryPool,
+        SemaphoreWaitValue, Tracker, TrackerKind, VideoEncodeQueueExt, VideoQueueExt, VideoSession,
+        VideoSessionParameters,
+    },
 };
 
 mod encode_parameter_sets;
@@ -269,12 +274,13 @@ struct EncodeFeedback {
 
 pub(crate) enum EncoderTrackerWaitState {
     InitializeEncoder,
+    ResizeInput,
     CopyBufferToImage,
     CopyImageToImage,
     Encode,
 }
 
-struct EncoderCommandBufferPools {
+pub(crate) struct EncoderCommandBufferPools {
     transfer: CommandBufferPool,
     encode: CommandBufferPool,
 }
@@ -301,7 +307,7 @@ impl CommandBufferPoolStorage for EncoderCommandBufferPools {
     }
 }
 
-struct EncoderTrackerKind {}
+pub(crate) struct EncoderTrackerKind {}
 
 impl TrackerKind for EncoderTrackerKind {
     type WaitState = EncoderTrackerWaitState;
@@ -309,13 +315,69 @@ impl TrackerKind for EncoderTrackerKind {
     type CommandBufferPools = EncoderCommandBufferPools;
 }
 
-type EncoderTracker = Tracker<EncoderTrackerKind>;
+pub(crate) type EncoderTracker = Tracker<EncoderTrackerKind>;
+
+pub(crate) struct EncodeSubmission<'borrow, 'encoder> {
+    pub(crate) is_idr: bool,
+    pub(crate) wait_value: SemaphoreWaitValue,
+    pub(crate) encoder: &'borrow mut VulkanEncoder<'encoder>,
+    pub(crate) pts: Option<u64>,
+    _image: Arc<Image>,
+}
+
+impl<'a, 'b> EncodeSubmission<'a, 'b> {
+    pub(crate) fn download(self) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
+        self.encoder.download_output(self.is_idr, self.pts)
+    }
+
+    pub(crate) fn mark_waited(&mut self) {
+        self.encoder.tracker.mark_waited(self.wait_value);
+    }
+
+    pub(crate) fn wait(&mut self, timeout: u64) -> Result<(), VulkanEncoderError> {
+        self.encoder.tracker.wait_for(self.wait_value, timeout)?;
+        Ok(())
+    }
+}
+
+pub(crate) struct UnwaitedEncodeSubmission<'a, 'b>(pub(crate) EncodeSubmission<'a, 'b>);
+
+impl<'a, 'b> UnwaitedEncodeSubmission<'a, 'b> {
+    pub(crate) fn mark_waited(mut self) -> WaitedEncodeSubmission<'a, 'b> {
+        self.0.mark_waited();
+        WaitedEncodeSubmission(self.0)
+    }
+
+    pub(crate) fn wait(
+        mut self,
+        timeout: u64,
+    ) -> Result<WaitedEncodeSubmission<'a, 'b>, VulkanEncoderError> {
+        self.0.wait(timeout)?;
+        Ok(WaitedEncodeSubmission(self.0))
+    }
+
+    pub(crate) fn wait_and_download(
+        self,
+        timeout: u64,
+    ) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
+        let waited = self.wait(timeout)?;
+        waited.download()
+    }
+}
+
+pub struct WaitedEncodeSubmission<'a, 'b>(pub(crate) EncodeSubmission<'a, 'b>);
+
+impl<'a, 'b> WaitedEncodeSubmission<'a, 'b> {
+    pub(crate) fn download(self) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
+        self.0.download()
+    }
+}
 
 pub struct VulkanEncoder<'a> {
-    tracker: EncoderTracker,
+    pub(crate) tracker: EncoderTracker,
     query_pool: EncodingQueryPool,
     profile: H264Profile,
-    profile_info: H264EncodeProfileInfo<'a>,
+    pub(crate) profile_info: H264EncodeProfileInfo<'a>,
     session_resources: VideoSessionResources<'a>,
     idr_period_counter: u32,
     idr_period: u32,
@@ -344,7 +406,7 @@ pub struct FullEncoderParameters {
     pub(crate) content_flags: vk::VideoEncodeContentFlagsKHR,
 }
 
-impl VulkanEncoder<'_> {
+impl<'a> VulkanEncoder<'a> {
     const OUTPUT_BUFFER_LEN: u64 = 4 * MB;
 
     pub(crate) fn new(
@@ -354,8 +416,11 @@ impl VulkanEncoder<'_> {
         let profile_info = H264EncodeProfileInfo::new_encode(&parameters);
 
         let command_buffer_pools = EncoderCommandBufferPools::new(&encoding_device)?;
-        let mut tracker =
-            EncoderTracker::new(encoding_device.device.clone(), command_buffer_pools)?;
+        let mut tracker = EncoderTracker::new(
+            encoding_device.device.clone(),
+            command_buffer_pools,
+            Some("encoder"),
+        )?;
 
         let query_pool = EncodingQueryPool::new(
             &encoding_device,
@@ -705,6 +770,9 @@ impl VulkanEncoder<'_> {
             .unwrap()
             .clone();
 
+        // this has to be raw, because normally we have our own command buffer that tracks this.
+        // since we don't have our buffer here and this is only one transition, we can do it
+        // ourselves.
         self.input_image.transition_layout_raw(
             buffer,
             &mut layout,
@@ -772,23 +840,18 @@ impl VulkanEncoder<'_> {
         // TODO: dont wait for all here
         self.tracker.wait_for_all(u64::MAX)?;
 
-        let mut wgpu_fence = wgpu::hal::vulkan::Fence::TimelineSemaphore(
-            self.tracker.semaphore_tracker.semaphore.semaphore,
-        );
-        let signal_value = self.tracker.semaphore_tracker.next_sem_value();
-
+        let mut semaphore_submit_info = self
+            .tracker
+            .semaphore_tracker
+            .next_submit_info(EncoderTrackerWaitState::CopyImageToImage);
         unsafe {
             wgpu_queue.submit(
                 &[&encoder.end_encoding()?],
                 &[],
-                (&mut wgpu_fence, signal_value.0),
+                semaphore_submit_info.wgpu_wait_info(),
             )?;
         }
-
-        self.tracker.semaphore_tracker.wait_for = Some(TrackerWait {
-            value: signal_value,
-            _state: EncoderTrackerWaitState::CopyImageToImage,
-        });
+        semaphore_submit_info.mark_submitted();
 
         self.tracker
             .image_layout_tracker
@@ -800,11 +863,12 @@ impl VulkanEncoder<'_> {
         Ok(encoder)
     }
 
-    fn encode(
-        &mut self,
+    pub(crate) fn encode<'b>(
+        &'b mut self,
         image: Arc<Image>,
         force_idr: bool,
-    ) -> Result<Vec<u8>, VulkanEncoderError> {
+        pts: Option<u64>,
+    ) -> Result<UnwaitedEncodeSubmission<'b, 'a>, VulkanEncoderError> {
         let is_idr = force_idr || self.idr_period_counter == 0;
         let mut idr_pic_id = 0;
 
@@ -1112,18 +1176,37 @@ impl VulkanEncoder<'_> {
                 );
         }
 
-        self.encoding_device
+        let wait_value = self
+            .encoding_device
             .h264_encode_queues
             .submit_chain_semaphore(
                 cmd_buffer.end()?,
                 &mut self.tracker,
-                vk::PipelineStageFlags2::VIDEO_ENCODE_KHR,
+                vk::PipelineStageFlags2::ALL_COMMANDS,
                 vk::PipelineStageFlags2::ALL_COMMANDS,
                 EncoderTrackerWaitState::Encode,
             )?;
 
-        self.tracker.wait_for_all(u64::MAX)?;
+        self.active_reference_slots
+            .push_back((setup_reference_slot_idx, std_new_slot_reference_info));
 
+        self.idr_period_counter += 1;
+        self.idr_period_counter %= self.idr_period;
+
+        Ok(UnwaitedEncodeSubmission(EncodeSubmission {
+            is_idr,
+            encoder: self,
+            wait_value,
+            pts,
+            _image: image,
+        }))
+    }
+
+    pub fn download_output(
+        &mut self,
+        is_idr: bool,
+        pts: Option<u64>,
+    ) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
         let feedback = self.query_pool.get_result_blocking()?;
 
         if feedback.status != vk::QueryResultStatusKHR::COMPLETE {
@@ -1152,9 +1235,6 @@ impl VulkanEncoder<'_> {
             Vec::new()
         };
 
-        self.active_reference_slots
-            .push_back((setup_reference_slot_idx, std_new_slot_reference_info));
-
         let encoded = unsafe {
             self.output_buffer
                 .download_data_from_buffer(feedback.bytes_written as usize)?
@@ -1162,10 +1242,11 @@ impl VulkanEncoder<'_> {
 
         output.extend_from_slice(&encoded);
 
-        self.idr_period_counter += 1;
-        self.idr_period_counter %= self.idr_period;
-
-        Ok(output)
+        Ok(EncodedOutputChunk {
+            data: output,
+            pts,
+            is_keyframe: is_idr,
+        })
     }
 
     pub fn encode_bytes(
@@ -1174,17 +1255,13 @@ impl VulkanEncoder<'_> {
         force_idr: bool,
     ) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
         let (image, _buffer) = self.transfer_buffer_to_image(frame)?;
-
         let image = Arc::new(image);
 
-        let is_keyframe = force_idr || self.idr_period_counter == 0;
-        let result = self.encode(image, force_idr)?;
+        let result = self
+            .encode(image, force_idr, frame.pts)?
+            .wait_and_download(u64::MAX)?;
 
-        Ok(EncodedOutputChunk {
-            data: result,
-            pts: frame.pts,
-            is_keyframe,
-        })
+        Ok(result)
     }
 
     /// # Safety
@@ -1197,21 +1274,18 @@ impl VulkanEncoder<'_> {
     ) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
         let _cmd_encoder = self.copy_wgpu_texture_to_image(&frame)?;
 
-        let is_keyframe = force_idr || self.idr_period_counter == 0;
-        let result = self.encode(self.input_image.clone(), force_idr)?;
+        let result = self
+            .encode(self.input_image.clone(), force_idr, frame.pts)?
+            .wait_and_download(u64::MAX)?;
 
-        Ok(EncodedOutputChunk {
-            data: result,
-            pts: frame.pts,
-            is_keyframe,
-        })
+        Ok(result)
     }
 
-    fn encoder_rate_control_for<'a>(
+    fn encoder_rate_control_for<'b>(
         &self,
         rate_control: RateControl,
-        layers: Option<&'a [vk::VideoEncodeRateControlLayerInfoKHR]>,
-    ) -> Option<vk::VideoEncodeRateControlInfoKHR<'a>> {
+        layers: Option<&'b [vk::VideoEncodeRateControlLayerInfoKHR]>,
+    ) -> Option<vk::VideoEncodeRateControlInfoKHR<'b>> {
         let layers = layers?;
 
         match rate_control {
@@ -1269,11 +1343,11 @@ impl VulkanEncoder<'_> {
         Some(vec![layer_info])
     }
 
-    fn rate_control_layers_for<'a>(
+    fn rate_control_layers_for<'b>(
         &self,
         rate_control: RateControl,
-        h264_layer_info: Option<&'a mut [vk::VideoEncodeH264RateControlLayerInfoKHR<'a>]>,
-    ) -> Option<Vec<vk::VideoEncodeRateControlLayerInfoKHR<'a>>> {
+        h264_layer_info: Option<&'b mut [vk::VideoEncodeH264RateControlLayerInfoKHR<'b>]>,
+    ) -> Option<Vec<vk::VideoEncodeRateControlLayerInfoKHR<'b>>> {
         let h264_layer_info = h264_layer_info?;
         let mut layer_info = vk::VideoEncodeRateControlLayerInfoKHR::default()
             .frame_rate_numerator(self.session_resources.framerate.numerator)

--- a/vk-video/src/vulkan_transcoder.rs
+++ b/vk-video/src/vulkan_transcoder.rs
@@ -1,0 +1,261 @@
+use std::sync::Arc;
+
+use ash::vk;
+
+use crate::{
+    DecoderError, EncodedInputChunk, EncodedOutputChunk, Frame, VulkanCommonError, VulkanDevice,
+    VulkanEncoderError,
+    device::EncoderParameters,
+    parser::{
+        decoder_instructions::{DecoderInstruction, compile_to_decoder_instructions},
+        h264::H264Parser,
+        reference_manager::ReferenceContext,
+    },
+    vulkan_decoder::{DecodeResult, FrameSorter, ImageModifiers, VulkanDecoder},
+    vulkan_encoder::{FullEncoderParameters, H264EncodeProfileInfo, VulkanEncoder},
+    vulkan_transcoder::pipeline::{OutputConfig, ResizeSubmission, ResizingPipeline},
+    wrappers::SemaphoreWaitValue,
+};
+
+mod pipeline;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TranscoderError {
+    #[error(transparent)]
+    Decoder(#[from] DecoderError),
+
+    #[error(transparent)]
+    Encoder(#[from] VulkanEncoderError),
+
+    #[error(transparent)]
+    Common(#[from] VulkanCommonError),
+
+    #[error("Vulkan error: {0}")]
+    Vulkan(#[from] vk::Result),
+
+    #[error("Wrong output number: expected a value between 0 and {expected_max}, found {actual}")]
+    WrongOutputNumber { expected_max: usize, actual: usize },
+}
+
+pub(crate) struct ResizedImages {
+    images: ResizeSubmission,
+    decoder_wait_value: SemaphoreWaitValue,
+}
+
+pub struct Transcoder {
+    device: Arc<VulkanDevice>,
+    decoder: VulkanDecoder<'static>,
+    parser: H264Parser,
+    reference_ctx: ReferenceContext,
+    sorter: FrameSorter<ResizedImages>,
+    resizing_pipeline: ResizingPipeline,
+    encoders: Vec<VulkanEncoder<'static>>,
+}
+
+impl Transcoder {
+    pub(crate) fn new(
+        device: Arc<VulkanDevice>,
+        parameters: Vec<EncoderParameters>,
+    ) -> Result<Self, TranscoderError> {
+        let decoder = VulkanDecoder::new(
+            Arc::new(
+                device
+                    .decoding_device()
+                    .map_err(DecoderError::VulkanDecoderError)?,
+            ),
+            vk::VideoDecodeUsageFlagsKHR::TRANSCODING,
+            ImageModifiers {
+                create_flags: vk::ImageCreateFlags::EXTENDED_USAGE
+                    | vk::ImageCreateFlags::MUTABLE_FORMAT,
+                usage_flags: vk::ImageUsageFlags::STORAGE,
+                additional_queue_index: device.queues.wgpu.family_index,
+            },
+        )
+        .map_err(DecoderError::VulkanDecoderError)?;
+
+        let parser = H264Parser::default();
+        let reference_ctx = ReferenceContext::default();
+        let sorter = FrameSorter::new();
+
+        let parameters = parameters
+            .iter()
+            .copied()
+            .map(|p| device.validate_and_fill_encoder_parameters(p))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let encoders = parameters
+            .iter()
+            .copied()
+            .map(|p| VulkanEncoder::new(Arc::new(device.encoding_device()?), p))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let output_configs = output_configs(&parameters);
+        let pipeline = pipeline::ResizingPipeline::new(device.clone(), output_configs)?;
+
+        Ok(Self {
+            decoder,
+            parser,
+            reference_ctx,
+            sorter,
+            resizing_pipeline: pipeline,
+            encoders,
+            device,
+        })
+    }
+
+    /// Transcodes the input bytes and returns a [`Vec`] where each element corresponds to an
+    /// output frame. Each frame is a [`Vec`] where each element corresponds to one output.
+    pub fn transcode(
+        &mut self,
+        input: EncodedInputChunk<&[u8]>,
+    ) -> Result<Vec<Vec<EncodedOutputChunk<Vec<u8>>>>, TranscoderError> {
+        let instructions = self.parse_input(input)?;
+        self.transcode_instructions(instructions)
+    }
+
+    pub fn flush(&mut self) -> Result<Vec<Vec<EncodedOutputChunk<Vec<u8>>>>, TranscoderError> {
+        let instructions = self.flush_parser()?;
+        let mut output = self.transcode_instructions(instructions)?;
+        output.append(&mut self.flush_transcoder()?);
+
+        Ok(output)
+    }
+
+    fn flush_parser(&mut self) -> Result<Vec<DecoderInstruction>, TranscoderError> {
+        let access_units = self.parser.flush().map_err(DecoderError::from)?;
+        let instructions = compile_to_decoder_instructions(&mut self.reference_ctx, access_units)
+            .map_err(DecoderError::from)?;
+
+        Ok(instructions)
+    }
+
+    fn flush_transcoder(
+        &mut self,
+    ) -> Result<Vec<Vec<EncodedOutputChunk<Vec<u8>>>>, TranscoderError> {
+        let remaining = self.sorter.flush();
+
+        let mut output = Vec::new();
+        for resized_images in remaining {
+            let encoded = self.encode_resized_images(resized_images)?;
+            output.push(encoded);
+        }
+
+        Ok(output)
+    }
+
+    fn parse_input(
+        &mut self,
+        input: EncodedInputChunk<&[u8]>,
+    ) -> Result<Vec<DecoderInstruction>, TranscoderError> {
+        let access_units = self
+            .parser
+            .parse(input.data, input.pts)
+            .map_err(DecoderError::from)?;
+
+        let instructions = compile_to_decoder_instructions(&mut self.reference_ctx, access_units)
+            .map_err(DecoderError::from)?;
+
+        Ok(instructions)
+    }
+
+    fn transcode_instructions(
+        &mut self,
+        instructions: Vec<DecoderInstruction>,
+    ) -> Result<Vec<Vec<EncodedOutputChunk<Vec<u8>>>>, TranscoderError> {
+        let mut encoded_frame_sets = Vec::new();
+
+        for instruction in instructions {
+            let Some(mut frame) = self
+                .decoder
+                .decode(&instruction)
+                .map_err(DecoderError::from)?
+            else {
+                continue;
+            };
+
+            let mut trackers = self
+                .encoders
+                .iter_mut()
+                .map(|e| &mut e.tracker)
+                .collect::<Vec<_>>();
+            let output = self.resizing_pipeline.run(&mut frame, &mut trackers)?;
+
+            let sorted = self.sorter.put(DecodeResult {
+                frame: ResizedImages {
+                    images: output,
+                    decoder_wait_value: frame.semaphore_wait_value,
+                },
+                metadata: frame.decode_result.metadata,
+            });
+
+            for resized_images in sorted {
+                let encoded_frames = self.encode_resized_images(resized_images)?;
+                encoded_frame_sets.push(encoded_frames);
+            }
+        }
+
+        Ok(encoded_frame_sets)
+    }
+
+    fn encode_resized_images(
+        &mut self,
+        resized_images: Frame<ResizedImages>,
+    ) -> Result<Vec<EncodedOutputChunk<Vec<u8>>>, TranscoderError> {
+        let mut submits = Vec::new();
+        for (encoder, frame) in self
+            .encoders
+            .iter_mut()
+            .zip(resized_images.data.images.outputs.iter())
+        {
+            let submit = encoder.encode(frame.image.clone(), false, resized_images.pts)?;
+            submits.push(submit);
+        }
+
+        let mut semaphores = Vec::new();
+        let mut values = Vec::new();
+        for submit in submits.iter() {
+            semaphores.push(
+                submit
+                    .0
+                    .encoder
+                    .tracker
+                    .semaphore_tracker
+                    .semaphore
+                    .semaphore,
+            );
+            values.push(submit.0.wait_value.0);
+        }
+        let wait = vk::SemaphoreWaitInfo::default()
+            .semaphores(&semaphores)
+            .values(&values);
+        unsafe { self.device.device.wait_semaphores(&wait, u64::MAX)? };
+
+        let mut results = Vec::new();
+        for submit in submits {
+            let waited = submit.mark_waited();
+            let result = waited.download()?;
+            results.push(result);
+        }
+
+        self.decoder
+            .tracker
+            .mark_waited(resized_images.data.decoder_wait_value);
+        self.resizing_pipeline
+            .mark_command_buffers_completed(resized_images.data.decoder_wait_value);
+        self.resizing_pipeline
+            .free_submission(resized_images.data.images);
+
+        Ok(results)
+    }
+}
+
+fn output_configs(parameters: &[FullEncoderParameters]) -> Vec<OutputConfig> {
+    parameters
+        .iter()
+        .map(|p| OutputConfig {
+            width: p.width.get(),
+            height: p.height.get(),
+            profile: H264EncodeProfileInfo::new_encode(p),
+        })
+        .collect()
+}

--- a/vk-video/src/vulkan_transcoder/pipeline.rs
+++ b/vk-video/src/vulkan_transcoder/pipeline.rs
@@ -1,0 +1,549 @@
+use std::sync::Arc;
+
+use ash::vk;
+
+use crate::{
+    VulkanDevice,
+    vulkan_decoder::{DecodeSubmission, DecoderTrackerWaitState},
+    vulkan_encoder::{EncoderTracker, EncoderTrackerWaitState, H264EncodeProfileInfo},
+    vulkan_transcoder::TranscoderError,
+    wrappers::{
+        CommandBufferPool, ComputePipeline, DescriptorPool, DescriptorSet, DescriptorSetLayout,
+        Image, ImageView, PipelineLayout, SemaphoreWaitValue, ShaderModule,
+    },
+};
+
+const MAX_OUTPUTS: u32 = 8;
+const MAX_FRAMES_IN_FLIGHT: u32 = 16; // The max reorder in h264
+
+pub(crate) struct ResizingImageBundle {
+    pub(crate) image: Arc<Image>,
+    view_y: ImageView,
+    view_uv: ImageView,
+}
+
+pub(crate) struct ResizeSubmission {
+    pub(crate) outputs: Box<[ResizingImageBundle]>,
+    pub(crate) _input: ResizingImageBundle,
+    pub(crate) descriptors: Descriptors,
+}
+
+impl ResizingImageBundle {
+    fn new(image: Arc<Image>, layer: u32) -> Result<Self, TranscoderError> {
+        let view_y = image.create_plane_view(
+            layer,
+            vk::ImageAspectFlags::PLANE_0,
+            vk::ImageUsageFlags::STORAGE,
+        )?;
+        let view_uv = image.create_plane_view(
+            layer,
+            vk::ImageAspectFlags::PLANE_1,
+            vk::ImageUsageFlags::STORAGE,
+        )?;
+
+        Ok(Self {
+            image,
+            view_y,
+            view_uv,
+        })
+    }
+}
+
+struct ImageHeap {
+    freelist: Vec<Box<[ResizingImageBundle]>>,
+    device: Arc<VulkanDevice>,
+    configs: Vec<OutputConfig>,
+}
+
+impl ImageHeap {
+    fn new(device: Arc<VulkanDevice>, configs: Vec<OutputConfig>) -> Self {
+        Self {
+            device,
+            freelist: Vec::new(),
+            configs,
+        }
+    }
+
+    fn free(&mut self, images: Box<[ResizingImageBundle]>) {
+        self.freelist.push(images);
+    }
+
+    fn allocate(
+        &mut self,
+        trackers: &mut [&mut EncoderTracker],
+    ) -> Result<Box<[ResizingImageBundle]>, TranscoderError> {
+        if let Some(images) = self.freelist.pop() {
+            return Ok(images);
+        }
+
+        let mut result = Vec::with_capacity(self.configs.len());
+        for (config, tracker) in self.configs.iter().zip(trackers.iter_mut()) {
+            let mut profile_list_info = vk::VideoProfileListInfoKHR::default()
+                .profiles(std::slice::from_ref(&config.profile.profile_info));
+            let queue_indices = [
+                self.device
+                    .queues
+                    .h264_encode
+                    .as_ref()
+                    .unwrap()
+                    .family_index as u32,
+                self.device.queues.wgpu.family_index as u32,
+            ];
+            let create_info = vk::ImageCreateInfo::default()
+                .flags(vk::ImageCreateFlags::EXTENDED_USAGE | vk::ImageCreateFlags::MUTABLE_FORMAT)
+                .image_type(vk::ImageType::TYPE_2D)
+                .format(vk::Format::G8_B8R8_2PLANE_420_UNORM)
+                .extent(vk::Extent3D {
+                    width: config.width,
+                    height: config.height,
+                    depth: 1,
+                })
+                .mip_levels(1)
+                .array_layers(1)
+                .samples(vk::SampleCountFlags::TYPE_1)
+                .tiling(vk::ImageTiling::OPTIMAL)
+                .usage(vk::ImageUsageFlags::STORAGE | vk::ImageUsageFlags::VIDEO_ENCODE_SRC_KHR)
+                .sharing_mode(vk::SharingMode::CONCURRENT)
+                .queue_family_indices(&queue_indices)
+                .initial_layout(vk::ImageLayout::UNDEFINED)
+                .push_next(&mut profile_list_info);
+
+            let image = Arc::new(Image::new(
+                self.device.allocator.clone(),
+                &create_info,
+                tracker.image_layout_tracker.clone(),
+            )?);
+
+            self.device
+                .device
+                .set_label(image.image, Some("resize image"))?;
+
+            result.push(ResizingImageBundle::new(image, 0)?);
+        }
+
+        Ok(result.into_boxed_slice())
+    }
+}
+
+pub(crate) struct OutputConfig {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) profile: H264EncodeProfileInfo<'static>,
+}
+
+pub(crate) struct Descriptors {
+    input: DescriptorSet,
+    output_y: DescriptorSet,
+    output_uv: DescriptorSet,
+}
+
+struct DescriptorHeap {
+    pool: Arc<DescriptorPool>,
+    freelist: Vec<Descriptors>,
+    layout_input: Arc<DescriptorSetLayout>,
+    layout_output: Arc<DescriptorSetLayout>,
+}
+
+impl DescriptorHeap {
+    fn new(
+        pool: Arc<DescriptorPool>,
+        layout_input: Arc<DescriptorSetLayout>,
+        layout_output: Arc<DescriptorSetLayout>,
+    ) -> Self {
+        Self {
+            pool,
+            freelist: Vec::new(),
+            layout_input,
+            layout_output,
+        }
+    }
+
+    fn free(&mut self, descriptors: Descriptors) {
+        self.freelist.push(descriptors);
+    }
+
+    fn allocate(&mut self) -> Result<Descriptors, TranscoderError> {
+        if let Some(descriptors) = self.freelist.pop() {
+            return Ok(descriptors);
+        }
+
+        let input = DescriptorSet::new(
+            self.pool.clone(),
+            &vk::DescriptorSetAllocateInfo::default()
+                .descriptor_pool(self.pool.pool)
+                .set_layouts(&[self.layout_input.set_layout]),
+        )?
+        .pop()
+        .unwrap();
+
+        let mut descriptor_set_outputs = DescriptorSet::new(
+            self.pool.clone(),
+            &vk::DescriptorSetAllocateInfo::default()
+                .set_layouts(&[self.layout_output.set_layout, self.layout_output.set_layout]),
+        )?;
+
+        let output_uv = descriptor_set_outputs.pop().unwrap();
+        let output_y = descriptor_set_outputs.pop().unwrap();
+
+        Ok(Descriptors {
+            input,
+            output_y,
+            output_uv,
+        })
+    }
+}
+
+pub(crate) struct ResizingPipeline {
+    descriptor_heap: DescriptorHeap,
+    image_heap: ImageHeap,
+    pipeline: ComputePipeline,
+    buffer_pool: CommandBufferPool,
+    device: Arc<VulkanDevice>,
+}
+
+impl ResizingPipeline {
+    pub(crate) fn new(
+        device: Arc<VulkanDevice>,
+        configs: Vec<OutputConfig>,
+    ) -> Result<Self, TranscoderError> {
+        if configs.is_empty() || configs.len() > MAX_OUTPUTS as usize {
+            return Err(TranscoderError::WrongOutputNumber {
+                expected_max: MAX_OUTPUTS as usize,
+                actual: configs.len(),
+            });
+        }
+        let pool_sizes = [vk::DescriptorPoolSize::default()
+            .ty(vk::DescriptorType::STORAGE_IMAGE)
+            .descriptor_count((2 * MAX_OUTPUTS + 2) * MAX_FRAMES_IN_FLIGHT)];
+        let descriptor_pool = Arc::new(DescriptorPool::new(
+            device.device.clone(),
+            &vk::DescriptorPoolCreateInfo::default()
+                .max_sets(3 * MAX_FRAMES_IN_FLIGHT)
+                .pool_sizes(&pool_sizes),
+        )?);
+
+        let bindings_input = [
+            vk::DescriptorSetLayoutBinding::default()
+                .descriptor_count(1)
+                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+                .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                .binding(0),
+            vk::DescriptorSetLayoutBinding::default()
+                .descriptor_count(1)
+                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+                .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                .binding(1),
+        ];
+
+        let layout_input = Arc::new(DescriptorSetLayout::new(
+            device.device.clone(),
+            &vk::DescriptorSetLayoutCreateInfo::default().bindings(&bindings_input),
+        )?);
+
+        let bindings_output = [vk::DescriptorSetLayoutBinding::default()
+            .descriptor_count(MAX_OUTPUTS)
+            .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+            .binding(0)
+            .stage_flags(vk::ShaderStageFlags::COMPUTE)];
+
+        let flags = [vk::DescriptorBindingFlags::PARTIALLY_BOUND];
+        let mut binding_flags =
+            vk::DescriptorSetLayoutBindingFlagsCreateInfo::default().binding_flags(&flags);
+
+        let layout_output = Arc::new(DescriptorSetLayout::new(
+            device.device.clone(),
+            &vk::DescriptorSetLayoutCreateInfo::default()
+                .bindings(&bindings_output)
+                .push_next(&mut binding_flags),
+        )?);
+
+        let descriptor_heap = DescriptorHeap::new(
+            descriptor_pool.clone(),
+            layout_input.clone(),
+            layout_output.clone(),
+        );
+        let image_heap = ImageHeap::new(device.clone(), configs);
+
+        let layouts = [
+            layout_input.set_layout,
+            layout_output.set_layout,
+            layout_output.set_layout,
+        ];
+        let push_constants = [vk::PushConstantRange::default()
+            .size(4)
+            .offset(0)
+            .stage_flags(vk::ShaderStageFlags::COMPUTE)];
+        let create_info = vk::PipelineLayoutCreateInfo::default()
+            .set_layouts(&layouts)
+            .push_constant_ranges(&push_constants);
+        let pipeline_layout = Arc::new(PipelineLayout::new(
+            device.device.clone(),
+            &create_info,
+            vec![layout_input.clone(), layout_output.clone()],
+        )?);
+
+        let mut front = wgpu::naga::front::wgsl::Frontend::new();
+        let parsed = front.parse(include_str!("shader.wgsl")).unwrap();
+        let mut validator = wgpu::naga::valid::Validator::new(
+            wgpu::naga::valid::ValidationFlags::all(),
+            wgpu::naga::valid::Capabilities::all(),
+        );
+        validator
+            .subgroup_stages(wgpu::naga::valid::ShaderStages::COMPUTE)
+            .subgroup_operations(wgpu::naga::valid::SubgroupOperationSet::all());
+        let module_info = validator.validate(&parsed).unwrap();
+        let compiled = wgpu::naga::back::spv::write_vec(
+            &parsed,
+            &module_info,
+            &wgpu::naga::back::spv::Options {
+                lang_version: (1, 6),
+                ..Default::default()
+            },
+            Some(&wgpu::naga::back::spv::PipelineOptions {
+                shader_stage: wgpu::naga::ShaderStage::Compute,
+                entry_point: "main".into(),
+            }),
+        )
+        .unwrap();
+
+        let shader_module = Arc::new(ShaderModule::new(
+            device.device.clone(),
+            &vk::ShaderModuleCreateInfo::default().code(&compiled),
+        )?);
+
+        let shader = vk::PipelineShaderStageCreateInfo::default()
+            .stage(vk::ShaderStageFlags::COMPUTE)
+            .name(c"main")
+            .module(shader_module.module);
+        let create_info = vk::ComputePipelineCreateInfo::default()
+            .stage(shader)
+            .layout(pipeline_layout.layout);
+
+        let pipeline = ComputePipeline::new(
+            device.device.clone(),
+            create_info,
+            pipeline_layout,
+            shader_module,
+        )?;
+
+        let buffer_pool = CommandBufferPool::new(device.clone(), device.queues.wgpu.family_index)?;
+
+        Ok(Self {
+            image_heap,
+            descriptor_heap,
+            pipeline,
+            buffer_pool,
+            device,
+        })
+    }
+
+    pub(crate) fn free_submission(&mut self, submission: ResizeSubmission) {
+        self.descriptor_heap.free(submission.descriptors);
+        self.image_heap.free(submission.outputs);
+    }
+
+    fn write_descriptors(
+        &mut self,
+        input: &ResizingImageBundle,
+        outputs: &[ResizingImageBundle],
+    ) -> Result<Descriptors, TranscoderError> {
+        let image_info_input_y = vk::DescriptorImageInfo::default()
+            .image_view(input.view_y.view)
+            .image_layout(vk::ImageLayout::GENERAL);
+        let image_info_input_uv = vk::DescriptorImageInfo::default()
+            .image_view(input.view_uv.view)
+            .image_layout(vk::ImageLayout::GENERAL);
+
+        let (image_infos_output_y, image_infos_output_uv) = outputs
+            .iter()
+            .map(|bundle| {
+                (
+                    vk::DescriptorImageInfo::default()
+                        .image_layout(vk::ImageLayout::GENERAL)
+                        .image_view(bundle.view_y.view),
+                    vk::DescriptorImageInfo::default()
+                        .image_layout(vk::ImageLayout::GENERAL)
+                        .image_view(bundle.view_uv.view),
+                )
+            })
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        let descriptors = self.descriptor_heap.allocate()?;
+
+        let writes = [
+            (
+                descriptors.input.descriptor_set,
+                std::slice::from_ref(&image_info_input_y),
+                0,
+            ),
+            (
+                descriptors.input.descriptor_set,
+                std::slice::from_ref(&image_info_input_uv),
+                1,
+            ),
+            (
+                descriptors.output_y.descriptor_set,
+                &image_infos_output_y,
+                0,
+            ),
+            (
+                descriptors.output_uv.descriptor_set,
+                &image_infos_output_uv,
+                0,
+            ),
+        ]
+        .into_iter()
+        .map(|(descriptor_set, image_infos, binding)| {
+            vk::WriteDescriptorSet::default()
+                .dst_set(descriptor_set)
+                .dst_binding(binding)
+                .dst_array_element(0)
+                .descriptor_count(image_infos.len() as u32)
+                .descriptor_type(vk::DescriptorType::STORAGE_IMAGE)
+                .image_info(image_infos)
+        })
+        .collect::<Vec<_>>();
+        unsafe { self.device.device.update_descriptor_sets(&writes, &[]) };
+
+        Ok(descriptors)
+    }
+
+    pub(crate) fn run(
+        &mut self,
+        input_submission: &mut DecodeSubmission,
+        encoder_trackers: &mut [&mut EncoderTracker],
+    ) -> Result<ResizeSubmission, TranscoderError> {
+        let input = ResizingImageBundle::new(
+            input_submission.decode_result.frame.image.clone(),
+            input_submission.decode_result.frame.layer,
+        )?;
+        let outputs = self.image_heap.allocate(encoder_trackers)?;
+        let descriptors = self.write_descriptors(&input, &outputs)?;
+
+        let mut buffer = self.buffer_pool.begin_buffer()?;
+        self.device
+            .device
+            .set_label(buffer.buffer(), Some("resize pipeline buffer"))?;
+
+        input.image.transition_layout_single_layer(
+            &mut buffer,
+            vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::COMPUTE_SHADER,
+            vk::AccessFlags2::NONE..vk::AccessFlags2::SHADER_STORAGE_READ,
+            vk::ImageLayout::GENERAL,
+            input_submission.decode_result.frame.layer,
+        )?;
+        for bundle in outputs.iter() {
+            bundle.image.transition_layout_single_layer(
+                &mut buffer,
+                vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::COMPUTE_SHADER,
+                vk::AccessFlags2::NONE..vk::AccessFlags2::SHADER_STORAGE_WRITE,
+                vk::ImageLayout::GENERAL,
+                0,
+            )?;
+        }
+
+        let dispatch_size = outputs
+            .iter()
+            .map(|ResizingImageBundle { image, .. }| {
+                (image.extent.width.next_multiple_of(16) * image.extent.height.next_multiple_of(16))
+                    .div_ceil(256)
+            })
+            .sum::<u32>();
+
+        unsafe {
+            self.device.device.cmd_bind_pipeline(
+                buffer.buffer(),
+                vk::PipelineBindPoint::COMPUTE,
+                self.pipeline.pipeline,
+            );
+            self.device.device.cmd_bind_descriptor_sets(
+                buffer.buffer(),
+                vk::PipelineBindPoint::COMPUTE,
+                self.pipeline.layout.layout,
+                0,
+                &[
+                    descriptors.input.descriptor_set,
+                    descriptors.output_y.descriptor_set,
+                    descriptors.output_uv.descriptor_set,
+                ],
+                &[],
+            );
+            self.device.device.cmd_push_constants(
+                buffer.buffer(),
+                self.pipeline.layout.layout,
+                vk::ShaderStageFlags::COMPUTE,
+                0,
+                &(outputs.len() as u32).to_ne_bytes(),
+            );
+            self.device
+                .device
+                .cmd_dispatch(buffer.buffer(), dispatch_size, 1, 1);
+        }
+
+        let buffer = buffer.end()?;
+        let buffer_info = vk::CommandBufferSubmitInfo::default().command_buffer(buffer.buffer());
+
+        let encoder_semaphore_submit_infos = encoder_trackers
+            .iter_mut()
+            .map(|tracker| {
+                tracker
+                    .semaphore_tracker
+                    .next_submit_info(EncoderTrackerWaitState::ResizeInput)
+            })
+            .collect::<Vec<_>>();
+
+        let mut signals = encoder_semaphore_submit_infos
+            .iter()
+            .map(|c| c.signal_info(vk::PipelineStageFlags2::ALL_COMMANDS))
+            .collect::<Vec<_>>();
+        let mut waits = encoder_semaphore_submit_infos
+            .iter()
+            .flat_map(|c| c.wait_info(vk::PipelineStageFlags2::ALL_COMMANDS))
+            .collect::<Vec<_>>();
+
+        let decoder_semaphore_submit_info = input_submission
+            .decoder
+            .tracker
+            .semaphore_tracker
+            .next_submit_info(DecoderTrackerWaitState::ExternalProcessing);
+
+        if let Some(wait) =
+            decoder_semaphore_submit_info.wait_info(vk::PipelineStageFlags2::ALL_COMMANDS)
+        {
+            waits.push(wait);
+        }
+
+        signals
+            .push(decoder_semaphore_submit_info.signal_info(vk::PipelineStageFlags2::ALL_COMMANDS));
+
+        let submit_info = vk::SubmitInfo2::default()
+            .command_buffer_infos(std::slice::from_ref(&buffer_info))
+            .wait_semaphore_infos(&waits)
+            .signal_semaphore_infos(&signals);
+
+        unsafe {
+            self.device.device.queue_submit2(
+                *self.device.queues.wgpu.queue.lock().unwrap(),
+                &[submit_info],
+                vk::Fence::null(),
+            )?;
+        }
+
+        buffer.mark_submitted(input_submission.semaphore_wait_value);
+        for semaphore_submit_info in encoder_semaphore_submit_infos {
+            semaphore_submit_info.mark_submitted();
+        }
+
+        decoder_semaphore_submit_info.mark_submitted();
+
+        Ok(ResizeSubmission {
+            outputs,
+            _input: input,
+            descriptors,
+        })
+    }
+
+    pub(crate) fn mark_command_buffers_completed(&self, decoder_wait_value: SemaphoreWaitValue) {
+        self.buffer_pool.mark_submitted_as_free(decoder_wait_value);
+    }
+}

--- a/vk-video/src/vulkan_transcoder/shader.wgsl
+++ b/vk-video/src/vulkan_transcoder/shader.wgsl
@@ -1,0 +1,48 @@
+@group(0) @binding(0) var source_y: texture_storage_2d<r8unorm, read>;
+@group(0) @binding(1) var source_uv: texture_storage_2d<rg8unorm, read>;
+
+@group(1) @binding(0) var dest_y: binding_array<texture_storage_2d<r8unorm, write>, 8>;
+@group(2) @binding(0) var dest_uv: binding_array<texture_storage_2d<rg8unorm, write>, 8>;
+
+var<immediate> output_number: u32;
+
+@compute
+@workgroup_size(256)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  var remaining_offset: u32 = id.x;
+  var i: u32 = 0;
+  for ( ; i < output_number; i++ ) {
+    let size = textureDimensions(dest_y[i]);
+    let total_size = (size.x * size.y + 255) / 256 * 256;
+    if (remaining_offset < total_size) {
+      break;
+    }
+
+    remaining_offset -= total_size;
+  }
+
+  if i >= output_number {
+    return;
+  }
+
+  let size = textureDimensions(dest_y[i]);
+  let y = remaining_offset / size.x;
+  let x = remaining_offset % size.x;
+  let coords_output = vec2(x, y);
+
+  if y >= size.y {
+    return;
+  }
+
+  let float_coords = (vec2<f32>(coords_output) + 0.5) / vec2<f32>(size);
+  let input_size = textureDimensions(source_y);
+  let coords_input = vec2<u32>(vec2<f32>(input_size) * float_coords);
+
+  let input_y = textureLoad(source_y, coords_input);
+  textureStore(dest_y[i], coords_output, input_y);
+
+  if (x % 2 == 0 && y % 2 == 0) {
+    let input_uv = textureLoad(source_uv, coords_input / 2);
+    textureStore(dest_uv[i], coords_output / 2, input_uv);
+  }
+}

--- a/vk-video/src/vulkan_video.rs
+++ b/vk-video/src/vulkan_video.rs
@@ -121,7 +121,7 @@ pub enum VulkanCommonError {
     #[error("DPB can have at most 32 slots, {0} was requested")]
     DpbTooLong(u32),
 
-    #[error("Tried to waits for an unsignaled semaphore value")]
+    #[error("Tried to wait for an unsignaled semaphore value")]
     SemaphoreWaitOnUnsignaledValue,
 
     #[error("Tried to register {0:x?} as a new image, while it already exists")]
@@ -132,6 +132,9 @@ pub enum VulkanCommonError {
 
     #[error("Tried to unregister image {0:x?} that was not registered")]
     UnregisteredNonexistentImage(ImageKey),
+
+    #[error("Unsupported image aspect: {0:?}")]
+    UnsupportedImageAspect(vk::ImageAspectFlags),
 }
 
 /// Represents a chunk of encoded video data used for decoding.

--- a/vk-video/src/wrappers.rs
+++ b/vk-video/src/wrappers.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use ash::Entry;
+use ash::{Entry, vk};
 
 mod command;
 mod debug;
 mod mem;
 mod parameter_sets;
+mod pipeline;
 mod sync;
 mod video;
 mod vk_extensions;
@@ -14,9 +15,12 @@ pub(crate) use command::*;
 pub(crate) use debug::*;
 pub(crate) use mem::*;
 pub(crate) use parameter_sets::*;
+pub(crate) use pipeline::*;
 pub(crate) use sync::*;
 pub(crate) use video::*;
 pub(crate) use vk_extensions::*;
+
+use crate::VulkanCommonError;
 
 pub(crate) struct Instance {
     pub(crate) instance: ash::Instance,
@@ -45,7 +49,53 @@ pub(crate) struct Device {
     pub(crate) video_queue_ext: ash::khr::video_queue::Device,
     pub(crate) video_decode_queue_ext: ash::khr::video_decode_queue::Device,
     pub(crate) video_encode_queue_ext: ash::khr::video_encode_queue::Device,
+    #[cfg(feature = "vk_validation")]
+    pub(crate) debug_utils_ext: ash::ext::debug_utils::Device,
     pub(crate) _instance: Arc<Instance>,
+}
+
+impl Device {
+    #[cfg(feature = "vk_validation")]
+    pub(crate) fn set_label<T: vk::Handle>(
+        &self,
+        object: T,
+        label: Option<&str>,
+    ) -> Result<(), VulkanCommonError> {
+        use std::ffi::CStr;
+
+        if let Some(label) = label {
+            let mut text = [0; 64];
+            let mut long_text = Vec::new();
+
+            let label = if label.len() < text.len() {
+                text[..label.len()].copy_from_slice(label.as_bytes());
+                CStr::from_bytes_until_nul(&text).unwrap()
+            } else {
+                long_text.extend_from_slice(label.as_bytes());
+                long_text.push(0);
+                CStr::from_bytes_until_nul(&long_text).unwrap()
+            };
+
+            unsafe {
+                self.debug_utils_ext.set_debug_utils_object_name(
+                    &vk::DebugUtilsObjectNameInfoEXT::default()
+                        .object_handle(object)
+                        .object_name(label),
+                )?
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(feature = "vk_validation"))]
+    pub(crate) fn set_label<T: vk::Handle>(
+        &self,
+        _object: T,
+        _label: Option<&str>,
+    ) -> Result<(), VulkanCommonError> {
+        Ok(())
+    }
 }
 
 impl std::ops::Deref for Device {

--- a/vk-video/src/wrappers/command.rs
+++ b/vk-video/src/wrappers/command.rs
@@ -127,7 +127,7 @@ impl CommandBufferPool {
             .enumerate()
             .filter(|(_, b)| b.semaphore_value <= last_waited_semaphore)
             .map(|(i, _)| i)
-            .last()
+            .next_back()
         else {
             return;
         };
@@ -138,10 +138,15 @@ impl CommandBufferPool {
     }
 }
 
+struct ImageLayoutChange {
+    tracker: Arc<Mutex<ImageLayoutTracker>>,
+    new_layout: Box<[vk::ImageLayout]>,
+}
+
 struct UnfinishedCommandBuffer {
     buffer: vk::CommandBuffer,
     pool: Arc<Mutex<CommandBufferPoolInner>>,
-    image_layout_transitions: FxHashMap<ImageKey, Box<[vk::ImageLayout]>>,
+    image_layout_transitions: FxHashMap<ImageKey, ImageLayoutChange>,
     reset_on_drop: bool,
 }
 
@@ -202,19 +207,24 @@ impl OpenCommandBuffer {
     pub(crate) fn image_layout(
         &mut self,
         image: ImageKey,
-        tracker: &ImageLayoutTracker,
+        tracker: &Arc<Mutex<ImageLayoutTracker>>,
     ) -> Result<&mut [vk::ImageLayout], VulkanCommonError> {
         let entry = self.0.image_layout_transitions.entry(image);
 
         match entry {
-            Entry::Occupied(entry) => Ok(entry.into_mut()),
-            Entry::Vacant(entry) => Ok(entry.insert(
-                tracker
-                    .map
-                    .get(&image)
-                    .ok_or(VulkanCommonError::TriedToAccessNonexistentImageState(image))?
-                    .clone(),
-            )),
+            Entry::Occupied(entry) => Ok(&mut entry.into_mut().new_layout),
+            Entry::Vacant(entry) => Ok(&mut entry
+                .insert(ImageLayoutChange {
+                    tracker: tracker.clone(),
+                    new_layout: tracker
+                        .lock()
+                        .unwrap()
+                        .map
+                        .get(&image)
+                        .ok_or(VulkanCommonError::TriedToAccessNonexistentImageState(image))?
+                        .clone(),
+                })
+                .new_layout),
         }
     }
 }
@@ -222,7 +232,7 @@ impl OpenCommandBuffer {
 pub(crate) struct RecordedCommandBuffer(UnfinishedCommandBuffer);
 
 impl RecordedCommandBuffer {
-    pub(crate) fn mark_submitted(mut self, tracker: &mut ImageLayoutTracker, semaphore_value: SemaphoreWaitValue) {
+    pub(crate) fn mark_submitted(mut self, semaphore_value: SemaphoreWaitValue) {
         self.0
             .pool
             .lock()
@@ -232,7 +242,16 @@ impl RecordedCommandBuffer {
                 semaphore_value,
                 buffer: self.0.buffer,
             });
-        tracker.map.extend(self.0.image_layout_transitions.drain());
+
+        for (key, layout_change) in self.0.image_layout_transitions.drain() {
+            layout_change
+                .tracker
+                .lock()
+                .unwrap()
+                .map
+                .insert(key, layout_change.new_layout);
+        }
+
         self.0.destroy_without_reset();
     }
 

--- a/vk-video/src/wrappers/debug.rs
+++ b/vk-video/src/wrappers/debug.rs
@@ -66,6 +66,14 @@ unsafe extern "system" fn debug_messenger_callback(
         return vk::FALSE;
     }
 
+    // This is an error about creating an image for video coding that has usage flags not
+    // advertised as supported by the GPU. We use this extensively on Nvidia and it works fine.
+    // Thread on Nvidia developer forum: https://forums.developer.nvidia.com/t/vkimagecreateflags-and-vulkan-encode/284369
+    // The VUID for this message is `VUID-VkImageCreateInfo-pNext-06811`.
+    if callback_data.message_id_number == 0x30f4ac70u32 as i32 {
+        return vk::FALSE;
+    }
+
     let message_id = unsafe {
         callback_data
             .message_id_name_as_c_str()

--- a/vk-video/src/wrappers/mem.rs
+++ b/vk-video/src/wrappers/mem.rs
@@ -443,7 +443,7 @@ impl Image {
         subresource_range: vk::ImageSubresourceRange,
     ) -> Result<(), VulkanCommonError> {
         let raw_buffer = command_buffer.buffer();
-        let layout = command_buffer.image_layout(self.key(), &self.tracker.lock().unwrap())?;
+        let layout = command_buffer.image_layout(self.key(), &self.tracker)?;
 
         self.transition_layout_raw(
             raw_buffer,
@@ -480,6 +480,38 @@ impl Image {
 
     pub(crate) fn key(&self) -> ImageKey {
         ImageKey(self.image.as_raw())
+    }
+
+    pub(crate) fn create_plane_view(
+        self: &Arc<Self>,
+        layer: u32,
+        plane: vk::ImageAspectFlags,
+        usage: vk::ImageUsageFlags,
+    ) -> Result<ImageView, VulkanCommonError> {
+        let mut view_usage_info = vk::ImageViewUsageCreateInfo::default().usage(usage);
+
+        let format = match plane {
+            vk::ImageAspectFlags::PLANE_0 => vk::Format::R8_UNORM,
+            vk::ImageAspectFlags::PLANE_1 => vk::Format::R8G8_UNORM,
+            aspect => return Err(VulkanCommonError::UnsupportedImageAspect(aspect)),
+        };
+
+        let view_create_info = vk::ImageViewCreateInfo::default()
+            .flags(vk::ImageViewCreateFlags::empty())
+            .image(self.image)
+            .view_type(vk::ImageViewType::TYPE_2D)
+            .format(format)
+            .components(vk::ComponentMapping::default())
+            .subresource_range(vk::ImageSubresourceRange {
+                aspect_mask: plane,
+                base_array_layer: layer,
+                level_count: 1,
+                base_mip_level: 0,
+                layer_count: 1,
+            })
+            .push_next(&mut view_usage_info);
+
+        ImageView::new(self.device.clone(), self.clone(), &view_create_info)
     }
 }
 

--- a/vk-video/src/wrappers/pipeline.rs
+++ b/vk-video/src/wrappers/pipeline.rs
@@ -1,0 +1,160 @@
+use std::sync::Arc;
+
+use ash::vk;
+
+use crate::VulkanCommonError;
+
+use super::Device;
+
+pub(crate) struct DescriptorSetLayout {
+    device: Arc<Device>,
+    pub(crate) set_layout: vk::DescriptorSetLayout,
+}
+
+impl DescriptorSetLayout {
+    pub(crate) fn new(
+        device: Arc<Device>,
+        create_info: &vk::DescriptorSetLayoutCreateInfo,
+    ) -> Result<Self, VulkanCommonError> {
+        let set_layout = unsafe { device.create_descriptor_set_layout(create_info, None)? };
+
+        Ok(Self { device, set_layout })
+    }
+}
+
+impl Drop for DescriptorSetLayout {
+    fn drop(&mut self) {
+        unsafe {
+            self.device
+                .destroy_descriptor_set_layout(self.set_layout, None)
+        };
+    }
+}
+
+pub(crate) struct DescriptorPool {
+    device: Arc<Device>,
+    pub(crate) pool: vk::DescriptorPool,
+}
+
+impl DescriptorPool {
+    pub(crate) fn new(
+        device: Arc<Device>,
+        create_info: &vk::DescriptorPoolCreateInfo,
+    ) -> Result<Self, VulkanCommonError> {
+        let pool = unsafe { device.create_descriptor_pool(create_info, None)? };
+        Ok(Self { device, pool })
+    }
+}
+
+impl Drop for DescriptorPool {
+    fn drop(&mut self) {
+        unsafe {
+            self.device.destroy_descriptor_pool(self.pool, None);
+        }
+    }
+}
+
+pub(crate) struct DescriptorSet {
+    pub(crate) descriptor_set: vk::DescriptorSet,
+    _pool: Arc<DescriptorPool>,
+}
+
+impl DescriptorSet {
+    pub(crate) fn new(
+        pool: Arc<DescriptorPool>,
+        allocate_info: &vk::DescriptorSetAllocateInfo,
+    ) -> Result<Vec<Self>, VulkanCommonError> {
+        let allocate_info = allocate_info.descriptor_pool(pool.pool);
+        let result = unsafe { pool.device.allocate_descriptor_sets(&allocate_info)? };
+        Ok(result
+            .into_iter()
+            .map(|set| DescriptorSet {
+                descriptor_set: set,
+                _pool: pool.clone(),
+            })
+            .collect())
+    }
+}
+
+pub(crate) struct PipelineLayout {
+    pub(crate) layout: vk::PipelineLayout,
+    device: Arc<Device>,
+    _descriptor_set_layouts: Vec<Arc<DescriptorSetLayout>>,
+}
+
+impl PipelineLayout {
+    pub(crate) fn new(
+        device: Arc<Device>,
+        create_info: &vk::PipelineLayoutCreateInfo,
+        descriptor_set_layouts: Vec<Arc<DescriptorSetLayout>>,
+    ) -> Result<Self, VulkanCommonError> {
+        let layout = unsafe { device.create_pipeline_layout(create_info, None)? };
+
+        Ok(Self {
+            layout,
+            device,
+            _descriptor_set_layouts: descriptor_set_layouts,
+        })
+    }
+}
+
+impl Drop for PipelineLayout {
+    fn drop(&mut self) {
+        unsafe { self.device.destroy_pipeline_layout(self.layout, None) };
+    }
+}
+
+pub(crate) struct ShaderModule {
+    device: Arc<Device>,
+    pub(crate) module: vk::ShaderModule,
+}
+
+impl ShaderModule {
+    pub(crate) fn new(
+        device: Arc<Device>,
+        create_info: &vk::ShaderModuleCreateInfo,
+    ) -> Result<Self, VulkanCommonError> {
+        let module = unsafe { device.create_shader_module(create_info, None)? };
+        Ok(Self { device, module })
+    }
+}
+
+impl Drop for ShaderModule {
+    fn drop(&mut self) {
+        unsafe { self.device.destroy_shader_module(self.module, None) };
+    }
+}
+
+pub(crate) struct ComputePipeline {
+    pub(crate) pipeline: vk::Pipeline,
+    pub(crate) layout: Arc<PipelineLayout>,
+    _shader_module: Arc<ShaderModule>,
+    device: Arc<Device>,
+}
+
+impl ComputePipeline {
+    pub(crate) fn new(
+        device: Arc<Device>,
+        create_info: vk::ComputePipelineCreateInfo,
+        layout: Arc<PipelineLayout>,
+        shader_module: Arc<ShaderModule>,
+    ) -> Result<Self, VulkanCommonError> {
+        let pipeline = unsafe {
+            device.create_compute_pipelines(vk::PipelineCache::null(), &[create_info], None)
+        }
+        .map_err(|(_, e)| e)?[0];
+
+        Ok(Self {
+            pipeline,
+            layout,
+            _shader_module: shader_module,
+            device,
+        })
+    }
+}
+
+impl Drop for ComputePipeline {
+    fn drop(&mut self) {
+        unsafe { self.device.destroy_pipeline(self.pipeline, None) };
+    }
+}

--- a/vk-video/src/wrappers/sync.rs
+++ b/vk-video/src/wrappers/sync.rs
@@ -16,18 +16,27 @@ pub(crate) struct TimelineSemaphore {
 }
 
 impl TimelineSemaphore {
-    pub(crate) fn new(device: Arc<Device>, initial_value: u64) -> Result<Self, VulkanCommonError> {
+    pub(crate) fn new(
+        device: Arc<Device>,
+        initial_value: u64,
+        label: Option<&str>,
+    ) -> Result<Self, VulkanCommonError> {
         let mut create_type_info = vk::SemaphoreTypeCreateInfo::default()
             .semaphore_type(vk::SemaphoreType::TIMELINE)
             .initial_value(initial_value);
         let create_info = vk::SemaphoreCreateInfo::default().push_next(&mut create_type_info);
-
         let semaphore = unsafe { device.create_semaphore(&create_info, None)? };
+
+        device.set_label(semaphore, label)?;
 
         Ok(Self { semaphore, device })
     }
 
-    pub(crate) fn wait(&self, timeout: u64, value: SemaphoreWaitValue) -> Result<(), VulkanCommonError> {
+    pub(crate) fn wait(
+        &self,
+        timeout: u64,
+        value: SemaphoreWaitValue,
+    ) -> Result<(), VulkanCommonError> {
         let wait_info = vk::SemaphoreWaitInfo::default()
             .semaphores(std::slice::from_ref(&self.semaphore))
             .values(std::slice::from_ref(&value.0));
@@ -61,6 +70,17 @@ pub(crate) struct TrackerWait<S> {
     pub(crate) _state: S,
 }
 
+impl<S: Clone> Clone for TrackerWait<S> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value,
+            _state: self._state.clone(),
+        }
+    }
+}
+
+impl<S: Copy> Copy for TrackerWait<S> {}
+
 pub(crate) struct Tracker<K: TrackerKind> {
     pub(crate) semaphore_tracker: SemaphoreTracker<K::WaitState>,
     pub(crate) command_buffer_pools: K::CommandBufferPools,
@@ -71,8 +91,12 @@ impl<K: TrackerKind> Tracker<K> {
     pub(crate) fn new(
         device: Arc<Device>,
         command_buffer_pools: K::CommandBufferPools,
+        label: Option<&str>,
     ) -> Result<Self, VulkanCommonError> {
-        let semaphore_tracker = SemaphoreTracker::new(device)?;
+        let semaphore_tracker = SemaphoreTracker::new(
+            device,
+            label.map(|name| format!("{name} semaphore")).as_deref(),
+        )?;
 
         Ok(Self {
             semaphore_tracker,
@@ -85,16 +109,67 @@ impl<K: TrackerKind> Tracker<K> {
         let waited_for = self.semaphore_tracker.wait_for_all(timeout)?;
 
         if let Some(waited_for) = waited_for {
-            self.command_buffer_pools.mark_submitted_as_free(waited_for);
+            self.mark_waited(waited_for);
         }
 
         Ok(())
     }
 
-    pub(crate) fn wait_for(&mut self, value: SemaphoreWaitValue, timeout: u64) -> Result<(), VulkanCommonError> {
+    pub(crate) fn wait_for(
+        &mut self,
+        value: SemaphoreWaitValue,
+        timeout: u64,
+    ) -> Result<(), VulkanCommonError> {
         self.semaphore_tracker.wait_for(value, timeout)?;
-        self.command_buffer_pools.mark_submitted_as_free(value);
+        self.mark_waited(value);
         Ok(())
+    }
+
+    /// Call this to mark that this value was waited for already
+    pub(crate) fn mark_waited(&mut self, value: SemaphoreWaitValue) {
+        self.command_buffer_pools.mark_submitted_as_free(value);
+    }
+}
+
+pub(crate) struct SemaphoreSubmitInfo<'a, S> {
+    pub(crate) signal: TrackerWait<S>,
+    tracker: &'a mut SemaphoreTracker<S>,
+    wgpu_fence: wgpu::hal::vulkan::Fence,
+}
+
+impl<'a, S> SemaphoreSubmitInfo<'a, S> {
+    pub(crate) fn wait_info(
+        &self,
+        stage: vk::PipelineStageFlags2,
+    ) -> Option<vk::SemaphoreSubmitInfo<'_>> {
+        self.tracker.wait_for.as_ref().map(|w| {
+            vk::SemaphoreSubmitInfo::default()
+                .stage_mask(stage)
+                .value(w.value.0)
+                .semaphore(self.tracker.semaphore.semaphore)
+        })
+    }
+
+    pub(crate) fn wgpu_wait_info(&mut self) -> (&mut wgpu::hal::vulkan::Fence, u64) {
+        (&mut self.wgpu_fence, self.signal.value.0)
+    }
+
+    pub(crate) fn signal_info(
+        &self,
+        stage: vk::PipelineStageFlags2,
+    ) -> vk::SemaphoreSubmitInfo<'_> {
+        vk::SemaphoreSubmitInfo::default()
+            .stage_mask(stage)
+            .value(self.signal.value.0)
+            .semaphore(self.tracker.semaphore.semaphore)
+    }
+
+    pub(crate) fn signal_value(&self) -> SemaphoreWaitValue {
+        self.signal.value
+    }
+
+    pub(crate) fn mark_submitted(self) {
+        self.tracker.wait_for = Some(self.signal);
     }
 }
 
@@ -106,12 +181,12 @@ pub(crate) struct SemaphoreTracker<S> {
 }
 
 impl<S> SemaphoreTracker<S> {
-    pub(crate) fn new(device: Arc<Device>) -> Result<Self, VulkanCommonError> {
+    pub(crate) fn new(device: Arc<Device>, label: Option<&str>) -> Result<Self, VulkanCommonError> {
         Ok(Self {
             next_value: 1,
             wait_for: None,
             last_waited_for: None,
-            semaphore: TimelineSemaphore::new(device, 0)?,
+            semaphore: TimelineSemaphore::new(device, 0, label)?,
         })
     }
 
@@ -121,12 +196,33 @@ impl<S> SemaphoreTracker<S> {
         SemaphoreWaitValue(val)
     }
 
+    pub(crate) fn next_submit_info(&mut self, new_state: S) -> SemaphoreSubmitInfo<'_, S> {
+        let signal = TrackerWait {
+            value: self.next_sem_value(),
+            _state: new_state,
+        };
+
+        SemaphoreSubmitInfo {
+            signal,
+            wgpu_fence: wgpu::hal::vulkan::Fence::TimelineSemaphore(self.semaphore.semaphore),
+            tracker: self,
+        }
+    }
+
     /// This is a noop if there's nothing to wait for
-    pub(crate) fn wait_for_all(&mut self, timeout: u64) -> Result<Option<SemaphoreWaitValue>, VulkanCommonError> {
+    pub(crate) fn wait_for_all(
+        &mut self,
+        timeout: u64,
+    ) -> Result<Option<SemaphoreWaitValue>, VulkanCommonError> {
         if let Some(wait_for) = self.wait_for.as_ref() {
             let waited_for = wait_for.value;
             self.semaphore.wait(timeout, waited_for)?;
             self.wait_for = None;
+
+            match self.last_waited_for {
+                Some(old_value) => self.last_waited_for = Some(old_value.max(waited_for)),
+                None => self.last_waited_for = Some(waited_for),
+            }
 
             return Ok(Some(waited_for));
         }
@@ -134,7 +230,11 @@ impl<S> SemaphoreTracker<S> {
         Ok(None)
     }
 
-    pub(crate) fn wait_for(&mut self, value: SemaphoreWaitValue, timeout: u64) -> Result<(), VulkanCommonError> {
+    pub(crate) fn wait_for(
+        &mut self,
+        value: SemaphoreWaitValue,
+        timeout: u64,
+    ) -> Result<(), VulkanCommonError> {
         if let Some(last) = self.last_waited_for.as_ref()
             && *last >= value
         {

--- a/vk-video/src/wrappers/video.rs
+++ b/vk-video/src/wrappers/video.rs
@@ -390,10 +390,14 @@ impl<'a> CodingImageBundle<'a> {
             }
         }
 
+        let mut image_view_usage_info = vk::ImageViewUsageCreateInfo::default()
+            .usage(image_usage & (!vk::ImageUsageFlags::STORAGE));
+
         let mut image_view_create_info = vk::ImageViewCreateInfo::default()
             .flags(vk::ImageViewCreateFlags::empty())
             .components(vk::ComponentMapping::default())
-            .format(format.format);
+            .format(format.format)
+            .push_next(&mut image_view_usage_info);
 
         let subresource_range = vk::ImageSubresourceRange {
             aspect_mask: vk::ImageAspectFlags::COLOR,
@@ -416,6 +420,12 @@ impl<'a> CodingImageBundle<'a> {
                         image_tracker.clone(),
                     )
                     .map(Arc::new)
+                    .and_then(|i| {
+                        vulkan_ctx
+                            .device
+                            .set_label(i.image, Some("decoding image"))?;
+                        Ok(i)
+                    })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
@@ -463,6 +473,10 @@ impl<'a> CodingImageBundle<'a> {
                 &image_create_info,
                 image_tracker.clone(),
             )?);
+
+            vulkan_ctx
+                .device
+                .set_label(image.image, Some("decoding image"))?;
 
             image_view_create_info = image_view_create_info
                 .image(image.image)


### PR DESCRIPTION
This patch adds transcoders to vk-video and performs a few necessary refactors that were necessary in order to add them.

## Transcoding

Transcoding uses a compute pipeline to convert between resolutions, for now only with nearest-neighbor resampling. The decoder output is immediately resized to all resolutions, and then the resize submission is put into a frame sorter (because the encoder needs images in normal order and decoder produces the decoding order on its own). After the resize submissions come out of the sorter, they're fed to encoders, and only after that we wait on a semaphore for all these operations to terminate.

## Semaphores

Semaphores and semaphore trackers are much easier to use now. Previously, syncing the trackers with anything different than the decoder or encoder they belong to needed many manual operations, where skipping any of them would result in incorrect synchronization. Now, this process is streamlined and supported by the semaphore trackers.

Semaphore operations now also return a wait value. The wait value is a way to wait for a specific submit to finish, rather than waiting for all of them every time we do a wait.

## Submissions

Both encoders and decoders return submissions when operations are submitted. The submissions expose an API that allows waiting for them and downloading their result. They also borrow their corresponding encoder or decoder to make sure they don't outlive them. Also the structure of the submissions was cleaned up a lot, reducing redundant fields and member structs. 