### PR TITLE
[vk-video] Add a possibility to not embed parameters in the stream

### DIFF
--- a/vk-video/CHANGELOG.md
+++ b/vk-video/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 💥 Breaking changes
+- `EncoderParameters` has an extra field, which determines whether stream parameters are inlined in the output stream.
 
 ### ✨ New features
 - One-to-many transcoders via `VulkanDevice::create_transcoder`

--- a/vk-video/src/device.rs
+++ b/vk-video/src/device.rs
@@ -123,6 +123,11 @@ pub struct EncoderParameters {
     ///
     /// Multiple flags can be combined using the `|` operator to indicate multiple usages.
     pub content_flags: Option<EncoderContentFlags>,
+
+    /// Whether to prepend SPS/PPS NAL units inline before IDR frames.
+    /// If `false`, SPS/PPS can be retrieved separately using methods defined on the encoder.
+    /// If [`None`], defaults to `true`.
+    pub inline_stream_params: Option<bool>,
 }
 
 /// Open connection to a coding-capable device. Also contains a [`wgpu::Device`], a [`wgpu::Queue`] and
@@ -487,6 +492,7 @@ impl VulkanDevice {
             usage_flags: Some(EncoderUsageFlags::DEFAULT),
             content_flags: Some(EncoderContentFlags::DEFAULT),
             tuning_mode: Some(EncoderTuningMode::LOW_LATENCY),
+            inline_stream_params: None,
         })
     }
 
@@ -514,6 +520,7 @@ impl VulkanDevice {
             usage_flags: Some(EncoderUsageFlags::DEFAULT),
             content_flags: Some(EncoderContentFlags::DEFAULT),
             tuning_mode: Some(EncoderTuningMode::HIGH_QUALITY),
+            inline_stream_params: None,
         })
     }
 
@@ -673,6 +680,7 @@ impl VulkanDevice {
             usage_flags,
             tuning_mode,
             content_flags,
+            inline_stream_params: encoder_parameters.inline_stream_params.unwrap_or(true),
         })
     }
 

--- a/vk-video/src/vulkan_encoder.rs
+++ b/vk-video/src/vulkan_encoder.rs
@@ -388,6 +388,7 @@ pub struct VulkanEncoder<'a> {
     pic_order_cnt: u8,
     active_reference_slots: VecDeque<(usize, vk::native::StdVideoEncodeH264ReferenceInfo)>,
     rate_control: RateControl,
+    inline_stream_params: bool,
     encoding_device: Arc<EncodingDevice>,
 }
 
@@ -404,6 +405,7 @@ pub struct FullEncoderParameters {
     pub(crate) usage_flags: vk::VideoEncodeUsageFlagsKHR,
     pub(crate) tuning_mode: vk::VideoEncodeTuningModeKHR,
     pub(crate) content_flags: vk::VideoEncodeContentFlagsKHR,
+    pub(crate) inline_stream_params: bool,
 }
 
 impl<'a> VulkanEncoder<'a> {
@@ -494,6 +496,7 @@ impl<'a> VulkanEncoder<'a> {
             idr_period: parameters.idr_period.get(),
             output_buffer,
             rate_control: parameters.rate_control,
+            inline_stream_params: parameters.inline_stream_params,
         })
     }
 
@@ -1213,24 +1216,8 @@ impl<'a> VulkanEncoder<'a> {
             return Err(VulkanEncoderError::EncodeOperationFailed(feedback.status));
         }
 
-        let mut output = if is_idr {
-            let mut h264_get_info = vk::VideoEncodeH264SessionParametersGetInfoKHR::default()
-                .write_std_sps(true)
-                .write_std_pps(true)
-                .std_sps_id(0)
-                .std_pps_id(0);
-
-            let get_info = vk::VideoEncodeSessionParametersGetInfoKHR::default()
-                .video_session_parameters(self.session_resources.parameters.parameters)
-                .push_next(&mut h264_get_info);
-
-            unsafe {
-                self.encoding_device
-                    .vulkan_device
-                    .device
-                    .video_encode_queue_ext
-                    .get_encoded_video_session_parameters_khr(&get_info, None)?
-            }
+        let mut output = if is_idr && self.inline_stream_params {
+            self.stream_parameters(true, true)?
         } else {
             Vec::new()
         };
@@ -1247,6 +1234,36 @@ impl<'a> VulkanEncoder<'a> {
             pts,
             is_keyframe: is_idr,
         })
+    }
+
+    pub fn stream_parameters(
+        &self,
+        write_sps: bool,
+        write_pps: bool,
+    ) -> Result<Vec<u8>, VulkanEncoderError> {
+        if !write_sps && !write_pps {
+            return Ok(Vec::new());
+        }
+
+        let mut h264_get_info = vk::VideoEncodeH264SessionParametersGetInfoKHR::default()
+            .write_std_sps(write_sps)
+            .write_std_pps(write_pps)
+            .std_sps_id(0)
+            .std_pps_id(0);
+
+        let get_info = vk::VideoEncodeSessionParametersGetInfoKHR::default()
+            .video_session_parameters(self.session_resources.parameters.parameters)
+            .push_next(&mut h264_get_info);
+
+        let data = unsafe {
+            self.encoding_device
+                .vulkan_device
+                .device
+                .video_encode_queue_ext
+                .get_encoded_video_session_parameters_khr(&get_info, None)?
+        };
+
+        Ok(data)
     }
 
     pub fn encode_bytes(

--- a/vk-video/src/vulkan_video.rs
+++ b/vk-video/src/vulkan_video.rs
@@ -286,6 +286,22 @@ impl BytesEncoder {
     ) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
         self.vulkan_encoder.encode_bytes(frame, force_keyframe)
     }
+
+    /// Retrieve encoded SPS NAL units from the video session parameters, in Annex B.
+    ///
+    /// Useful when `inline_stream_params` is `false` and the parameters need to be
+    /// sent out-of-band (e.g. in RTMP or MP4 headers).
+    pub fn sps(&self) -> Result<Vec<u8>, VulkanEncoderError> {
+        self.vulkan_encoder.stream_parameters(true, false)
+    }
+
+    /// Retrieve encoded PPS NAL units from the video session parameters, in Annex B.
+    ///
+    /// Useful when `inline_stream_params` is `false` and the parameters need to be
+    /// sent out-of-band (e.g. in RTMP or MP4 headers).
+    pub fn pps(&self) -> Result<Vec<u8>, VulkanEncoderError> {
+        self.vulkan_encoder.stream_parameters(false, true)
+    }
 }
 
 /// An encoder that takes input frames as [`wgpu::Texture`]s (in [`wgpu::TextureFormat::NV12`])
@@ -342,5 +358,21 @@ impl WgpuTexturesEncoder {
         force_keyframe: bool,
     ) -> Result<EncodedOutputChunk<Vec<u8>>, VulkanEncoderError> {
         unsafe { self.vulkan_encoder.encode_texture(frame, force_keyframe) }
+    }
+
+    /// Retrieve encoded SPS NAL units from the video session parameters, in Annex B.
+    ///
+    /// Useful when `inline_stream_params` is `false` and the parameters need to be
+    /// sent out-of-band (e.g. in RTMP or MP4 headers).
+    pub fn sps(&self) -> Result<Vec<u8>, VulkanEncoderError> {
+        self.vulkan_encoder.stream_parameters(true, false)
+    }
+
+    /// Retrieve encoded PPS NAL units from the video session parameters, in Annex B.
+    ///
+    /// Useful when `inline_stream_params` is `false` and the parameters need to be
+    /// sent out-of-band (e.g. in RTMP or MP4 headers).
+    pub fn pps(&self) -> Result<Vec<u8>, VulkanEncoderError> {
+        self.vulkan_encoder.stream_parameters(false, true)
     }
 }


### PR DESCRIPTION
This patch adds an option to the encoder to not embed parameters in the output stream, and a way to request the encoder to provide just the parameters to facilitate transferring them out-of-bound