### PR TITLE
Lanczos3 mipmap cache

### DIFF
--- a/smelter-render/src/transformations/layout.rs
+++ b/smelter-render/src/transformations/layout.rs
@@ -25,6 +25,7 @@ pub(crate) trait LayoutProvider: Send {
 pub(crate) struct LayoutNode {
     layout_provider: Box<dyn LayoutProvider>,
     shader: Arc<LayoutShader>,
+    mip_cache: HashMap<usize, crate::wgpu::utils::MippedTexture>,
 }
 
 /// When rendering we cut this fragment from texture and stretch it on
@@ -155,6 +156,7 @@ impl LayoutNode {
         Self {
             layout_provider,
             shader,
+            mip_cache: HashMap::new(),
         }
     }
 
@@ -184,9 +186,7 @@ impl LayoutNode {
         };
 
         // Apply global filter and compute mip levels for Lanczos3 child nodes.
-        // Only apply to sources that actually have texture data — ended inputs
-        // fall back to a 1x1 empty texture where Lanczos3 would sample
-        // non-existent mip levels.
+        // Only apply to sources that actually have texture data
         let mut mip_levels_needed: HashMap<usize, u32> = HashMap::new();
         for layout in &mut layouts {
             let layout_width = layout.width;
@@ -221,7 +221,6 @@ impl LayoutNode {
             }
         }
 
-        // Generate mipped textures for sources that need them
         let mut encoder =
             ctx.wgpu_ctx
                 .device
@@ -230,11 +229,13 @@ impl LayoutNode {
                 });
 
         let format = ctx.wgpu_ctx.default_view_format();
+        // Generate mipped textures for sources that need them
         let mut mipped_textures: HashMap<usize, crate::wgpu::utils::MippedTexture> = HashMap::new();
         for (source_index, max_level) in &mip_levels_needed {
             if let Some(node_texture) = sources.get(*source_index)
                 && let Some(state) = node_texture.state()
             {
+                let existing = self.mip_cache.remove(source_index);
                 let mipped = ctx.wgpu_ctx.utils.mipmap_generator.generate(
                     &mut encoder,
                     ctx.wgpu_ctx,
@@ -242,12 +243,12 @@ impl LayoutNode {
                     format,
                     // +1 because max_level is 0-indexed but generate expects a count
                     *max_level + 1,
+                    existing,
                 );
                 mipped_textures.insert(*source_index, mipped);
             }
         }
 
-        // Resolve texture views: one per layout entry
         let resolved_views: Vec<&wgpu::TextureView> = layouts
             .iter()
             .map(|layout| match &layout.content {
@@ -288,6 +289,8 @@ impl LayoutNode {
         );
 
         ctx.wgpu_ctx.queue.submit(Some(encoder.finish()));
+
+        self.mip_cache = mipped_textures;
     }
 }
 

--- a/smelter-render/src/wgpu/utils/mipmap_generator.rs
+++ b/smelter-render/src/wgpu/utils/mipmap_generator.rs
@@ -20,7 +20,7 @@ pub struct MipMapGenerator {
 }
 
 impl MipMapGenerator {
-    pub fn new(device: &wgpu::Device) -> Self {
+    pub(crate) fn new(device: &wgpu::Device) -> Self {
         let shader_module = device.create_shader_module(wgpu::include_wgsl!("mipmap_blit.wgsl"));
 
         let single_texture_layout =
@@ -107,37 +107,49 @@ impl MipMapGenerator {
         })
     }
 
-    /// Generate mipmaps for `source`. Encodes all blit passes into `encoder`.
-    /// Returns a `MippedTexture` with a full mip chain.
-    pub fn generate(
+    /// Generate mipmaps for `source`, reusing `existing` if its dimensions, format,
+    /// and mip count match. Otherwise allocates a new texture.
+    pub(crate) fn generate(
         &self,
         encoder: &mut wgpu::CommandEncoder,
         ctx: &WgpuCtx,
         source: &wgpu::Texture,
         format: wgpu::TextureFormat,
         max_levels: u32,
+        existing: Option<MippedTexture>,
     ) -> MippedTexture {
         let w = source.width();
         let h = source.height();
         let max_possible = (w.max(h) as f32).log2().floor() as u32 + 1;
         let mip_count = max_levels.clamp(1, max_possible);
 
-        let mipped_texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("MipMapGenerator mipped texture"),
-            size: wgpu::Extent3d {
-                width: w,
-                height: h,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: mip_count,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::COPY_DST,
-            view_formats: &[],
+        let can_reuse = existing.as_ref().is_some_and(|e| {
+            e.texture.width() == w
+                && e.texture.height() == h
+                && e.mip_count == mip_count
+                && e.texture.format() == format
         });
+
+        let mipped_texture = if can_reuse {
+            existing.unwrap().texture
+        } else {
+            ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("MipMapGenerator mipped texture"),
+                size: wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: mip_count,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            })
+        };
 
         // Copy source mip 0 → mipped mip 0
         encoder.copy_texture_to_texture(


### PR DESCRIPTION
A very simple cache for textures with mipmaps, to avoid allocating them each frame.