### PR TITLE
`MP4` better `elst` offset handling.

### DIFF
--- a/smelter-core/src/pipeline/mp4/mp4_input.rs
+++ b/smelter-core/src/pipeline/mp4/mp4_input.rs
@@ -459,6 +459,7 @@ impl TrackThread {
     fn run_video_thread(mut self) -> TrackThreadResult {
         let mut last_pts = self.offset;
         for (mut chunk, duration) in self.track.chunks(self.seek) {
+            chunk.pts += self.offset;
             chunk.dts = chunk.dts.map(|dts| dts + self.offset);
             last_pts = Duration::max(last_pts, chunk.pts + duration);
 
@@ -495,6 +496,7 @@ impl TrackThread {
     fn run_audio_thread(mut self) -> TrackThreadResult {
         let mut last_pts = self.offset;
         for (mut chunk, duration) in self.track.chunks(self.seek) {
+            chunk.pts += self.offset;
             chunk.dts = chunk.dts.map(|dts| dts + self.offset);
             last_pts = Duration::max(last_pts, chunk.pts + duration);
 
@@ -507,10 +509,10 @@ impl TrackThread {
             self.ctx.buffer.recalculate_buffer(chunk.pts);
             chunk.pts += self.ctx.buffer.size();
 
-            trace!(pts=?chunk.pts, "MP4 reader produced a audio chunk.");
+            trace!(pts=?chunk.pts, "MP4 reader produced an audio chunk.");
             let chunk_sender = &self.ctx.decoder_handle.chunk_sender;
             if chunk_sender.send(PipelineEvent::Data(chunk)).is_err() {
-                debug!("Failed to send a audio chunk. Channel closed.");
+                debug!("Failed to send an audio chunk. Channel closed.");
                 break;
             }
 

--- a/smelter-core/src/pipeline/mp4/mp4_input.rs
+++ b/smelter-core/src/pipeline/mp4/mp4_input.rs
@@ -459,7 +459,6 @@ impl TrackThread {
     fn run_video_thread(mut self) -> TrackThreadResult {
         let mut last_pts = self.offset;
         for (mut chunk, duration) in self.track.chunks(self.seek) {
-            chunk.pts += self.offset;
             chunk.dts = chunk.dts.map(|dts| dts + self.offset);
             last_pts = Duration::max(last_pts, chunk.pts + duration);
 
@@ -496,7 +495,6 @@ impl TrackThread {
     fn run_audio_thread(mut self) -> TrackThreadResult {
         let mut last_pts = self.offset;
         for (mut chunk, duration) in self.track.chunks(self.seek) {
-            chunk.pts += self.offset;
             chunk.dts = chunk.dts.map(|dts| dts + self.offset);
             last_pts = Duration::max(last_pts, chunk.pts + duration);
 

--- a/smelter-core/src/pipeline/mp4/reader.rs
+++ b/smelter-core/src/pipeline/mp4/reader.rs
@@ -132,7 +132,7 @@ impl<Reader: Read + Seek + Send + 'static> Mp4FileReader<Reader> {
         match first_elst {
             Some(elst) => {
                 if elst.media_time == u32::MAX as u64 {
-                    // most likely the result of overflowing -1
+                    // The result of overflowing -1,
                     // it signifies empty edit
                     return Duration::ZERO;
                 }
@@ -155,22 +155,24 @@ pub(crate) struct Track<Reader: Read + Seek + Send + 'static> {
 
 impl<Reader: Read + Seek + Send + 'static> Track<Reader> {
     pub(crate) fn chunks(&mut self, seek: Option<Duration>) -> TrackChunks<'_, Reader> {
-        if let Some(seek) = seek
-            && let Some((start_index, present_index)) = self.find_seek_start_sample(seek)
-        {
-            TrackChunks {
+        let seek = match seek {
+            Some(seek) => seek + self.offset,
+            None => self.offset,
+        };
+
+        match self.find_seek_start_sample(seek) {
+            Some((start_index, present_index)) => TrackChunks {
                 track: self,
                 seek,
                 next_sample_index: start_index,
                 present_from_index: present_index,
-            }
-        } else {
-            TrackChunks {
+            },
+            None => TrackChunks {
                 track: self,
                 seek: Duration::ZERO,
                 next_sample_index: 1,
                 present_from_index: 1,
-            }
+            },
         }
     }
 
@@ -191,8 +193,7 @@ impl<Reader: Read + Seek + Send + 'static> Track<Reader> {
     /// `present_from_index` is the first sample at or after seek.
     /// Returns `None` if seek is past the end.
     fn find_seek_start_sample(&self, seek: Duration) -> Option<(u32, u32)> {
-        let seek_timestamp =
-            (seek.saturating_sub(self.offset).as_secs_f64() * self.timescale as f64) as u64;
+        let seek_timestamp = (seek.as_secs_f64() * self.timescale as f64) as u64;
         let track = &self.reader.tracks()[&self.track_id];
 
         // The STTS box maps samples to batches of samples with the same length
@@ -289,7 +290,6 @@ impl<Reader: Read + Seek + Send + 'static> TrackChunks<'_, Reader> {
         let pts = Duration::from_secs_f64(
             (start_time as f64 + rendering_offset as f64) / self.track.timescale as f64,
         )
-        .saturating_sub(self.track.offset)
         .saturating_sub(self.seek);
 
         // When seeking in video, we start reading from the nearest sync (keyframe)

--- a/smelter-core/src/pipeline/mp4/reader.rs
+++ b/smelter-core/src/pipeline/mp4/reader.rs
@@ -132,8 +132,7 @@ impl<Reader: Read + Seek + Send + 'static> Mp4FileReader<Reader> {
         match first_elst {
             Some(elst) => {
                 if elst.media_time == u32::MAX as u64 {
-                    // The result of overflowing -1,
-                    // it signifies empty edit
+                    // The result of overflowing -1, it signifies empty edit
                     return Duration::ZERO;
                 }
                 Duration::from_secs_f64(elst.media_time as f64 / track.timescale() as f64)
@@ -212,7 +211,7 @@ impl<Reader: Read + Seek + Send + 'static> Track<Reader> {
                 let samples_remaining =
                     duration_remaining.div_ceil(entry.sample_delta as u64) as u32;
 
-                present_from_index = Some(samples_remaining + samples_skipped);
+                present_from_index = Some(samples_remaining + samples_skipped + 1);
                 break;
             }
 


### PR DESCRIPTION
- New snapshots: https://github.com/smelter-labs/smelter-snapshot-tests/pull/79

---

Offset calculation and move is now performed using the Seek function. This way frames that will not be displayed are not pushed to decoder.