### PR TITLE
Expose video encoder info on registered outputs

### DIFF
--- a/integration-tests/examples/encoded_channel_output.rs
+++ b/integration-tests/examples/encoded_channel_output.rs
@@ -92,7 +92,7 @@ fn main() {
 
     Pipeline::register_input(&state.pipeline().unwrap(), input_id.clone(), input_options).unwrap();
 
-    let output_receiver = Pipeline::register_encoded_data_output(
+    let output = Pipeline::register_encoded_data_output(
         &state.pipeline().unwrap(),
         output_id.clone(),
         output_options,
@@ -106,7 +106,7 @@ fn main() {
     let mut opus_dump =
         File::create(root_dir.join("examples/encoded_channel_output_dump.opus")).unwrap();
 
-    for (index, chunk) in output_receiver.iter().enumerate() {
+    for (index, chunk) in output.receiver.iter().enumerate() {
         if index > 3000 {
             return;
         }

--- a/integration-tests/src/bin/benchmark/benchmark_pass.rs
+++ b/integration-tests/src/bin/benchmark/benchmark_pass.rs
@@ -210,7 +210,7 @@ impl SingleBenchmarkPass {
                 },
             },
         )?;
-        Ok(Box::new(result))
+        Ok(Box::new(result.receiver))
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -244,7 +244,7 @@ impl SingleBenchmarkPass {
                 },
             },
         )?;
-        Ok(Box::new(result))
+        Ok(Box::new(result.receiver))
     }
 
     fn register_pipeline_raw_output(

--- a/smelter-core/src/output.rs
+++ b/smelter-core/src/output.rs
@@ -1,3 +1,5 @@
+use bytes::Bytes;
+use crossbeam_channel::Receiver;
 use smelter_render::scene::Component;
 
 use crate::prelude::*;
@@ -77,6 +79,24 @@ pub enum PipelineOutputEndCondition {
 #[derive(Debug)]
 pub struct OutputInfo {
     pub protocol: OutputProtocolKind,
+}
+
+#[derive(Debug, Clone)]
+pub struct EncodedDataOutputHandle {
+    pub receiver: Receiver<EncodedOutputEvent>,
+    pub video: Option<VideoEncoderInfo>,
+    pub audio: Option<AudioEncoderInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VideoEncoderInfo {
+    pub resolution: Resolution,
+    pub extradata: Option<Bytes>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AudioEncoderInfo {
+    pub extradata: Option<Bytes>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/smelter-core/src/pipeline/channel/encoded_data_output.rs
+++ b/smelter-core/src/pipeline/channel/encoded_data_output.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crossbeam_channel::{Receiver, bounded};
+use crossbeam_channel::bounded;
 use smelter_render::OutputId;
 
 use crate::{
@@ -36,7 +36,7 @@ impl EncodedDataOutput {
         ctx: Arc<PipelineCtx>,
         output_id: Ref<OutputId>,
         options: EncodedDataOutputOptions,
-    ) -> Result<(Self, Receiver<EncodedOutputEvent>), OutputInitError> {
+    ) -> Result<(Self, EncodedDataOutputHandle), OutputInitError> {
         let (sender, encoded_chunks_receiver) = bounded(1);
         let video = match &options.video {
             Some(video) => match video {
@@ -110,7 +110,17 @@ impl EncodedDataOutput {
             None => None,
         };
 
-        Ok((Self { video, audio }, encoded_chunks_receiver))
+        let handle = EncodedDataOutputHandle {
+            receiver: encoded_chunks_receiver,
+            video: video.as_ref().map(|v| VideoEncoderInfo {
+                resolution: v.config.resolution,
+                extradata: v.config.extradata.clone(),
+            }),
+            audio: audio.as_ref().map(|a| AudioEncoderInfo {
+                extradata: a.config.extradata.clone(),
+            }),
+        };
+        Ok((Self { video, audio }, handle))
     }
 }
 

--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -160,16 +160,16 @@ impl Pipeline {
         pipeline: &Arc<Mutex<Self>>,
         output_id: OutputId,
         register_options: RegisterEncodedDataOutputOptions,
-    ) -> Result<Receiver<EncodedOutputEvent>, RegisterOutputError> {
+    ) -> Result<EncodedDataOutputHandle, RegisterOutputError> {
         register_pipeline_output(
             pipeline,
             output_id,
             register_options.video,
             register_options.audio,
             |ctx, output_ref| {
-                let (output, result) =
+                let (output, handle) =
                     EncodedDataOutput::new(ctx, output_ref, register_options.output_options)?;
-                Ok((Box::new(output), result))
+                Ok((Box::new(output), handle))
             },
         )
     }


### PR DESCRIPTION
Adds `Pipeline::output_video_encoder_info(&output_id) -> Option<VideoEncoderInfo>` so downstream consumers can read the encoder's `resolution` and H.264 `avcC` extradata without re-parsing NAL units from the encoded chunk stream.

Useful for anyone building a custom muxer or transport on top of `register_encoded_data_output`: populate `codec_private` for Matroska/MP4, feed `description` into a browser WebCodecs `VideoDecoder`, or hand `extradata` to an ffmpeg decoder in another process.

Purely additive: one new public method on `Pipeline`, one new public struct `VideoEncoderInfo`, and a default-`None` method on the crate-internal `Output` trait. No existing code needs to change.

Happy to reshape if preferred — alt (B): return a handle struct `{ receiver, video_encoder_info, audio_encoder_info }` from `register_encoded_data_output` (atomic with registration, breaking).
Alt (C): add a `VideoEncoderReady` variant to `EncodedOutputEvent` (async delivery via the existing stream, mildly breaking for exhaustive matches).