### PR TITLE
[libopus] Populate AudioEncoderConfig.extradata with OpusHead

### DIFF
--- a/smelter-core/src/pipeline/encoder/libopus.rs
+++ b/smelter-core/src/pipeline/encoder/libopus.rs
@@ -43,6 +43,13 @@ impl AudioEncoder for OpusEncoder {
         encoder.set_inband_fec(options.forward_error_correction)?;
         encoder.set_packet_loss_perc(options.packet_loss)?;
 
+        // OpusHead pre_skip is in 48 kHz samples (RFC 7845 §4.2) but
+        // `get_lookahead` returns input-rate samples; scale or decoders miss
+        // part of the pre-roll on sub-48 kHz streams. Matches ffmpeg's
+        // `libavcodec/libopusenc.c:100`.
+        let pre_skip = (encoder.get_lookahead()? as u32 * 48_000 / options.sample_rate) as u16;
+        let extradata = opus_head(options.channels, options.sample_rate, pre_skip);
+
         let output_buffer = vec![0u8; 1024 * 1024];
 
         Ok((
@@ -54,7 +61,9 @@ impl AudioEncoder for OpusEncoder {
                 first_input_pts: None,
                 encoded_samples: 0,
             },
-            AudioEncoderConfig { extradata: None },
+            AudioEncoderConfig {
+                extradata: Some(extradata),
+            },
         ))
     }
 
@@ -129,4 +138,21 @@ impl From<OpusEncoderPreset> for opus::Application {
             OpusEncoderPreset::LowestLatency => opus::Application::LowDelay,
         }
     }
+}
+
+// RFC 7845 §5.1 OpusHead (mono/stereo, channel mapping family 0).
+fn opus_head(channels: AudioChannels, sample_rate: u32, pre_skip: u16) -> Bytes {
+    let channel_count: u8 = match channels {
+        AudioChannels::Mono => 1,
+        AudioChannels::Stereo => 2,
+    };
+    let mut buf = [0u8; 19];
+    buf[0..8].copy_from_slice(b"OpusHead");
+    buf[8] = 1;
+    buf[9] = channel_count;
+    buf[10..12].copy_from_slice(&pre_skip.to_le_bytes());
+    buf[12..16].copy_from_slice(&sample_rate.to_le_bytes());
+    buf[16..18].copy_from_slice(&0i16.to_le_bytes());
+    buf[18] = 0;
+    Bytes::copy_from_slice(&buf)
 }


### PR DESCRIPTION
Populates `AudioEncoderConfig.extradata` for libopus with a 19-byte OpusHead (RFC 7845 §5.1), matching what `fdk_aac.rs` does for AAC. Downstream consumers can hand the bytes directly to WebCodecs `AudioDecoder`, a Matroska/MP4 muxer's `codec_private`, or an ffmpeg decoder's `extradata` instead of synthesizing them.

`pre_skip` is scaled to 48 kHz samples from the input-rate value `OPUS_GET_LOOKAHEAD` returns — matching `ffmpeg/libavcodec/libopusenc.c:100`. Without scaling, a sub-48 kHz stream (e.g. 24 kHz) would encode half the correct pre_skip and decoders would bleed through the first ~3 ms of audio.

Purely additive: packet bytes are unchanged.