### PR TITLE
[vk-video] Make sure all nalus contain their start codes

### DIFF
--- a/smelter-core/src/pipeline/utils/h264_au_splitter.rs
+++ b/smelter-core/src/pipeline/utils/h264_au_splitter.rs
@@ -54,19 +54,6 @@ impl H264AuSplitter {
                 }
             };
 
-            // Parser returns nalus which may not start with a start code
-            // but each nalu always ends with the start code of the next nalu,
-            // so we have to make sure that there is a start code in the beginning
-            const START_CODES: [&[u8]; 2] = [&[0, 0, 0, 1], &[0, 0, 1]];
-            if let Some(first_nalu) = au.0.first() {
-                let has_start_code = START_CODES
-                    .iter()
-                    .any(|code| first_nalu.raw_bytes.starts_with(code));
-                if !has_start_code {
-                    data.extend_from_slice(&[0, 0, 1]);
-                }
-            }
-
             for nalu in au.0.iter() {
                 data.extend_from_slice(&nalu.raw_bytes);
             }

--- a/vk-video/CHANGELOG.md
+++ b/vk-video/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 💥 Breaking changes
+- All nalus returned by `H264Parser` now contain their own start codes (`001` or `0001` bytes at the beginning)
 
 ### ✨ New features
 

--- a/vk-video/src/parser.rs
+++ b/vk-video/src/parser.rs
@@ -9,11 +9,8 @@ pub(crate) mod reference_manager;
 
 pub mod h264 {
     use super::au_splitter::AUSplitter;
-    use super::nalu_parser::NalReceiver;
+    use super::nalu_parser::NalParser;
     use super::nalu_splitter::NALUSplitter;
-    use h264_reader::annexb::AnnexBReader;
-    use h264_reader::push::NalAccumulator;
-    use std::sync::mpsc;
 
     pub use super::au_splitter::AccessUnit;
     pub use super::nalu_parser::{Nalu, ParsedNalu};
@@ -42,24 +39,11 @@ pub mod h264 {
     }
 
     /// H264 parser for Annex B format
+    #[derive(Default)]
     pub struct H264Parser {
-        reader: AnnexBReader<NalAccumulator<NalReceiver>>,
-        receiver: mpsc::Receiver<Result<ParsedNalu, H264ParserError>>,
+        nal_parser: NalParser,
         nalu_splitter: NALUSplitter,
         au_splitter: AUSplitter,
-    }
-
-    impl Default for H264Parser {
-        fn default() -> Self {
-            let (tx, rx) = mpsc::channel();
-
-            H264Parser {
-                reader: AnnexBReader::accumulate(NalReceiver::new(tx)),
-                receiver: rx,
-                nalu_splitter: NALUSplitter::default(),
-                au_splitter: AUSplitter::default(),
-            }
-        }
     }
 
     impl H264Parser {
@@ -72,14 +56,13 @@ pub mod h264 {
         ) -> Result<Vec<AccessUnit>, H264ParserError> {
             let nalus = self.nalu_splitter.push(bytes, pts);
             let nalus = nalus.into_iter().map(|(nalu_bytes, pts)| {
-                self.reader.push(&nalu_bytes);
-
-                let parsed_nalu = self.receiver.try_recv().unwrap();
-                parsed_nalu.map(|parsed_nalu| Nalu {
-                    parsed: parsed_nalu,
-                    raw_bytes: nalu_bytes.into_boxed_slice(),
-                    pts,
-                })
+                self.nal_parser
+                    .parse_nalu(&nalu_bytes)
+                    .map(|parsed_nalu| Nalu {
+                        parsed: parsed_nalu,
+                        raw_bytes: nalu_bytes.into_boxed_slice(),
+                        pts,
+                    })
             });
 
             let mut access_units = Vec::new();
@@ -99,14 +82,13 @@ pub mod h264 {
         pub fn flush(&mut self) -> Result<Vec<AccessUnit>, H264ParserError> {
             let nalus = self.nalu_splitter.flush();
             let nalus = nalus.into_iter().map(|(nalu_bytes, pts)| {
-                self.reader.push(&nalu_bytes);
-
-                let parsed_nalu = self.receiver.try_recv().unwrap();
-                parsed_nalu.map(|parsed_nalu| Nalu {
-                    parsed: parsed_nalu,
-                    raw_bytes: nalu_bytes.into_boxed_slice(),
-                    pts,
-                })
+                self.nal_parser
+                    .parse_nalu(&nalu_bytes)
+                    .map(|parsed_nalu| Nalu {
+                        parsed: parsed_nalu,
+                        raw_bytes: nalu_bytes.into_boxed_slice(),
+                        pts,
+                    })
             });
 
             let mut access_units = Vec::new();

--- a/vk-video/src/parser/nalu_parser.rs
+++ b/vk-video/src/parser/nalu_parser.rs
@@ -1,19 +1,37 @@
-use std::{
-    io::Read,
-    sync::{Arc, mpsc},
-};
+use std::{io::Read, sync::Arc};
 
 use h264_reader::{
-    Context,
+    annexb::AnnexBReader,
     nal::{Nal, RefNal, pps::PicParameterSet, slice::SliceHeader, sps::SeqParameterSet},
-    push::{AccumulatedNalHandler, NalInterest},
+    push::{AccumulatedNalHandler, NalAccumulator, NalInterest},
 };
 
 use super::h264::H264ParserError;
 
-pub(crate) struct NalReceiver {
+pub(crate) struct NalParser {
+    reader: AnnexBReader<NalAccumulator<NalReceiver>>,
+}
+
+impl Default for NalParser {
+    fn default() -> Self {
+        Self {
+            reader: AnnexBReader::accumulate(NalReceiver::default()),
+        }
+    }
+}
+
+impl NalParser {
+    pub fn parse_nalu(&mut self, nalu: &[u8]) -> Result<ParsedNalu, H264ParserError> {
+        self.reader.push(nalu);
+        self.reader.reset();
+        self.reader.nal_handler_mut().parsed_nalu.take().unwrap()
+    }
+}
+
+#[derive(Default)]
+struct NalReceiver {
     parser_ctx: h264_reader::Context,
-    sender: mpsc::Sender<Result<ParsedNalu, H264ParserError>>,
+    parsed_nalu: Option<Result<ParsedNalu, H264ParserError>>,
 }
 
 impl AccumulatedNalHandler for NalReceiver {
@@ -22,21 +40,13 @@ impl AccumulatedNalHandler for NalReceiver {
             return NalInterest::Buffer;
         }
 
-        let result = self.handle_nal(nal);
-        self.sender.send(result).unwrap();
+        self.parsed_nalu = Some(self.handle_nal(nal));
 
         NalInterest::Ignore
     }
 }
 
 impl NalReceiver {
-    pub(crate) fn new(sender: mpsc::Sender<Result<ParsedNalu, H264ParserError>>) -> Self {
-        Self {
-            sender,
-            parser_ctx: Context::default(),
-        }
-    }
-
     fn handle_nal(&mut self, nal: RefNal<'_>) -> Result<ParsedNalu, H264ParserError> {
         let nal_unit_type = nal
             .header()

--- a/vk-video/src/parser/nalu_splitter.rs
+++ b/vk-video/src/parser/nalu_splitter.rs
@@ -25,10 +25,14 @@ fn find_start_of_next_nalu(buf: &[u8]) -> Option<usize> {
     // this could mean either that it's the longer 0, 0, 0, 1 code, or that there is one byte of
     // the previous nalu and the shorter code. This is what is checked here.
     if buf[0] != 0 && buf[1..4] == [0, 0, 1] {
-        return Some(5);
+        return Some(1);
     }
 
-    FINDER.find(&buf[2..]).map(|i| i + 5)
+    FINDER.find(&buf[2..]).map(|i| match buf[i + 1] {
+        // there's 0 before 0 0 1 so we have the longer start code
+        0 => i + 1,
+        _ => i + 2,
+    })
 }
 
 impl NALUSplitter {
@@ -55,7 +59,7 @@ impl NALUSplitter {
 
         // This will cause the whole start code to be reprocessed when the beginning of the next start code
         // is at the end of current buffer.
-        self.previous_search_end = self.buffer.len().saturating_sub(3);
+        self.previous_search_end = self.buffer.len().saturating_sub(4);
 
         self.pts = pts;
 
@@ -74,10 +78,7 @@ impl NALUSplitter {
             result.push((nalu.to_vec(), self.pts));
         }
 
-        result.push((
-            [self.buffer.to_vec(), [0, 0, 1].to_vec()].concat(),
-            self.pts,
-        ));
+        result.push((self.buffer.to_vec(), self.pts));
         self.buffer = BytesMut::new();
         self.previous_search_end = 0;
 


### PR DESCRIPTION
Changed nalu splitter so that it won't include start code of the next nalu in the current nalu bytes. Also fixed some bugs