### PR TITLE
Fix failing socket binding for long file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4897,6 +4897,7 @@ dependencies = [
  "axum",
  "bytes",
  "crossbeam-channel",
+ "dirs",
  "ffmpeg-next",
  "fs_extra",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ tracing-subscriber = { workspace = true }
 libc = "0.2.151"
 webrtc-util = { workspace = true }
 rand = { workspace = true }
+dirs = "5.0"
 reqwest = { workspace = true }
 rubato = { workspace = true }
 tokio = { workspace = true }

--- a/smelter-core/src/error.rs
+++ b/smelter-core/src/error.rs
@@ -47,6 +47,9 @@ pub enum InitPipelineError {
     #[error("Failed to create a download directory.")]
     CreateDownloadDir(#[source] std::io::Error),
 
+    #[error("Side channel socket directory error: {0}")]
+    SideChannelSocketDir(String),
+
     #[error("Failed to create tokio::Runtime.")]
     CreateTokioRuntime(#[source] std::io::Error),
 

--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{Arc, Mutex, Weak},
     thread,
     time::Duration,
@@ -564,6 +565,10 @@ fn create_pipeline(opts: PipelineOptions) -> Result<Pipeline, InitPipelineError>
         .into();
     std::fs::create_dir_all(&download_dir).map_err(InitPipelineError::CreateDownloadDir)?;
 
+    if let Some(dir) = opts.side_channel_socket_dir.as_deref() {
+        prepare_side_channel_socket_dir(dir)?;
+    }
+
     let tokio_rt = match opts.tokio_rt {
         Some(tokio_rt) => tokio_rt,
         None => Arc::new(Runtime::new().map_err(InitPipelineError::CreateTokioRuntime)?),
@@ -633,4 +638,38 @@ fn create_pipeline(opts: PipelineOptions) -> Result<Pipeline, InitPipelineError>
     };
 
     Ok(pipeline)
+}
+
+fn prepare_side_channel_socket_dir(dir: &Path) -> Result<(), InitPipelineError> {
+    if !dir.exists() {
+        return std::fs::create_dir_all(dir).map_err(|e| {
+            InitPipelineError::SideChannelSocketDir(format!(
+                "failed to create \"{}\": {e}",
+                dir.display()
+            ))
+        });
+    }
+    if !dir.is_dir() {
+        return Err(InitPipelineError::SideChannelSocketDir(format!(
+            "\"{}\" exists but is not a directory",
+            dir.display()
+        )));
+    }
+    let is_empty = dir
+        .read_dir()
+        .map_err(|e| {
+            InitPipelineError::SideChannelSocketDir(format!(
+                "failed to read \"{}\": {e}",
+                dir.display()
+            ))
+        })?
+        .next()
+        .is_none();
+    if !is_empty {
+        return Err(InitPipelineError::SideChannelSocketDir(format!(
+            "\"{}\" is not empty",
+            dir.display()
+        )));
+    }
+    Ok(())
 }

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -231,11 +231,11 @@ impl QueueInput {
     pub fn new(ctx: &Arc<PipelineCtx>, input_ref: &Ref<InputId>, opts: QueueInputOptions) -> Self {
         let socket_dir = ctx.queue_ctx.side_channel_socket_dir.as_deref();
         let video_side_channel = match (opts.video_side_channel, socket_dir) {
-            (true, Some(dir)) => Some(VideoSideChannel::new(ctx, input_ref, dir)),
+            (true, Some(dir)) => VideoSideChannel::new(ctx, input_ref, dir),
             _ => None,
         };
         let audio_side_channel = match (opts.audio_side_channel, socket_dir) {
-            (true, Some(dir)) => Some(AudioSideChannel::new(ctx, input_ref, dir)),
+            (true, Some(dir)) => AudioSideChannel::new(ctx, input_ref, dir),
             _ => None,
         };
         Self(Arc::new(Mutex::new(InnerQueueInput {

--- a/smelter-core/src/queue/side_channel/mod.rs
+++ b/smelter-core/src/queue/side_channel/mod.rs
@@ -23,14 +23,19 @@ pub struct VideoSideChannel {
 }
 
 impl VideoSideChannel {
-    pub fn new(ctx: &Arc<PipelineCtx>, input_ref: &Ref<InputId>, socket_dir: &Path) -> Self {
+    pub fn new(
+        ctx: &Arc<PipelineCtx>,
+        input_ref: &Ref<InputId>,
+        socket_dir: &Path,
+    ) -> Option<Self> {
         let path = socket_dir.join(format!("video_{}.sock", input_ref.id()));
         info!(?path, "Starting video side channel");
-        Self {
+        let server = VideoSideChannelServer::new(path, input_ref.id(), ctx.wgpu_ctx.clone())?;
+        Some(Self {
             track_offset: TrackOffset::default(),
             start_pts: ctx.queue_ctx.start_pts.clone(),
-            server: VideoSideChannelServer::new(path, input_ref.id(), ctx.wgpu_ctx.clone()),
-        }
+            server,
+        })
     }
 
     pub(super) fn with_track_offset(&self, track_offset: &TrackOffset) -> Self {
@@ -62,14 +67,19 @@ pub struct AudioSideChannel {
 }
 
 impl AudioSideChannel {
-    pub fn new(ctx: &Arc<PipelineCtx>, input_ref: &Ref<InputId>, socket_dir: &Path) -> Self {
+    pub fn new(
+        ctx: &Arc<PipelineCtx>,
+        input_ref: &Ref<InputId>,
+        socket_dir: &Path,
+    ) -> Option<Self> {
         let path = socket_dir.join(format!("audio_{}.sock", input_ref.id()));
         info!(?path, "Starting audio side channel");
-        Self {
+        let server = AudioSideChannelServer::new(path, input_ref.id())?;
+        Some(Self {
             track_offset: TrackOffset::default(),
             start_pts: ctx.queue_ctx.start_pts.clone(),
-            server: AudioSideChannelServer::new(path, input_ref.id()),
-        }
+            server,
+        })
     }
 
     pub(super) fn with_track_offset(&self, track_offset: &TrackOffset) -> Self {

--- a/smelter-core/src/queue/side_channel/server.rs
+++ b/smelter-core/src/queue/side_channel/server.rs
@@ -13,7 +13,7 @@ use std::{
 use bytes::Bytes;
 use crossbeam_channel::{Sender, TrySendError};
 use smelter_render::{Frame, FramePreProcessor, InputId, WgpuCtx};
-use tracing::{Span, debug, info_span};
+use tracing::{Span, debug, error, info_span};
 
 use crate::prelude::InputAudioSamples;
 
@@ -42,14 +42,14 @@ pub(super) struct VideoSideChannelServer {
 }
 
 impl VideoSideChannelServer {
-    pub fn new(socket_path: PathBuf, input_id: &InputId, wgpu_ctx: Arc<WgpuCtx>) -> Self {
+    pub fn new(socket_path: PathBuf, input_id: &InputId, wgpu_ctx: Arc<WgpuCtx>) -> Option<Self> {
         let span = info_span!("side_channel", kind = "video", input_id = %input_id);
         let (clients, cleanup) = bind_and_spawn_accept(
             socket_path,
             "video-sc",
             VIDEO_CHANNEL_CAPACITY,
             span.clone(),
-        );
+        )?;
 
         let (sender, receiver) = crossbeam_channel::bounded::<Frame>(VIDEO_CHANNEL_CAPACITY);
         thread::Builder::new()
@@ -68,10 +68,10 @@ impl VideoSideChannelServer {
             })
             .expect("Failed to spawn video side channel send thread");
 
-        Self {
+        Some(Self {
             sender,
             _cleanup: cleanup,
-        }
+        })
     }
 }
 
@@ -82,14 +82,14 @@ pub(super) struct AudioSideChannelServer {
 }
 
 impl AudioSideChannelServer {
-    pub fn new(socket_path: PathBuf, input_id: &InputId) -> Self {
+    pub fn new(socket_path: PathBuf, input_id: &InputId) -> Option<Self> {
         let span = info_span!("side_channel", kind = "audio", input_id = %input_id);
         let (clients, cleanup) = bind_and_spawn_accept(
             socket_path,
             "audio-sc",
             AUDIO_CHANNEL_CAPACITY,
             span.clone(),
-        );
+        )?;
 
         let (sender, receiver) =
             crossbeam_channel::bounded::<InputAudioSamples>(AUDIO_CHANNEL_CAPACITY);
@@ -105,10 +105,10 @@ impl AudioSideChannelServer {
             })
             .expect("Failed to spawn audio side channel send thread");
 
-        Self {
+        Some(Self {
             sender,
             _cleanup: cleanup,
-        }
+        })
     }
 }
 
@@ -119,10 +119,18 @@ fn bind_and_spawn_accept(
     name_prefix: &'static str,
     client_channel_capacity: usize,
     span: Span,
-) -> (Clients, Arc<ServerCleanup>) {
+) -> Option<(Clients, Arc<ServerCleanup>)> {
     let _ = std::fs::remove_file(&socket_path);
-    let listener =
-        UnixListener::bind(&socket_path).expect("Failed to bind side channel unix socket");
+    let listener = match UnixListener::bind(&socket_path) {
+        Ok(listener) => listener,
+        Err(e) => {
+            error!(
+                path = %socket_path.display(),
+                "Failed to bind side channel unix socket: {e}"
+            );
+            return None;
+        }
+    };
     listener
         .set_nonblocking(true)
         .expect("Failed to set side channel listener to non-blocking");
@@ -149,7 +157,7 @@ fn bind_and_spawn_accept(
         socket_path,
         should_close,
     });
-    (clients, cleanup)
+    Some((clients, cleanup))
 }
 
 fn run_accept_clients_thread(

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,7 +257,7 @@ fn try_read_config() -> Result<Config, String> {
         Err(_) => DEFAULT_SIDE_CHANNEL_DELAY,
     };
 
-    let side_channel_socket_dir = read_side_channel_socket_dir()?;
+    let side_channel_socket_dir = Some(read_side_channel_socket_dir());
 
     let load_system_fonts = match env::var("SMELTER_LOAD_SYSTEM_FONTS") {
         Ok(enable) => bool_env_from_str(&enable).unwrap_or(true),
@@ -410,48 +410,23 @@ fn try_read_config() -> Result<Config, String> {
     Ok(config)
 }
 
-fn read_side_channel_socket_dir() -> Result<Option<Arc<Path>>, String> {
+fn read_side_channel_socket_dir() -> Arc<Path> {
     let dir = match env::var("SMELTER_SIDE_CHANNEL_SOCKET_DIR") {
         Ok(path) => PathBuf::from(path),
         Err(_) => {
             let name = format!("smelter_side_channel_{}", rand::rng().random::<u64>());
-            env::temp_dir().join(name)
+            // Prefer the XDG runtime dir when available. On macOS `env::temp_dir()`
+            // resolves to a per-user `/var/folders/...` path that is long enough to
+            // overflow the 104-byte `sun_path` limit once socket filenames are
+            // appended, so fall back to `/tmp` there instead.
+            let tmp_root = dirs::runtime_dir().unwrap_or_else(|| match cfg!(target_os = "macos") {
+                true => PathBuf::from("/tmp"),
+                false => env::temp_dir(),
+            });
+            tmp_root.join(name)
         }
     };
-
-    if dir.exists() {
-        if !dir.is_dir() {
-            return Err(format!(
-                "SMELTER_SIDE_CHANNEL_SOCKET_DIR: \"{}\" exists but is not a directory",
-                dir.display()
-            ));
-        }
-        let is_empty = dir
-            .read_dir()
-            .map_err(|e| {
-                format!(
-                    "SMELTER_SIDE_CHANNEL_SOCKET_DIR: failed to read \"{}\": {e}",
-                    dir.display()
-                )
-            })?
-            .next()
-            .is_none();
-        if !is_empty {
-            return Err(format!(
-                "SMELTER_SIDE_CHANNEL_SOCKET_DIR: \"{}\" is not empty",
-                dir.display()
-            ));
-        }
-    } else {
-        std::fs::create_dir_all(&dir).map_err(|e| {
-            format!(
-                "SMELTER_SIDE_CHANNEL_SOCKET_DIR: failed to create \"{}\": {e}",
-                dir.display()
-            )
-        })?;
-    }
-
-    Ok(Some(Arc::from(dir)))
+    Arc::from(dir)
 }
 
 fn framerate_from_str(s: &str) -> Result<Framerate, &'static str> {


### PR DESCRIPTION
move dir for macos, handle a gracefully a case where path is still to long