### PR TITLE
[vk-video] Use Box in H264 & H265 parameters

### DIFF
--- a/vk-video/CHANGELOG.md
+++ b/vk-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added an H.265 encoder ([#1919](https://github.com/software-mansion/smelter/pull/1919) by @jerzywilczek)
 
 ### 🐛 Bug fixes
+- Use Box instead of NonNull in h264 & h265 codec parameters ([#1934](https://github.com/software-mansion/smelter/pull/1934) by @krakow10)
 
 ## [v0.3.0](https://github.com/software-mansion/smelter/releases/tag/vk-video%2Fv0.3.0)
 
@@ -51,4 +52,3 @@
 - H.264 Encoding ([#1215](https://github.com/software-mansion/smelter/pull/1215) by @noituri and @jerzywilczek)
 
 ### 🐛 Bug fixes
-- Use Box instead of NonNull in h264 & h265 codec parameters ([#1934](https://github.com/software-mansion/smelter/pull/1934) by @krakow10)

--- a/vk-video/CHANGELOG.md
+++ b/vk-video/CHANGELOG.md
@@ -51,3 +51,4 @@
 - H.264 Encoding ([#1215](https://github.com/software-mansion/smelter/pull/1215) by @noituri and @jerzywilczek)
 
 ### 🐛 Bug fixes
+- Use Box instead of NonNull in h264 & h265 codec parameters ([#1934](https://github.com/software-mansion/smelter/pull/1934) by @krakow10)

--- a/vk-video/src/codec/h264/parameters.rs
+++ b/vk-video/src/codec/h264/parameters.rs
@@ -68,12 +68,11 @@ impl SeqParameterSetExt for SeqParameterSet {
     }
 }
 
-#[expect(unused)]
 pub(crate) struct VkH264SequenceParameterSet {
     pub(crate) sps: vk::native::StdVideoH264SequenceParameterSet,
-    scaling_lists: Option<Box<H264ScalingLists>>,
-    offset_for_ref_frame: Option<Box<[i32]>>,
-    vui: Option<Box<vk::native::StdVideoH264SequenceParameterSetVui>>,
+    _scaling_lists: Option<Box<H264ScalingLists>>,
+    _offset_for_ref_frame: Option<Box<[i32]>>,
+    _vui: Option<Box<vk::native::StdVideoH264SequenceParameterSetVui>>,
 }
 
 impl From<&'_ SeqParameterSet> for VkH264SequenceParameterSet {
@@ -228,9 +227,9 @@ impl From<&'_ SeqParameterSet> for VkH264SequenceParameterSet {
                 pScalingLists,
                 pSequenceParameterSetVui,
             },
-            scaling_lists,
-            offset_for_ref_frame,
-            vui: None,
+            _scaling_lists: scaling_lists,
+            _offset_for_ref_frame: offset_for_ref_frame,
+            _vui: None,
         }
     }
 }
@@ -347,9 +346,9 @@ impl VkH264SequenceParameterSet {
 
         Ok(Self {
             sps,
-            scaling_lists: None,
-            offset_for_ref_frame: None,
-            vui: Some(vui),
+            _scaling_lists: None,
+            _offset_for_ref_frame: None,
+            _vui: Some(vui),
         })
     }
 }
@@ -564,10 +563,9 @@ fn h264_profile_idc_to_vk(
     }
 }
 
-#[expect(unused)]
 pub(crate) struct VkH264PictureParameterSet {
     pub(crate) pps: vk::native::StdVideoH264PictureParameterSet,
-    scaling_list: Option<Box<H264ScalingLists>>,
+    _scaling_list: Option<Box<H264ScalingLists>>,
 }
 
 impl From<&'_ h264_reader::nal::pps::PicParameterSet> for VkH264PictureParameterSet {
@@ -629,7 +627,7 @@ impl From<&'_ h264_reader::nal::pps::PicParameterSet> for VkH264PictureParameter
                 second_chroma_qp_index_offset,
                 pScalingLists,
             },
-            scaling_list,
+            _scaling_list: scaling_list,
         }
     }
 }
@@ -678,7 +676,7 @@ impl VkH264PictureParameterSet {
 
         Self {
             pps,
-            scaling_list: None,
+            _scaling_list: None,
         }
     }
 }

--- a/vk-video/src/codec/h264/parameters.rs
+++ b/vk-video/src/codec/h264/parameters.rs
@@ -1,5 +1,3 @@
-use std::ptr::NonNull;
-
 use ash::vk;
 use h264_reader::nal::sps::{FrameMbsFlags, SeqParameterSet};
 
@@ -70,20 +68,12 @@ impl SeqParameterSetExt for SeqParameterSet {
     }
 }
 
+#[expect(unused)]
 pub(crate) struct VkH264SequenceParameterSet {
     pub(crate) sps: vk::native::StdVideoH264SequenceParameterSet,
-
-    /// # Safety
-    /// Do not modify this pointer or anything it points to
-    scaling_lists_ptr: Option<NonNull<H264ScalingLists>>,
-
-    /// # Safety
-    /// Do not modify this pointer or anything it points to
-    offset_for_ref_frame: Option<NonNull<[i32]>>,
-
-    /// # Safety
-    /// Do not modify this pointer or anything it points to
-    vui_ptr: Option<NonNull<vk::native::StdVideoH264SequenceParameterSetVui>>,
+    scaling_lists: Option<Box<H264ScalingLists>>,
+    offset_for_ref_frame: Option<Box<[i32]>>,
+    vui: Option<Box<vk::native::StdVideoH264SequenceParameterSetVui>>,
 }
 
 impl From<&'_ SeqParameterSet> for VkH264SequenceParameterSet {
@@ -188,29 +178,23 @@ impl From<&'_ SeqParameterSet> for VkH264SequenceParameterSet {
             | h264_reader::nal::sps::PicOrderCntType::TypeTwo => None,
         };
 
-        let offset_for_ref_frame = offset_for_ref_frame
-            .map(|o| o.into_boxed_slice())
-            .map(Box::leak);
+        let offset_for_ref_frame = offset_for_ref_frame.map(|o| o.into_boxed_slice());
 
         let pOffsetForRefFrame = match offset_for_ref_frame.as_ref() {
             Some(o) => o.as_ptr(),
             None => std::ptr::null(),
         };
 
-        let offset_for_ref_frame = offset_for_ref_frame.map(NonNull::from);
-
-        let scaling_lists: Option<&mut H264ScalingLists> = sps
+        let scaling_lists: Option<Box<H264ScalingLists>> = sps
             .chroma_info
             .scaling_matrix
             .as_ref()
-            .map(|matrix| Box::leak(Box::new(matrix.into())));
+            .map(|matrix| Box::new(matrix.into()));
 
         let pScalingLists = match scaling_lists.as_ref() {
             Some(l) => &l.list,
             None => std::ptr::null(),
         };
-
-        let scaling_lists_ptr = scaling_lists.map(NonNull::from);
 
         // TODO: this is not necessary to reconstruct samples. I don't know why the decoder would
         // need this. Maybe we can do this in the future.
@@ -244,22 +228,10 @@ impl From<&'_ SeqParameterSet> for VkH264SequenceParameterSet {
                 pScalingLists,
                 pSequenceParameterSetVui,
             },
-            scaling_lists_ptr,
+            scaling_lists,
             offset_for_ref_frame,
-            vui_ptr: None,
+            vui: None,
         }
-    }
-}
-
-impl Drop for VkH264SequenceParameterSet {
-    fn drop(&mut self) {
-        self.scaling_lists_ptr
-            .map(|p| unsafe { Box::from_raw(p.as_ptr()) });
-
-        self.offset_for_ref_frame
-            .map(|p| unsafe { Box::from_raw(p.as_ptr()) });
-
-        self.vui_ptr.map(|p| unsafe { Box::from_raw(p.as_ptr()) });
     }
 }
 
@@ -331,7 +303,6 @@ impl VkH264SequenceParameterSet {
             reserved1: 0,
             pHrdParameters: std::ptr::null(),
         });
-        let vui_ptr = NonNull::from(Box::leak(vui));
 
         let sps = vk::native::StdVideoH264SequenceParameterSet {
             flags: vk::native::StdVideoH264SpsFlags {
@@ -371,14 +342,14 @@ impl VkH264SequenceParameterSet {
             reserved2: 0,
             pOffsetForRefFrame: std::ptr::null(),
             pScalingLists: std::ptr::null(),
-            pSequenceParameterSetVui: vui_ptr.as_ptr(),
+            pSequenceParameterSetVui: vui.as_ref(),
         };
 
         Ok(Self {
             sps,
-            scaling_lists_ptr: None,
+            scaling_lists: None,
             offset_for_ref_frame: None,
-            vui_ptr: Some(vui_ptr),
+            vui: Some(vui),
         })
     }
 }
@@ -593,9 +564,10 @@ fn h264_profile_idc_to_vk(
     }
 }
 
+#[expect(unused)]
 pub(crate) struct VkH264PictureParameterSet {
     pub(crate) pps: vk::native::StdVideoH264PictureParameterSet,
-    scaling_list_ptr: Option<NonNull<H264ScalingLists>>,
+    scaling_list: Option<Box<H264ScalingLists>>,
 }
 
 impl From<&'_ h264_reader::nal::pps::PicParameterSet> for VkH264PictureParameterSet {
@@ -630,18 +602,16 @@ impl From<&'_ h264_reader::nal::pps::PicParameterSet> for VkH264PictureParameter
             .map(|ext| ext.second_chroma_qp_index_offset as i8)
             .unwrap_or(chroma_qp_index_offset);
 
-        let scaling_list: Option<&mut H264ScalingLists> = pps
+        let scaling_list: Option<Box<H264ScalingLists>> = pps
             .extension
             .as_ref()
             .and_then(|e| e.pic_scaling_matrix.as_ref())
-            .map(|matrix| Box::leak(Box::new(matrix.into())));
+            .map(|matrix| Box::new(matrix.into()));
 
         let pScalingLists = match scaling_list.as_ref() {
             Some(l) => &l.list,
             None => std::ptr::null(),
         };
-
-        let scaling_list_ptr = scaling_list.map(NonNull::from);
 
         Self {
             pps: vk::native::StdVideoH264PictureParameterSet {
@@ -659,20 +629,13 @@ impl From<&'_ h264_reader::nal::pps::PicParameterSet> for VkH264PictureParameter
                 second_chroma_qp_index_offset,
                 pScalingLists,
             },
-            scaling_list_ptr,
+            scaling_list,
         }
     }
 }
 
 unsafe impl Send for VkH264PictureParameterSet {}
 unsafe impl Sync for VkH264PictureParameterSet {}
-
-impl Drop for VkH264PictureParameterSet {
-    fn drop(&mut self) {
-        self.scaling_list_ptr
-            .map(|p| unsafe { Box::from_raw(p.as_ptr()) });
-    }
-}
 
 impl VkH264PictureParameterSet {
     pub(crate) fn new_encode(
@@ -715,7 +678,7 @@ impl VkH264PictureParameterSet {
 
         Self {
             pps,
-            scaling_list_ptr: None,
+            scaling_list: None,
         }
     }
 }

--- a/vk-video/src/codec/h265/parameters.rs
+++ b/vk-video/src/codec/h265/parameters.rs
@@ -4,8 +4,8 @@ use crate::{VulkanDecoderError, codec::h265::H265Codec, vulkan_encoder::FullEnco
 
 pub(crate) struct VkH265VideoParameterSet {
     pub(crate) vps: vk::native::StdVideoH265VideoParameterSet,
-    _profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
-    _dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
+    _profile_tier_level: Box<vk::native::StdVideoH265ProfileTierLevel>,
+    _dec_pic_buf_mgr: Box<vk::native::StdVideoH265DecPicBufMgr>,
 }
 
 fn profile_tier_level(
@@ -64,8 +64,8 @@ impl VkH265VideoParameterSet {
                 pDecPicBufMgr: dec_pic_buf_mgr.as_ref(),
                 pProfileTierLevel: profile_tier_level.as_ref(),
             },
-            _profile_tier_level: Some(profile_tier_level),
-            _dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
+            _profile_tier_level: profile_tier_level,
+            _dec_pic_buf_mgr: dec_pic_buf_mgr,
         }
     }
 }

--- a/vk-video/src/codec/h265/parameters.rs
+++ b/vk-video/src/codec/h265/parameters.rs
@@ -2,11 +2,10 @@ use ash::vk;
 
 use crate::{VulkanDecoderError, codec::h265::H265Codec, vulkan_encoder::FullEncoderParameters};
 
-#[expect(unused)]
 pub(crate) struct VkH265VideoParameterSet {
     pub(crate) vps: vk::native::StdVideoH265VideoParameterSet,
-    profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
-    dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
+    _profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
+    _dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
 }
 
 fn profile_tier_level(
@@ -65,17 +64,16 @@ impl VkH265VideoParameterSet {
                 pDecPicBufMgr: dec_pic_buf_mgr.as_ref(),
                 pProfileTierLevel: profile_tier_level.as_ref(),
             },
-            profile_tier_level: Some(profile_tier_level),
-            dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
+            _profile_tier_level: Some(profile_tier_level),
+            _dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
         }
     }
 }
 
-#[expect(unused)]
 pub(crate) struct VkH265SequenceParameterSet {
     pub(crate) sps: vk::native::StdVideoH265SequenceParameterSet,
-    profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
-    dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
+    _profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
+    _dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
 }
 
 impl VkH265SequenceParameterSet {
@@ -187,8 +185,8 @@ impl VkH265SequenceParameterSet {
                 pPredictorPaletteEntries: std::ptr::null(),
             },
 
-            profile_tier_level: Some(profile_tier_level),
-            dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
+            _profile_tier_level: Some(profile_tier_level),
+            _dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
         }
     }
 }

--- a/vk-video/src/codec/h265/parameters.rs
+++ b/vk-video/src/codec/h265/parameters.rs
@@ -1,14 +1,12 @@
-use std::ptr::NonNull;
-
 use ash::vk;
 
 use crate::{VulkanDecoderError, codec::h265::H265Codec, vulkan_encoder::FullEncoderParameters};
 
+#[expect(unused)]
 pub(crate) struct VkH265VideoParameterSet {
     pub(crate) vps: vk::native::StdVideoH265VideoParameterSet,
-
-    profile_tier_level: Option<NonNull<vk::native::StdVideoH265ProfileTierLevel>>,
-    dec_pic_buf_mgr: Option<NonNull<vk::native::StdVideoH265DecPicBufMgr>>,
+    profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
+    dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
 }
 
 fn profile_tier_level(
@@ -44,13 +42,11 @@ fn dec_pic_buf_mgr(
 
 impl VkH265VideoParameterSet {
     pub(crate) fn new_encode(params: &FullEncoderParameters<H265Codec>) -> Self {
-        let profile_tier_level = NonNull::from(Box::leak(Box::new(profile_tier_level(params))));
+        let profile_tier_level = Box::new(profile_tier_level(params));
 
-        let dec_pic_buf_mgr = NonNull::from(Box::leak(Box::new(dec_pic_buf_mgr(params))));
+        let dec_pic_buf_mgr = Box::new(dec_pic_buf_mgr(params));
 
         Self {
-            profile_tier_level: Some(profile_tier_level),
-            dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
             vps: vk::native::StdVideoH265VideoParameterSet {
                 reserved1: 0,
                 flags: vk::native::StdVideoH265VpsFlags {
@@ -66,31 +62,20 @@ impl VkH265VideoParameterSet {
                 vps_num_ticks_poc_diff_one_minus1: 0,
                 reserved3: 0,
                 pHrdParameters: std::ptr::null(),
-                pDecPicBufMgr: dec_pic_buf_mgr.as_ptr(),
-                pProfileTierLevel: profile_tier_level.as_ptr() as *const _,
+                pDecPicBufMgr: dec_pic_buf_mgr.as_ref(),
+                pProfileTierLevel: profile_tier_level.as_ref(),
             },
+            profile_tier_level: Some(profile_tier_level),
+            dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
         }
     }
 }
 
-impl Drop for VkH265VideoParameterSet {
-    fn drop(&mut self) {
-        unsafe {
-            if let Some(profile_tier_level) = self.profile_tier_level {
-                drop(Box::from_raw(profile_tier_level.as_ptr()));
-            }
-
-            if let Some(dec_pic_buf_mgr) = self.dec_pic_buf_mgr {
-                drop(Box::from_raw(dec_pic_buf_mgr.as_ptr()));
-            }
-        }
-    }
-}
-
+#[expect(unused)]
 pub(crate) struct VkH265SequenceParameterSet {
-    profile_tier_level: Option<NonNull<vk::native::StdVideoH265ProfileTierLevel>>,
     pub(crate) sps: vk::native::StdVideoH265SequenceParameterSet,
-    dec_pic_buf_mgr: Option<NonNull<vk::native::StdVideoH265DecPicBufMgr>>,
+    profile_tier_level: Option<Box<vk::native::StdVideoH265ProfileTierLevel>>,
+    dec_pic_buf_mgr: Option<Box<vk::native::StdVideoH265DecPicBufMgr>>,
 }
 
 impl VkH265SequenceParameterSet {
@@ -99,8 +84,8 @@ impl VkH265SequenceParameterSet {
         caps: &vk::VideoEncodeH265CapabilitiesKHR<'_>,
     ) -> Self {
         // TODO: VUI
-        let profile_tier_level = NonNull::from(Box::leak(Box::new(profile_tier_level(params))));
-        let dec_pic_buf_mgr = NonNull::from(Box::leak(Box::new(dec_pic_buf_mgr(params))));
+        let profile_tier_level = Box::new(profile_tier_level(params));
+        let dec_pic_buf_mgr = Box::new(dec_pic_buf_mgr(params));
 
         let ctb_log2_size = largest_supported_ctb_log2_size(caps.ctb_sizes);
 
@@ -193,8 +178,8 @@ impl VkH265SequenceParameterSet {
                 conf_win_right_offset: 0,
                 conf_win_top_offset: 0,
                 conf_win_bottom_offset: 0,
-                pProfileTierLevel: profile_tier_level.as_ptr(),
-                pDecPicBufMgr: dec_pic_buf_mgr.as_ptr(),
+                pProfileTierLevel: profile_tier_level.as_ref(),
+                pDecPicBufMgr: dec_pic_buf_mgr.as_ref(),
                 pScalingLists: std::ptr::null(),
                 pShortTermRefPicSet: std::ptr::null(),
                 pLongTermRefPicsSps: std::ptr::null(),
@@ -204,20 +189,6 @@ impl VkH265SequenceParameterSet {
 
             profile_tier_level: Some(profile_tier_level),
             dec_pic_buf_mgr: Some(dec_pic_buf_mgr),
-        }
-    }
-}
-
-impl Drop for VkH265SequenceParameterSet {
-    fn drop(&mut self) {
-        unsafe {
-            if let Some(profile_tier_level) = self.profile_tier_level {
-                drop(Box::from_raw(profile_tier_level.as_ptr()));
-            }
-
-            if let Some(dec_pic_buf_mgr) = self.dec_pic_buf_mgr {
-                drop(Box::from_raw(dec_pic_buf_mgr.as_ptr()));
-            }
         }
     }
 }


### PR DESCRIPTION
I noticed this is manually converting to and from NonNull with unsafe, why not just directly use Box?