### PR TITLE
[gpu-video] Move the check for `gaps_in_frame_num` from parser to reference manager

### DIFF
--- a/gpu-video/CHANGELOG.md
+++ b/gpu-video/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### 💥 Breaking changes
+- Moved `GapsInFrameNumNotSupported` error from `H264ParserError` to `ReferenceManagementError` ([#1957](https://github.com/software-mansion/smelter/pull/1957) by @jerzywilczek)
 - All nalus returned by `H264Parser` now contain their own start codes (`001` or `0001` bytes at the beginning) ([#1921](https://github.com/software-mansion/smelter/pull/1921) by @noituri)
 - Decoders, encoders and encoder parameters are now created using codec-specific methods, e. g. `Device::encoder_output_parameters_low_latency` -> `Device::encoder_output_parameters_h264_low_latency`, `Device::create_bytes_encoder` -> `Device::create_bytes_encoder_h264` ([#1871](https://github.com/software-mansion/smelter/pull/1871) by @jerzywilczek)
 - Added `DecoderEvent::DecodeParsedFrame` event for decoding already parsed frames (needs `expose-parsers` feature enabled). The type of the frame is provided as a generic type of `DecoderEvent`. Users using H.264 decoders should switch to `H264DecoderEvent` alias ([#1936](https://github.com/software-mansion/smelter/pull/1936) by @noituri)

--- a/gpu-video/src/parser.rs
+++ b/gpu-video/src/parser.rs
@@ -19,9 +19,6 @@ pub mod h264 {
 
     #[derive(Debug, thiserror::Error)]
     pub enum H264ParserError {
-        #[error("Bitstreams that allow gaps in frame_num are not supported")]
-        GapsInFrameNumNotSupported,
-
         #[error("Streams containing fields instead of frames are not supported")]
         FieldsNotSupported,
 

--- a/gpu-video/src/parser/decoder_instructions.rs
+++ b/gpu-video/src/parser/decoder_instructions.rs
@@ -37,6 +37,9 @@ pub(crate) fn compile_to_decoder_instructions(
         for nalu in nalus {
             match nalu.parsed {
                 ParsedNalu::Sps(seq_parameter_set) => {
+                    if seq_parameter_set.gaps_in_frame_num_value_allowed_flag {
+                        return Err(ReferenceManagementError::GapsInFrameNumNotSupported);
+                    }
                     instructions.push(DecoderInstruction::Sps(seq_parameter_set))
                 }
                 ParsedNalu::Pps(pic_parameter_set) => {

--- a/gpu-video/src/parser/nalu_parser.rs
+++ b/gpu-video/src/parser/nalu_parser.rs
@@ -58,18 +58,8 @@ impl NalReceiver {
                 let parsed = h264_reader::nal::sps::SeqParameterSet::from_bits(nal.rbsp_bits())
                     .map_err(H264ParserError::SpsParseError)?;
 
-                // Perhaps this shouldn't be here, but this is the only place we process sps
-                // before sending them to the decoder. It also seems that this is the only thing we
-                // need to check about the sps.
-                if parsed.gaps_in_frame_num_value_allowed_flag {
-                    // TODO: what else to do here? sure we'll throw an error, but shouldn't we also
-                    // terminate the parser somehow?
-                    // perhaps this should be considered in other places we throw errors too
-                    Err(H264ParserError::GapsInFrameNumNotSupported)
-                } else {
-                    self.parser_ctx.put_seq_param_set(parsed.clone());
-                    Ok(ParsedNalu::Sps(parsed.clone()))
-                }
+                self.parser_ctx.put_seq_param_set(parsed.clone());
+                Ok(ParsedNalu::Sps(parsed.clone()))
             }
 
             h264_reader::nal::UnitType::PicParameterSet => {

--- a/gpu-video/src/parser/reference_manager.rs
+++ b/gpu-video/src/parser/reference_manager.rs
@@ -29,6 +29,9 @@ pub enum ReferenceManagementError {
 
     #[error("Missing frame. Decoder is in a corrupted state. Waiting for IDR frame")]
     MissingFrame,
+
+    #[error("Bitstreams that allow gaps in frame_num are not supported")]
+    GapsInFrameNumNotSupported,
 }
 
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
This allows API users that just use the parser to parse streams with this option set.