### PR TITLE
Resize jitter-buffer at a (per sec rate instead per packet)

### DIFF
--- a/smelter-core/src/audio_mixer/input/resampler.rs
+++ b/smelter-core/src/audio_mixer/input/resampler.rs
@@ -9,7 +9,9 @@ use tracing::{debug, error, trace, warn};
 
 use crate::{AudioChannels, AudioSamples, prelude::InputAudioSamples, utils::AudioSamplesBuffer};
 
-const MAX_STRETCH_FACTOR: f64 = 1.05;
+// Extra 0.001 is just to account for inputs that have dynamic buffer
+// and are configured to shift by max 4%
+const MAX_STRETCH_FACTOR: f64 = 0.041;
 
 /// Data flow:
 /// Initial data is appended to `resampler_input_buffer`. When we need to get samples for specific
@@ -85,7 +87,10 @@ const SHIFT_THRESHOLD: Duration = Duration::from_millis(2);
 /// This threshold defines at what point we should still try stretch audio
 /// and when to just drop packets. Consequence of that is also that this
 /// value defines de-sync between audio and video tracks.
-const STRETCH_THRESHOLD: Duration = Duration::from_millis(500);
+const SQUASH_THRESHOLD: Duration = Duration::from_millis(500);
+
+// stretch needs to be more aggressive because we might not have enough buffer
+const STRETCH_THRESHOLD: Duration = Duration::from_millis(40);
 
 impl InputResampler {
     pub fn new(
@@ -105,7 +110,7 @@ impl InputResampler {
         let original_resampler_ratio = output_sample_rate as f64 / input_sample_rate as f64;
         let resampler = rubato::Async::<f64>::new_sinc(
             original_resampler_ratio,
-            MAX_STRETCH_FACTOR,
+            1.0 + MAX_STRETCH_FACTOR,
             Self::interpolation_params(input_sample_rate, output_sample_rate),
             samples_in_batch,
             match channels {
@@ -167,7 +172,7 @@ impl InputResampler {
     }
 
     fn set_resample_ratio_relative(&mut self, rel_ratio: f64) {
-        let rel_ratio = rel_ratio.clamp(1.0 / MAX_STRETCH_FACTOR, MAX_STRETCH_FACTOR);
+        let rel_ratio = rel_ratio.clamp(1.0 / (1.0 + MAX_STRETCH_FACTOR), 1.0 + MAX_STRETCH_FACTOR);
         let desired = self.original_resampler_ratio * rel_ratio;
         let current = self.resampler.resample_ratio();
         let should_update = (current == 1.0 && desired != 1.0) || (desired - current).abs() > 0.01;
@@ -255,17 +260,23 @@ impl InputResampler {
                 // stretch
                 let drift = input_start_pts.saturating_sub(requested_start_pts);
                 let ratio = drift.as_secs_f64() / STRETCH_THRESHOLD.as_secs_f64();
-                self.set_resample_ratio_relative(1.0 + (0.1 * ratio));
+
+                // multiply by 2.0 so max resampling is reached at the half point
+                // of the stretch limit
+                self.set_resample_ratio_relative(1.0 + (2.0 * MAX_STRETCH_FACTOR * ratio));
                 trace!(ratio, ?drift, "Input buffer behind, stretching");
             } else if input_start_pts + SHIFT_THRESHOLD > requested_start_pts {
                 // no squashing/stretching
                 self.set_resample_ratio_relative(1.0);
                 trace!("Input buffer on time");
-            } else if input_start_pts + STRETCH_THRESHOLD > requested_start_pts {
+            } else if input_start_pts + SQUASH_THRESHOLD > requested_start_pts {
                 // squash
                 let drift = requested_start_pts.saturating_sub(input_start_pts);
-                let ratio = drift.as_secs_f64() / STRETCH_THRESHOLD.as_secs_f64();
-                self.set_resample_ratio_relative(1.0 - (0.1 * ratio));
+                let ratio = drift.as_secs_f64() / SQUASH_THRESHOLD.as_secs_f64();
+
+                // multiply by 2.0 so max resampling is reached at the half point
+                // of the squash limit
+                self.set_resample_ratio_relative(1.0 - (2.0 * MAX_STRETCH_FACTOR * ratio));
                 trace!(ratio, ?drift, "Input buffer ahead, squashing");
             } else {
                 // drop data

--- a/smelter-core/src/audio_mixer/input/resampler.rs
+++ b/smelter-core/src/audio_mixer/input/resampler.rs
@@ -11,7 +11,7 @@ use crate::{AudioChannels, AudioSamples, prelude::InputAudioSamples, utils::Audi
 
 // Extra 0.001 is just to account for inputs that have dynamic buffer
 // and are configured to shift by max 4%
-const MAX_STRETCH_FACTOR: f64 = 0.041;
+const MAX_STRETCH_RATIO: f64 = 0.04 + 0.001;
 
 /// Data flow:
 /// Initial data is appended to `resampler_input_buffer`. When we need to get samples for specific
@@ -84,12 +84,12 @@ const CONTINUITY_THRESHOLD: Duration = Duration::from_millis(80);
 /// the timestamps and number of samples is out of sync.
 const SHIFT_THRESHOLD: Duration = Duration::from_millis(2);
 
-/// This threshold defines at what point we should still try stretch audio
-/// and when to just drop packets. Consequence of that is also that this
-/// value defines de-sync between audio and video tracks.
+/// Upper limit for drift size where we still attempt to squash audio.
+/// Above that limit, resampler should force reset.
 const SQUASH_THRESHOLD: Duration = Duration::from_millis(500);
 
-// stretch needs to be more aggressive because we might not have enough buffer
+/// Upper limit for drift size where we still attempt to stretch audio.
+/// Above that limit, resampler should force reset.
 const STRETCH_THRESHOLD: Duration = Duration::from_millis(40);
 
 impl InputResampler {
@@ -110,7 +110,7 @@ impl InputResampler {
         let original_resampler_ratio = output_sample_rate as f64 / input_sample_rate as f64;
         let resampler = rubato::Async::<f64>::new_sinc(
             original_resampler_ratio,
-            1.0 + MAX_STRETCH_FACTOR,
+            1.0 + MAX_STRETCH_RATIO,
             Self::interpolation_params(input_sample_rate, output_sample_rate),
             samples_in_batch,
             match channels {
@@ -172,7 +172,7 @@ impl InputResampler {
     }
 
     fn set_resample_ratio_relative(&mut self, rel_ratio: f64) {
-        let rel_ratio = rel_ratio.clamp(1.0 / (1.0 + MAX_STRETCH_FACTOR), 1.0 + MAX_STRETCH_FACTOR);
+        let rel_ratio = rel_ratio.clamp(1.0 / (1.0 + MAX_STRETCH_RATIO), 1.0 + MAX_STRETCH_RATIO);
         let desired = self.original_resampler_ratio * rel_ratio;
         let current = self.resampler.resample_ratio();
         let should_update = (current == 1.0 && desired != 1.0) || (desired - current).abs() > 0.01;
@@ -263,7 +263,7 @@ impl InputResampler {
 
                 // multiply by 2.0 so max resampling is reached at the half point
                 // of the stretch limit
-                self.set_resample_ratio_relative(1.0 + (2.0 * MAX_STRETCH_FACTOR * ratio));
+                self.set_resample_ratio_relative(1.0 + (2.0 * MAX_STRETCH_RATIO * ratio));
                 trace!(ratio, ?drift, "Input buffer behind, stretching");
             } else if input_start_pts + SHIFT_THRESHOLD > requested_start_pts {
                 // no squashing/stretching
@@ -276,7 +276,7 @@ impl InputResampler {
 
                 // multiply by 2.0 so max resampling is reached at the half point
                 // of the squash limit
-                self.set_resample_ratio_relative(1.0 - (2.0 * MAX_STRETCH_FACTOR * ratio));
+                self.set_resample_ratio_relative(1.0 - (2.0 * MAX_STRETCH_RATIO * ratio));
                 trace!(ratio, ?drift, "Input buffer ahead, squashing");
             } else {
                 // drop data

--- a/smelter-core/src/pipeline/rtp/rtp_input/jitter_buffer.rs
+++ b/smelter-core/src/pipeline/rtp/rtp_input/jitter_buffer.rs
@@ -24,11 +24,11 @@ struct JitterBufferPacket {
 
 #[derive(Debug, Clone, Copy)]
 pub enum RtpJitterBufferMode {
-    /// If I receive packet for sample `x`, then don't wait
-    /// for missing packets older than `(x-size)`
+    /// Release packets once the PTS span of buffered packets exceeds the window.
+    /// Wall clock is not consulted.
     FixedWindow(Duration),
-    /// Packet needs to be returned from buffer before instant.elapsed() gets bigger
-    /// than pts. (with some extra fixed buffer e.g. 80ms)
+    /// Release packets when their output PTS (PTS + dynamic buffer size) is about
+    /// to be reached on the wall clock, with `MIN_DECODE_TIME` of slack.
     RealTime,
 }
 
@@ -60,9 +60,9 @@ impl RtpJitterBufferSharedContext {
                         offset: window_size + ctx.default_buffer_duration,
                     }
                 }
-                RtpJitterBufferMode::RealTime => BufferingStrategy::LatencyOptimized(Arc::new(
-                    Mutex::new(LatencyOptimizedBuffer::new(ctx, reference_time)),
-                )),
+                RtpJitterBufferMode::RealTime => {
+                    BufferingStrategy::LatencyOptimized(LatencyOptimizedBuffer::new(reference_time))
+                }
             },
         }
     }
@@ -93,11 +93,13 @@ impl RtpJitterBufferSharedContext {
 ///       is synced to real time, normalizing it to zero is incorrect.
 ///
 pub(crate) struct RtpJitterBuffer {
-    shared_ctx: RtpJitterBufferSharedContext,
+    mode: RtpJitterBufferMode,
+    ntp_sync_point: Arc<RtpNtpSyncPoint>,
+    input_buffer: BufferingStrategy,
     timestamp_sync: RtpTimestampSync,
     seq_num_rollover: SequenceNumberRollover,
     packets: BTreeMap<u64, JitterBufferPacket>,
-    /// Last sequence number returned from `read_packet`
+    /// Next expected sequence number (last returned from `read_packet` + 1).
     next_seq_num: Option<u64>,
     on_stats_event: Box<dyn FnMut(RtpJitterBufferStatsEvent) + 'static + Send>,
 }
@@ -105,7 +107,7 @@ pub(crate) struct RtpJitterBuffer {
 /// We are assuming here that it is enough time to decode. Might be
 /// problematic in case of B-frames, because it would require processing multiple
 /// frames before
-const MIN_DECODE_TIME: Duration = Duration::from_millis(30);
+const MIN_DECODE_TIME: Duration = Duration::from_millis(80);
 
 impl RtpJitterBuffer {
     pub fn new(
@@ -113,10 +115,17 @@ impl RtpJitterBuffer {
         clock_rate: u32,
         on_stats_event: Box<dyn FnMut(RtpJitterBufferStatsEvent) + 'static + Send>,
     ) -> Self {
-        let timestamp_sync = RtpTimestampSync::new(shared_ctx.ntp_sync_point.clone(), clock_rate);
+        let RtpJitterBufferSharedContext {
+            mode,
+            ntp_sync_point,
+            input_buffer,
+        } = shared_ctx;
+        let timestamp_sync = RtpTimestampSync::new(ntp_sync_point.clone(), clock_rate);
 
         Self {
-            shared_ctx,
+            mode,
+            ntp_sync_point,
+            input_buffer,
             timestamp_sync,
             seq_num_rollover: SequenceNumberRollover::default(),
             packets: BTreeMap::new(),
@@ -152,7 +161,15 @@ impl RtpJitterBuffer {
             .timestamp_sync
             .pts_from_timestamp(packet.header.timestamp);
 
-        self.shared_ctx.input_buffer.on_new_packet(pts);
+        // We estimate buffer size here, but actual calculation and
+        // packet smoothing happens when removing packet from jitter buffer.
+        //
+        // - Buffer needs to be estimated here because lost packet will delay popping
+        // and totally pollute data
+        // - PTS needs to be added after pop based on target at the time to avoid
+        // reorders and minimize large jumps
+        //
+        self.input_buffer.on_new_packet(pts);
 
         trace!(packet=?packet.header, ?pts, buffer_size=self.packets.len(), "Writing packet to jitter buffer");
         self.packets
@@ -166,7 +183,7 @@ impl RtpJitterBuffer {
             return self.read_packet();
         }
 
-        let wait_for_next_packet = match self.shared_ctx.mode {
+        let wait_for_next_packet = match self.mode {
             RtpJitterBufferMode::FixedWindow(window_size) => {
                 let lowest_pts = self.packets.values().map(|packet| packet.pts).min()?;
                 let highest_pts = self.packets.values().map(|packet| packet.pts).max()?;
@@ -179,8 +196,8 @@ impl RtpJitterBuffer {
                 //
                 // It would be safer to use value based on index than constant, in the worst
                 // case scenario this could be 16 frames that needs to decoded in that time
-                let next_pts = lowest_pts + self.shared_ctx.input_buffer.size();
-                let reference_time = self.shared_ctx.ntp_sync_point.reference_time;
+                let next_pts = lowest_pts + self.input_buffer.size();
+                let reference_time = self.ntp_sync_point.reference_time;
                 next_pts > reference_time.elapsed() + MIN_DECODE_TIME
             }
         };
@@ -206,15 +223,14 @@ impl RtpJitterBuffer {
 
         let packet = first_entry.remove();
 
-        let input_buffer_size = self.shared_ctx.input_buffer.size();
-        let timestamp = packet.pts + input_buffer_size;
+        let timestamp = self.input_buffer.apply_offset(packet.pts);
 
-        let reference_time = self.shared_ctx.ntp_sync_point.reference_time;
+        let reference_time = self.ntp_sync_point.reference_time;
         (self.on_stats_event)(RtpJitterBufferStatsEvent::EffectiveBuffer(
             timestamp.saturating_sub(reference_time.elapsed()),
         ));
         (self.on_stats_event)(RtpJitterBufferStatsEvent::InputBufferSize(
-            input_buffer_size,
+            self.input_buffer.size(),
         ));
 
         self.next_seq_num = Some(seq_num + 1);
@@ -226,14 +242,14 @@ impl RtpJitterBuffer {
 
     pub fn peek_next_pts(&self) -> Option<Duration> {
         let (_, packet) = self.packets.first_key_value()?;
-        Some(packet.pts + self.shared_ctx.input_buffer.size())
+        Some(packet.pts + self.input_buffer.size())
     }
 }
 
 #[derive(Clone)]
 enum BufferingStrategy {
     FixedOffset { offset: Duration },
-    LatencyOptimized(Arc<Mutex<LatencyOptimizedBuffer>>),
+    LatencyOptimized(LatencyOptimizedBuffer),
 }
 
 impl fmt::Debug for BufferingStrategy {
@@ -249,156 +265,385 @@ impl fmt::Debug for BufferingStrategy {
 }
 
 impl BufferingStrategy {
-    pub fn on_new_packet(&self, pts: Duration) {
+    /// Called the moment a packet is received off the network. Records the
+    /// trend observation against the *receive-time* effective buffer (so packets
+    /// sitting in the jitter buffer waiting for predecessors don't get misread
+    /// as emergencies) and updates the shared target size. Per-track size
+    /// converges toward that target separately in `apply_offset` at pop time.
+    pub fn on_new_packet(&mut self, pts: Duration) {
         match self {
-            BufferingStrategy::LatencyOptimized(buffer) => {
-                buffer.lock().unwrap().on_new_packet(pts)
-            }
+            BufferingStrategy::LatencyOptimized(buffer) => buffer.on_new_packet(pts),
             BufferingStrategy::FixedOffset { .. } => (),
+        }
+    }
+
+    pub fn apply_offset(&mut self, pts: Duration) -> Duration {
+        match self {
+            BufferingStrategy::FixedOffset { offset } => pts + *offset,
+            BufferingStrategy::LatencyOptimized(buffer) => buffer.apply_offset(pts),
         }
     }
 
     pub fn size(&self) -> Duration {
         match self {
             BufferingStrategy::FixedOffset { offset } => *offset,
-            BufferingStrategy::LatencyOptimized(buffer) => buffer.lock().unwrap().dynamic_buffer,
+            BufferingStrategy::LatencyOptimized(buffer) => buffer.target_size(),
         }
     }
 }
 
-/// Buffer intended for low latency inputs, if input stream is not delivered on time,
-/// it quickly increases. However, when buffer is stable for some time it starts to shrink to
-/// minimize the latency.
+/// Per-track wrapper around a shared [`InnerLatencyOptimizedBuffer`]. The inner state
+/// (observation history, trend resolution, target size selection) is shared across all
+/// tracks of the same RTP stream via `Arc<Mutex<…>>`. Each track keeps its own `size`
+/// and converges linearly toward the inner's target on every `apply_offset` call, so
+/// per-track output PTS is smooth even though the target can jump.
+#[derive(Clone)]
 pub(crate) struct LatencyOptimizedBuffer {
-    reference_time: Instant,
-    state: LatencyOptimizedBufferState,
-    dynamic_buffer: Duration,
-
-    /// effective_buffer = next_pts - queue_sync_point.elapsed()
-    /// Estimates how much time packet has to reach the queue.
-
-    /// If effective_buffer is above this threshold for a period of time, aggressively shrink
-    /// the buffer.
-    shrink_threshold_1: Duration,
-    /// If effective_buffer is above this threshold for a period of time, shrink the buffer
-    /// quickly
-    shrink_threshold_2: Duration,
-    /// If effective_buffer is above this threshold for a period of time, slowly shrink the buffer.
-    max_desired_buffer: Duration,
-    /// If effective_buffer is below this value, slowly increase the buffer with every packet.
-    min_desired_buffer: Duration,
-    /// If effective_buffer is below this threshold, aggressively and immediately increase the buffer.
-    grow_threshold: Duration,
+    inner: Arc<Mutex<InnerLatencyOptimizedBuffer>>,
+    /// Per-track buffer size. Slowly converges toward `inner.target_size`.
+    size: Duration,
+    /// Per-track largest PTS seen — drives the linear convergence's stream_delta.
+    max_pts: Option<Duration>,
 }
 
 impl LatencyOptimizedBuffer {
-    fn new(ctx: &PipelineCtx, reference_time: Instant) -> Self {
-        // As a result for default numbers if effective_buffer is between 80ms and 240ms, no
-        // adjustment/optimization will be triggered
-        let grow_threshold = ctx.default_buffer_duration;
-        let min_desired_buffer = grow_threshold + ctx.default_buffer_duration;
-        let max_desired_buffer = min_desired_buffer + ctx.default_buffer_duration;
-        let shrink_threshold_2 = max_desired_buffer + Duration::from_millis(400);
-        let shrink_threshold_1 = shrink_threshold_2 + Duration::from_millis(400);
+    /// Linear convergence rate. The per-track `size` moves toward `target_size` by at
+    /// most `stream_delta * CONVERGENCE_RATE` per call (~50 ms per second of stream
+    /// time). Slow enough that target jumps don't translate into per-track jolts.
+    const CONVERGENCE_RATE: f64 = 0.04;
+    /// If the target diverges from the per-track size by more than this, snap
+    /// directly to the target instead of rate-limiting. Avoids long catch-up
+    /// after a `JumpGrow` or any other large target shift.
+    const SNAP_THRESHOLD: Duration = Duration::from_millis(200);
+
+    fn new(reference_time: Instant) -> Self {
+        let inner = InnerLatencyOptimizedBuffer::new(reference_time);
+        let size = inner.target_size;
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+            size,
+            max_pts: None,
+        }
+    }
+
+    /// Decides the size of the buffer, but the change will be applied
+    /// immediately on packets removed from jitter buffer
+    fn on_new_packet(&mut self, pts: Duration) {
+        self.inner.lock().unwrap().on_new_packet(pts);
+    }
+
+    fn apply_offset(&mut self, pts: Duration) -> Duration {
+        let target_size = self.inner.lock().unwrap().target_size;
+
+        let stream_delta = match self.max_pts {
+            Some(prev_max_pts) => {
+                self.max_pts = Some(Duration::max(prev_max_pts, pts));
+                pts.saturating_sub(prev_max_pts)
+            }
+            None => {
+                self.max_pts = Some(pts);
+                Duration::ZERO
+            }
+        };
+        if target_size.abs_diff(self.size) > Self::SNAP_THRESHOLD {
+            self.size = target_size;
+        } else {
+            let max_step = stream_delta.mul_f64(Self::CONVERGENCE_RATE);
+            self.size = if target_size > self.size {
+                Duration::min(self.size + max_step, target_size)
+            } else {
+                Duration::max(self.size.saturating_sub(max_step), target_size)
+            };
+        }
+        pts + self.size
+    }
+
+    fn target_size(&self) -> Duration {
+        // lower size will mean that packet will be popped too early, which
+        // is still preferred outcome compared to sending it too late
+        Duration::min(self.inner.lock().unwrap().target_size, self.size)
+    }
+}
+
+/// Shared trend state behind [`LatencyOptimizedBuffer`]. Holds the observation history,
+/// resolves the trend, and drives the *target* buffer size. Per-track wrappers read this
+/// target and converge their own `size` toward it.
+///
+/// All adjustments are driven by stream time (PTS deltas), never by wall clock:
+/// - Every incoming packet — including out-of-order packets with `pts <= max_pts` — re-evaluates
+///   the [`LatencyTrend`] state from its own `effective_buffer`. Late packets observed near the
+///   edge of the buffer still pull the trend toward Grow.
+/// - The target size only changes when a packet advances `max_pts`. The change is scaled by the
+///   PTS delta since the previous max, so the rate of change is bounded in stream-time terms.
+///
+/// `effective_buffer = (pts + target_size) - reference_time.elapsed()` represents how much
+/// margin a packet has before reaching the queue. Wall clock is only consulted to compute that
+/// margin; it never gates the adjustment cadence.
+struct InnerLatencyOptimizedBuffer {
+    reference_time: Instant,
+    target_size: Duration,
+
+    /// Largest PTS observed so far. Target-size changes only run when a new packet exceeds it.
+    max_pts: Option<Duration>,
+    /// PTS at which the last `+GROW_JUMP` was applied. Drives the rate-limit on
+    /// jumps; not used as a zone observation.
+    last_jump_pts: Option<Duration>,
+
+    /// Largest PTS observed with each grow-side zone classification. The effective
+    /// `trend` returns the most-grow-leaning zone whose timestamp still lies within
+    /// `TREND_WINDOW` of `pts`. A grow signal latches for the window length so that
+    /// a recent Grow outranks a newer Shrink.
+    last_jump_grow_pts: Option<Duration>,
+    last_grow_fast_pts: Option<Duration>,
+    last_grow_pts: Option<Duration>,
+    last_stable_pts: Option<Duration>,
+
+    /// PTS at which the current uninterrupted Shrink-or-stronger streak began, or
+    /// `None` if the streak was just broken by a non-shrink observation. The trend
+    /// only resolves to Shrink once `pts - shrink_streak_start >= TREND_WINDOW`,
+    /// and the streak is intentionally preserved across successive shrink scales
+    /// so we don't have to re-accumulate the window after every shrink.
+    shrink_streak_start: Option<Duration>,
+    /// Same idea for ShrinkFast — only ShrinkFast observations keep this streak
+    /// alive; a plain Shrink (or any grow-side observation) clears it.
+    shrink_fast_streak_start: Option<Duration>,
+
+    thresholds: LatencyThresholds,
+}
+
+struct LatencyThresholds {
+    /// Above this effective_buffer the buffer shrinks at the fast rate.
+    shrink_fast: Duration,
+    /// Above this effective_buffer the buffer shrinks at the slow rate.
+    shrink: Duration,
+    /// Below this effective_buffer the buffer grows proportionally at the slow rate.
+    grow: Duration,
+    /// Below this effective_buffer the buffer grows proportionally at the fast rate.
+    grow_fast: Duration,
+    /// Below this effective_buffer the buffer must jump up immediately.
+    grow_jump: Duration,
+}
+
+impl InnerLatencyOptimizedBuffer {
+    /// Slow shrink rate of stream time.
+    const SHRINK_RATE: f64 = 0.005;
+    /// Fast shrink rate per second of stream time.
+    const SHRINK_FAST_RATE: f64 = 0.02;
+    /// Slow grow rate per second of stream time.
+    const GROW_RATE: f64 = 0.01;
+    /// Fast grow rate per second of stream time.
+    const GROW_FAST_RATE: f64 = 0.03;
+    /// Fixed amount applied when the effective buffer drops below `grow_jump`.
+    const GROW_JUMP: Duration = Duration::from_millis(1000);
+    /// Minimum stream-time spacing between two grow jumps.
+    const GROW_JUMP_INTERVAL: Duration = Duration::from_millis(3000);
+    /// Stream-time window during which a per-zone observation still influences the
+    /// effective trend. Equivalent to "no contradicting trend in N seconds" — when this
+    /// window expires for a zone its observation is forgotten.
+    const TREND_WINDOW: Duration = Duration::from_secs(10);
+
+    fn new(reference_time: Instant) -> Self {
+        // Stable zone spans grow..shrink (240..320ms).
+        let thresholds = LatencyThresholds {
+            grow_jump: Duration::from_millis(80),
+            grow_fast: Duration::from_millis(160),
+            grow: Duration::from_millis(240),
+            shrink: Duration::from_millis(320),
+            shrink_fast: Duration::from_millis(2000),
+        };
         Self {
             reference_time,
-            dynamic_buffer: ctx.default_buffer_duration,
-            state: LatencyOptimizedBufferState::Ok,
-
-            grow_threshold,
-            min_desired_buffer,
-            max_desired_buffer,
-            shrink_threshold_1,
-            shrink_threshold_2,
+            target_size: Duration::from_millis(600),
+            max_pts: None,
+            last_jump_pts: None,
+            last_jump_grow_pts: None,
+            last_grow_fast_pts: None,
+            last_grow_pts: None,
+            last_stable_pts: None,
+            shrink_streak_start: None,
+            shrink_fast_streak_start: None,
+            thresholds,
         }
     }
 
-    /// pts is a value relative to time elapsed from reference_time.
-    /// If `reference_time.elapsed() == pts` that means that effective buffer is zero
+    /// Called the moment a packet is received. Classifies it against the
+    /// *receive-time* effective buffer, records the observation, resolves the
+    /// trend, and updates `target_size`. Per-track wrappers read the updated
+    /// target separately in `apply_offset`.
     fn on_new_packet(&mut self, pts: Duration) {
-        // Increment duration is larger than decrement, because when buffer is too small
-        // we don't have much time to adjust to a difference.
-        const INCREMENT_DURATION: Duration = Duration::from_micros(500);
-        const SMALL_DECREMENT_DURATION: Duration = Duration::from_micros(200);
-        const LARGE_DECREMENT_DURATION: Duration = Duration::from_micros(500);
-
-        // Duration that defines at what point we can consider state stable enough
-        // to consider shrinking the buffer
-        const STABLE_STATE_DURATION: Duration = Duration::from_secs(10);
-
-        let reference_time = self.reference_time;
-        let next_pts = pts + self.dynamic_buffer;
+        let next_pts = pts + self.target_size;
+        let effective_buffer = next_pts.saturating_sub(self.reference_time.elapsed());
+        let observed = LatencyTrend::from_effective_buffer(effective_buffer, &self.thresholds);
         trace!(
-            effective_buffer=?next_pts.saturating_sub(reference_time.elapsed()),
-            dynamic_buffer=?self.dynamic_buffer,
-            ?pts
+            ?effective_buffer,
+            target_size=?self.target_size,
+            ?observed,
+            "Latency trend observation",
         );
+        self.record_observation(observed, pts);
 
-        if next_pts > reference_time.elapsed() + self.shrink_threshold_1 {
-            let first_pts = self.state.set_too_large(next_pts);
-            if next_pts.saturating_sub(first_pts) > STABLE_STATE_DURATION {
-                self.dynamic_buffer = self
-                    .dynamic_buffer
-                    .saturating_sub(self.dynamic_buffer / 1000);
+        // Advance `max_pts` and compute the stream-time delta. For out-of-order or
+        // first packets the delta is zero, which makes every proportional op a noop.
+        let stream_delta = match self.max_pts {
+            Some(prev_max_pts) => {
+                self.max_pts = Some(Duration::max(prev_max_pts, pts));
+                pts.saturating_sub(prev_max_pts)
             }
-        } else if next_pts > reference_time.elapsed() + self.shrink_threshold_2 {
-            let first_pts = self.state.set_too_large(next_pts);
-            if next_pts.saturating_sub(first_pts) > STABLE_STATE_DURATION {
-                self.dynamic_buffer = self.dynamic_buffer.saturating_sub(LARGE_DECREMENT_DURATION);
+            None => {
+                self.max_pts = Some(pts);
+                Duration::ZERO
             }
-        } else if next_pts > reference_time.elapsed() + self.max_desired_buffer {
-            let first_pts = self.state.set_too_large(next_pts);
-            if next_pts.saturating_sub(first_pts) > STABLE_STATE_DURATION {
-                self.dynamic_buffer = self.dynamic_buffer.saturating_sub(SMALL_DECREMENT_DURATION);
+        };
+
+        match self.resolve_trend(pts) {
+            LatencyTrend::ShrinkFast => self.scale_target(-Self::SHRINK_FAST_RATE, stream_delta),
+            LatencyTrend::Shrink => self.scale_target(-Self::SHRINK_RATE, stream_delta),
+            LatencyTrend::Stable => {}
+            LatencyTrend::Grow => self.scale_target(Self::GROW_RATE, stream_delta),
+            LatencyTrend::GrowFast => self.scale_target(Self::GROW_FAST_RATE, stream_delta),
+            LatencyTrend::JumpGrow => self.try_grow_jump(pts),
+        }
+    }
+
+    fn record_observation(&mut self, observed: LatencyTrend, pts: Duration) {
+        let grow_slot = match observed {
+            LatencyTrend::JumpGrow => Some(&mut self.last_jump_grow_pts),
+            LatencyTrend::GrowFast => Some(&mut self.last_grow_fast_pts),
+            LatencyTrend::Grow => Some(&mut self.last_grow_pts),
+            LatencyTrend::Stable => Some(&mut self.last_stable_pts),
+            LatencyTrend::Shrink | LatencyTrend::ShrinkFast => None,
+        };
+        if let Some(slot) = grow_slot {
+            *slot = Some(match *slot {
+                Some(prev) => Duration::max(prev, pts),
+                None => pts,
+            });
+        }
+
+        // Shrink streaks accumulate continuous evidence; any contradicting
+        // observation breaks the streak so the next shrink has to start over.
+        match observed {
+            LatencyTrend::ShrinkFast => {
+                self.shrink_streak_start.get_or_insert(pts);
+                self.shrink_fast_streak_start.get_or_insert(pts);
             }
-        } else if next_pts > reference_time.elapsed() + self.min_desired_buffer {
-            self.state.set_ok();
-        } else if next_pts > reference_time.elapsed() + self.grow_threshold {
-            trace!(
-                old=?self.dynamic_buffer,
-                new=?self.dynamic_buffer + INCREMENT_DURATION,
-                "Increase latency optimized buffer"
-            );
-            self.state.set_too_small();
-            self.dynamic_buffer += INCREMENT_DURATION;
+            LatencyTrend::Shrink => {
+                self.shrink_streak_start.get_or_insert(pts);
+                self.shrink_fast_streak_start = None;
+            }
+            LatencyTrend::Stable
+            | LatencyTrend::Grow
+            | LatencyTrend::GrowFast
+            | LatencyTrend::JumpGrow => {
+                self.shrink_streak_start = None;
+                self.shrink_fast_streak_start = None;
+            }
+        }
+    }
+
+    /// Walk the zones from most-grow to most-shrink. Grow-side zones latch on a single
+    /// recent observation. Shrink-side zones require a continuous streak of at least
+    /// `TREND_WINDOW` of stream time, so an isolated shrink signal never fires.
+    fn resolve_trend(&self, pts: Duration) -> LatencyTrend {
+        let recent = |last: Option<Duration>| -> bool {
+            last.is_some_and(|p| pts.saturating_sub(p) < Self::TREND_WINDOW)
+        };
+        let streak_ready = |start: Option<Duration>| -> bool {
+            start.is_some_and(|s| pts.saturating_sub(s) >= Self::TREND_WINDOW)
+        };
+        if recent(self.last_jump_grow_pts) {
+            LatencyTrend::JumpGrow
+        } else if recent(self.last_grow_fast_pts) {
+            LatencyTrend::GrowFast
+        } else if recent(self.last_grow_pts) {
+            LatencyTrend::Grow
+        } else if recent(self.last_stable_pts) {
+            LatencyTrend::Stable
+        } else if streak_ready(self.shrink_fast_streak_start) {
+            LatencyTrend::ShrinkFast
+        } else if streak_ready(self.shrink_streak_start) {
+            LatencyTrend::Shrink
         } else {
-            let new_buffer =
-                (reference_time.elapsed() + self.max_desired_buffer).saturating_sub(pts);
-            debug!(
-                old=?self.dynamic_buffer,
-                new=?new_buffer,
-                "Increase latency optimized buffer (force)"
-            );
-            self.state.set_too_small();
-            // adjust buffer so:
-            // pts + self.dynamic_buffer == self.sync_point.elapsed() + self.max_desired_buffer
-            self.dynamic_buffer = new_buffer
-        }
-    }
-}
-
-enum LatencyOptimizedBufferState {
-    Ok,
-    TooSmall,
-    TooLarge { first_pts: Duration },
-}
-
-impl LatencyOptimizedBufferState {
-    fn set_too_large(&mut self, pts: Duration) -> Duration {
-        match &self {
-            LatencyOptimizedBufferState::TooLarge { first_pts } => *first_pts,
-            _ => {
-                *self = LatencyOptimizedBufferState::TooLarge { first_pts: pts };
-                pts
-            }
+            LatencyTrend::Stable
         }
     }
 
-    fn set_too_small(&mut self) {
-        *self = LatencyOptimizedBufferState::TooSmall
+    fn scale_target(&mut self, rate: f64, stream_delta: Duration) {
+        if stream_delta == Duration::ZERO {
+            return;
+        }
+        let factor = 1.0 + rate * stream_delta.as_secs_f64();
+        let new_size = self.target_size.mul_f64(factor.max(0.0));
+        trace!(
+            ?new_size,
+            size_diff_secs = new_size.as_secs_f64() - self.target_size.as_secs_f64(),
+            rate,
+            "Scale latency optimized target"
+        );
+        self.target_size = new_size;
+        self.reset_grow_observations();
     }
 
-    fn set_ok(&mut self) {
-        *self = LatencyOptimizedBufferState::Ok
+    fn try_grow_jump(&mut self, pts: Duration) {
+        self.reset_grow_observations();
+        if let Some(last) = self.last_jump_pts
+            && pts.saturating_sub(last) < Self::GROW_JUMP_INTERVAL
+        {
+            return;
+        }
+
+        self.last_jump_pts = Some(pts);
+        let new_size = self.target_size + Self::GROW_JUMP;
+        debug!(?new_size, "Grow latency optimized target (jump)");
+        self.target_size = new_size;
+    }
+
+    /// All grow-side observations were measured against the old target
+    /// size; after a target change they no longer reflect reality. Stable is kept
+    /// because its zone remains valid after either direction of change and is what
+    /// blocks spurious cross-side firing via the priority resolver. Shrink streaks
+    /// are *not* reset here: continuing a shrink streak across successive shrink
+    /// scales is the whole point of the streak — we don't want to re-accumulate
+    /// `TREND_WINDOW` of evidence after every shrink.
+    fn reset_grow_observations(&mut self) {
+        self.last_jump_grow_pts = None;
+        self.last_grow_fast_pts = None;
+        self.last_grow_pts = None;
+    }
+}
+
+/// State machine deciding which direction the buffer should move on the next PTS-advancing
+/// packet. Re-derived per packet from `effective_buffer`.
+#[derive(Debug, Clone, Copy)]
+enum LatencyTrend {
+    /// effective_buffer < grow_jump — must add a fixed jump.
+    JumpGrow,
+    /// effective_buffer in [grow_jump, grow_fast) — grow proportionally at the fast rate.
+    GrowFast,
+    /// effective_buffer in [grow_fast, grow) — grow proportionally at the slow rate.
+    Grow,
+    /// effective_buffer in [grow, shrink) — leave alone.
+    Stable,
+    /// effective_buffer in [shrink, shrink_fast) — shrink proportionally at the slow rate.
+    Shrink,
+    /// effective_buffer >= shrink_fast — shrink proportionally at the fast rate.
+    ShrinkFast,
+}
+
+impl LatencyTrend {
+    fn from_effective_buffer(effective_buffer: Duration, t: &LatencyThresholds) -> Self {
+        if effective_buffer >= t.shrink_fast {
+            Self::ShrinkFast
+        } else if effective_buffer >= t.shrink {
+            Self::Shrink
+        } else if effective_buffer >= t.grow {
+            Self::Stable
+        } else if effective_buffer >= t.grow_fast {
+            Self::Grow
+        } else if effective_buffer >= t.grow_jump {
+            Self::GrowFast
+        } else {
+            Self::JumpGrow
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,13 +144,13 @@ fn try_read_config() -> Result<Config, String> {
     };
     let gpu_driver_name = env::var("SMELTER_GPU_DEVICE_DRIVER").ok();
 
-    const DEFAULT_STREAM_FALLBACK_TIMEOUT: Duration = Duration::from_millis(2000);
+    const DEFAULT_STREAM_FALLBACK_TIMEOUT: Duration = Duration::from_millis(3000);
     let stream_fallback_timeout = match env::var("SMELTER_STREAM_FALLBACK_TIMEOUT_MS") {
         Ok(timeout_ms) => match timeout_ms.parse::<f64>() {
             Ok(timeout_ms) => Duration::from_secs_f64(timeout_ms / 1000.0),
             Err(_) => {
                 println!(
-                    "CONFIG ERROR: Invalid value provided for \"SMELTER_STREAM_FALLBACK_TIMEOUT_MS\". Falling back to default value 2000ms."
+                    "CONFIG ERROR: Invalid value provided for \"SMELTER_STREAM_FALLBACK_TIMEOUT_MS\". Falling back to default value 3000ms."
                 );
                 DEFAULT_STREAM_FALLBACK_TIMEOUT
             }


### PR DESCRIPTION
Jitter buffer algo:
- starts with 600ms
- on each package incoming from the network (the inner struct shared between tracks)
  - decide trend based on effective buffer (queue_sync_point.elapsed() - packet_pts)
  - Below 80ms - increase buffer immediately by one second (thrtled to trigger at most every 3 seconds)
  - Below 160ms - select trend GrowFast
  - Below 240ms - select trend Grow
  - Above 320ms - and all packets in the past 10 seconds were above then select Shrink
  - Above 2000ms -  and all packets in the past 10 seconds were above, then select ShrinkFast
  - If packet pts is larger than max pts, then modify buffer based on trend. It can only be modified as a percentage of the distance from last, e.g. if GrowFast then increase by diff * 0.03
- Per-track wrapper
  - There might be cases where audio does not increase, but video does, or the other way around, so it could cause a situation where the video increased buffer and then we got an audio packet that would jump by a large value. That is why there is an additional per-track layer that is smoothing it out, so the single step is not larger than 4%.

When popping a packet from the buffer
- shared struct stores target size
- per-track struct stores actual size (and tries to converge on target)
- actual pts from per-track struct are used when modifying popped packet pts
- When calculating next_pts to decide whether the packet needs to be popped, we use `min(target_size, real_size)`. I think it is a good trade-off, that at worst it is causing pop a bit earlier
  