### PR TITLE
`WHIP` input required handled.

### DIFF
--- a/integration-tests/examples/demo/inputs/whip.rs
+++ b/integration-tests/examples/demo/inputs/whip.rs
@@ -40,6 +40,7 @@ impl WhipInput {
             "type": "whip_server",
             "bearer_token": self.bearer_token,
             "video": self.video.as_ref().map(|v| v.serialize_register()),
+            "required": true,
         })
     }
 

--- a/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
@@ -145,13 +145,13 @@ pub(crate) async fn create_new_whip_session(
             audio_track: None,
         }));
 
-        // Timeout: if the second track hasn't arrived within 3 seconds,
+        // Timeout: if the second track hasn't arrived within 2 seconds,
         // resolve with whatever tracks we have so far. This prevents
         // indefinite waiting when a client only sends audio or only video.
         {
             let deferred_state = deferred_state.clone();
             tokio::spawn(async move {
-                tokio::time::sleep(Duration::from_secs(3)).await;
+                tokio::time::sleep(Duration::from_secs(2)).await;
                 deferred_state.lock().unwrap().resolve();
             });
         }

--- a/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
@@ -1,10 +1,17 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
-use tracing::debug;
+use tracing::{debug, warn};
 use uuid::Uuid;
-use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
+use webrtc::{
+    peer_connection::sdp::session_description::RTCSessionDescription,
+    rtp_transceiver::rtp_codec::RTPCodecType,
+};
 
 use crate::{
+    codecs::VideoDecoderOptions,
     pipeline::{
         rtp::{RtpJitterBufferMode, RtpJitterBufferSharedContext},
         webrtc::{
@@ -13,15 +20,63 @@ use crate::{
             offer_codec_filter::codecs_from_offer,
             peer_connection_recvonly::RecvonlyPeerConnection,
             whip_input::{
-                WhipTrackContext, on_track::handle_on_track, state::WhipInputSession,
+                WhipTrackContext,
+                on_track::{handle_audio_track, handle_video_track},
+                state::WhipInputSession,
                 video_preferences::video_params_compliant_with_offer,
             },
         },
     },
-    queue::{QueueTrackOffset, QueueTrackOptions},
+    queue::{QueueInput, QueueTrackOffset, QueueTrackOptions},
 };
 
 use crate::prelude::*;
+
+/// Tracks which media tracks have arrived and defers queue creation
+/// until we know exactly which track types the WHIP client sends.
+struct DeferredTrackState {
+    queue_input: QueueInput,
+    resolved: bool,
+    video_track: Option<(WhipTrackContext, Ref<InputId>, Vec<VideoDecoderOptions>)>,
+    audio_track: Option<(WhipTrackContext, Ref<InputId>)>,
+}
+
+impl DeferredTrackState {
+    /// Resolve the deferred state: create the queue track with only the arrived
+    /// track types and start processing all buffered tracks.
+    fn resolve(&mut self) {
+        if self.resolved {
+            return;
+        }
+        self.resolved = true;
+
+        let has_video = self.video_track.is_some();
+        let has_audio = self.audio_track.is_some();
+
+        if !has_video && !has_audio {
+            warn!("Deferred track state resolved with no tracks");
+            return;
+        }
+
+        let (video_sender, audio_sender) = self.queue_input.queue_new_track(QueueTrackOptions {
+            video: has_video,
+            audio: has_audio,
+            offset: QueueTrackOffset::Pts(Duration::ZERO),
+        });
+
+        if let Some((ctx, input_ref, video_preferences)) = self.video_track.take()
+            && let Some(sender) = video_sender
+        {
+            handle_video_track(ctx, input_ref, video_preferences, sender);
+        }
+
+        if let Some((ctx, input_ref)) = self.audio_track.take()
+            && let Some(sender) = audio_sender
+        {
+            handle_audio_track(ctx, input_ref, sender);
+        }
+    }
+}
 
 pub(crate) async fn create_new_whip_session(
     state: WhipWhepServerState,
@@ -83,21 +138,57 @@ pub(crate) async fn create_new_whip_session(
             state.ctx.queue_ctx.sync_point,
         );
 
-        let (mut video_sender, mut audio_sender) = queue_input.queue_new_track(QueueTrackOptions {
-            video: true,
-            audio: true,
-            offset: QueueTrackOffset::Pts(Duration::ZERO),
-        });
+        let deferred_state = Arc::new(Mutex::new(DeferredTrackState {
+            queue_input,
+            resolved: false,
+            video_track: None,
+            audio_track: None,
+        }));
+
+        // Timeout: if the second track hasn't arrived within 3 seconds,
+        // resolve with whatever tracks we have so far. This prevents
+        // indefinite waiting when a client only sends audio or only video.
+        {
+            let deferred_state = deferred_state.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(3)).await;
+                deferred_state.lock().unwrap().resolve();
+            });
+        }
 
         peer_connection.on_track(move |track_ctx| {
             let ctx = WhipTrackContext::new(track_ctx, &state, &buffer);
-            handle_on_track(
-                ctx,
-                input_ref.clone(),
-                video_preferences.clone(),
-                &mut video_sender,
-                &mut audio_sender,
-            );
+            let kind = ctx.track.kind();
+            debug!(?kind, input_id=%input_ref, "on_track called");
+
+            let mut deferred = deferred_state.lock().unwrap();
+            match kind {
+                RTPCodecType::Video => {
+                    if deferred.video_track.is_some() {
+                        warn!("Video track already registered");
+                        return;
+                    }
+                    deferred.video_track =
+                        Some((ctx, input_ref.clone(), video_preferences.clone()));
+                }
+                RTPCodecType::Audio => {
+                    if deferred.audio_track.is_some() {
+                        warn!("Audio track already registered");
+                        return;
+                    }
+                    deferred.audio_track = Some((ctx, input_ref.clone()));
+                }
+                RTPCodecType::Unspecified => {
+                    warn!("Unknown track kind");
+                    return;
+                }
+            }
+
+            // If both tracks have arrived, resolve immediately without
+            // waiting for the timeout.
+            if deferred.video_track.is_some() && deferred.audio_track.is_some() {
+                deferred.resolve();
+            }
         })
     };
 

--- a/smelter-core/src/pipeline/webrtc/whip_input/on_track.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/on_track.rs
@@ -22,52 +22,46 @@ use crate::{
 
 use crate::prelude::*;
 
-pub(super) fn handle_on_track(
+pub(super) fn handle_video_track(
     ctx: WhipTrackContext,
     input_ref: Ref<InputId>,
     video_preferences: Vec<VideoDecoderOptions>,
-    video_sender: &mut Option<QueueSender<Frame>>,
-    audio_sender: &mut Option<QueueSender<InputAudioSamples>>,
+    video_sender: QueueSender<Frame>,
 ) {
-    let kind = ctx.track.kind();
+    let kind = RTPCodecType::Video;
     let span = info_span!("WHIP input track", ?kind, input_id=%input_ref);
     {
         let _span = span.enter();
-        debug!("on_track called");
+        debug!("starting video track processing");
     }
-    match kind {
-        RTPCodecType::Audio => {
-            let Some(audio_sender) = audio_sender.take() else {
-                warn!("Audio track already started");
-                return;
-            };
-            let task = async move {
-                if let Err(err) = process_audio_track(ctx, input_ref, audio_sender).await {
-                    // TODO: address after WhipWhepServerError rework
-                    warn!(?err, "On track handler failed")
-                }
-            };
-            tokio::spawn(task.instrument(span));
-        }
-        RTPCodecType::Video => {
-            let Some(video_sender) = video_sender.take() else {
-                warn!("Audio track already started");
-                return;
-            };
-            let task = async move {
-                if let Err(err) =
-                    process_video_track(ctx, input_ref, video_preferences, video_sender).await
-                {
-                    // TODO: address after WhipWhepServerError rework
-                    warn!(?err, "On track handler failed")
-                }
-            };
-            tokio::spawn(task.instrument(span));
-        }
-        RTPCodecType::Unspecified => {
-            warn!("Unknown track kind");
+    let task = async move {
+        if let Err(err) = process_video_track(ctx, input_ref, video_preferences, video_sender).await
+        {
+            // TODO: address after WhipWhepServerError rework
+            warn!(?err, "On track handler failed")
         }
     };
+    tokio::spawn(task.instrument(span));
+}
+
+pub(super) fn handle_audio_track(
+    ctx: WhipTrackContext,
+    input_ref: Ref<InputId>,
+    audio_sender: QueueSender<InputAudioSamples>,
+) {
+    let kind = RTPCodecType::Audio;
+    let span = info_span!("WHIP input track", ?kind, input_id=%input_ref);
+    {
+        let _span = span.enter();
+        debug!("starting audio track processing");
+    }
+    let task = async move {
+        if let Err(err) = process_audio_track(ctx, input_ref, audio_sender).await {
+            // TODO: address after WhipWhepServerError rework
+            warn!(?err, "On track handler failed")
+        }
+    };
+    tokio::spawn(task.instrument(span));
 }
 
 async fn process_audio_track(


### PR DESCRIPTION
This solution works by calling the `.queue_new_track()` after the `.on_track()`. It utilizes shared state to check which tracks (audio or video) actually send data and add only them into the queue.
Queue is started if **one** of the following happens:
- 2 seconds pass
- `.on_track()` handle is called for both audio and video.