### PR TITLE
`WHIP` / `WHEP` input required single track fixed.

### DIFF
--- a/smelter-core/src/pipeline/webrtc/whep_input/input.rs
+++ b/smelter-core/src/pipeline/webrtc/whep_input/input.rs
@@ -193,8 +193,11 @@ async fn init_whep_client(
         let video_sender = Arc::new(Mutex::new(video_sender));
         let audio_sender = Arc::new(Mutex::new(audio_sender));
 
-        // Drop senders if appropriate tracks do not come within 2 seconds.
-        wait_for_tracks(video_sender.clone(), audio_sender.clone());
+        // If the input is required, drop senders if appropriate tracks do not
+        // come within 2 seconds.
+        if queue_input.required() {
+            wait_for_tracks(video_sender.clone(), audio_sender.clone());
+        }
 
         pc.on_track(move |track_ctx| {
             let ctx = WhepTrackContext::new(track_ctx, &ctx, &buffer);

--- a/smelter-core/src/pipeline/webrtc/whep_input/input.rs
+++ b/smelter-core/src/pipeline/webrtc/whep_input/input.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::Arc,
+    sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant},
 };
@@ -23,7 +23,7 @@ use crate::{
             },
         },
     },
-    queue::{QueueInput, QueueTrackOffset, QueueTrackOptions},
+    queue::{QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions},
 };
 
 use crate::prelude::*;
@@ -184,11 +184,17 @@ async fn init_whep_client(
             ctx.queue_ctx.sync_point,
         );
 
-        let (mut video_sender, mut audio_sender) = queue_input.queue_new_track(QueueTrackOptions {
+        let (video_sender, audio_sender) = queue_input.queue_new_track(QueueTrackOptions {
             video: true,
             audio: true,
             offset: QueueTrackOffset::Pts(Duration::ZERO),
         });
+
+        let video_sender = Arc::new(Mutex::new(video_sender));
+        let audio_sender = Arc::new(Mutex::new(audio_sender));
+
+        // Drop senders if appropriate tracks do not come within 2 seconds.
+        wait_for_tracks(video_sender.clone(), audio_sender.clone());
 
         pc.on_track(move |track_ctx| {
             let ctx = WhepTrackContext::new(track_ctx, &ctx, &buffer);
@@ -196,8 +202,8 @@ async fn init_whep_client(
                 ctx,
                 input_ref.clone(),
                 video_preferences.clone(),
-                &mut video_sender,
-                &mut audio_sender,
+                &video_sender,
+                &audio_sender,
             );
         });
     }
@@ -212,4 +218,24 @@ async fn init_whep_client(
         InputInitInfo::Other,
         queue_input,
     ))
+}
+
+/// This function prevents queue lock if there is only one video or audio track and input is
+/// required. If track is not received within 2 seconds from connection start, the sender is dropped
+/// and the queue is unblocked.
+fn wait_for_tracks(
+    video_sender: Arc<Mutex<Option<QueueSender<Frame>>>>,
+    audio_sender: Arc<Mutex<Option<QueueSender<InputAudioSamples>>>>,
+) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let mut video_sender = video_sender.lock().unwrap();
+        let mut audio_sender = audio_sender.lock().unwrap();
+        if video_sender.take().is_some() {
+            debug!("Video track not started, sender dropped!");
+        }
+        if audio_sender.take().is_some() {
+            debug!("Audio track not started, sender dropped!");
+        }
+    });
 }

--- a/smelter-core/src/pipeline/webrtc/whep_input/on_track.rs
+++ b/smelter-core/src/pipeline/webrtc/whep_input/on_track.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use tracing::{Instrument, debug, info_span, trace, warn};
 use webrtc::rtp_transceiver::rtp_codec::RTPCodecType;
 
@@ -24,8 +26,8 @@ pub fn handle_on_track(
     ctx: WhepTrackContext,
     input_ref: Ref<InputId>,
     video_preferences: Vec<VideoDecoderOptions>,
-    video_sender: &mut Option<QueueSender<Frame>>,
-    audio_sender: &mut Option<QueueSender<InputAudioSamples>>,
+    video_sender: &Arc<Mutex<Option<QueueSender<Frame>>>>,
+    audio_sender: &Arc<Mutex<Option<QueueSender<InputAudioSamples>>>>,
 ) {
     let kind = ctx.track.kind();
     let span = info_span!("WHEP input track", ?kind, input_id=%input_ref);
@@ -36,8 +38,8 @@ pub fn handle_on_track(
 
     match kind {
         RTPCodecType::Audio => {
-            let Some(audio_sender) = audio_sender.take() else {
-                warn!("Audio track already started");
+            let Some(audio_sender) = audio_sender.lock().unwrap().take() else {
+                warn!("Audio sender not available, track already started or dropped after timeout");
                 return;
             };
             let task = async move {
@@ -49,8 +51,8 @@ pub fn handle_on_track(
             tokio::spawn(task.instrument(span));
         }
         RTPCodecType::Video => {
-            let Some(video_sender) = video_sender.take() else {
-                warn!("Audio track already started");
+            let Some(video_sender) = video_sender.lock().unwrap().take() else {
+                warn!("Video sender not available, track already started or dropped after timeout");
                 return;
             };
             let task = async move {

--- a/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use tracing::debug;
 use uuid::Uuid;
@@ -18,7 +21,7 @@ use crate::{
             },
         },
     },
-    queue::{QueueTrackOffset, QueueTrackOptions},
+    queue::{QueueSender, QueueTrackOffset, QueueTrackOptions},
 };
 
 use crate::prelude::*;
@@ -92,11 +95,17 @@ pub(crate) async fn create_new_whip_session(
             state.ctx.queue_ctx.sync_point,
         );
 
-        let (mut video_sender, mut audio_sender) = queue_input.queue_new_track(QueueTrackOptions {
+        let (video_sender, audio_sender) = queue_input.queue_new_track(QueueTrackOptions {
             video: true,
             audio: true,
             offset: QueueTrackOffset::Pts(Duration::ZERO),
         });
+
+        let video_sender = Arc::new(Mutex::new(video_sender));
+        let audio_sender = Arc::new(Mutex::new(audio_sender));
+
+        // Drop senders if appropriate tracks do not come within 2 seconds.
+        wait_for_tracks(video_sender.clone(), audio_sender.clone());
 
         peer_connection.on_track(move |track_ctx| {
             let ctx = WhipTrackContext::new(track_ctx, &state, &buffer);
@@ -104,11 +113,31 @@ pub(crate) async fn create_new_whip_session(
                 ctx,
                 input_ref.clone(),
                 video_preferences.clone(),
-                &mut video_sender,
-                &mut audio_sender,
+                &video_sender,
+                &audio_sender,
             );
         })
     };
 
     Ok((session_id, answer))
+}
+
+/// This function prevents queue lock if there is only one video or audio track and input is
+/// required. If track is not received within 2 seconds from connection start, the sender is dropped
+/// and the queue is unblocked.
+fn wait_for_tracks(
+    video_sender: Arc<Mutex<Option<QueueSender<Frame>>>>,
+    audio_sender: Arc<Mutex<Option<QueueSender<InputAudioSamples>>>>,
+) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let mut video_sender = video_sender.lock().unwrap();
+        let mut audio_sender = audio_sender.lock().unwrap();
+        if video_sender.take().is_some() {
+            debug!("Video track not started, sender dropped!");
+        }
+        if audio_sender.take().is_some() {
+            debug!("Audio track not started, sender dropped!");
+        }
+    });
 }

--- a/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/create_new_session.rs
@@ -104,8 +104,11 @@ pub(crate) async fn create_new_whip_session(
         let video_sender = Arc::new(Mutex::new(video_sender));
         let audio_sender = Arc::new(Mutex::new(audio_sender));
 
-        // Drop senders if appropriate tracks do not come within 2 seconds.
-        wait_for_tracks(video_sender.clone(), audio_sender.clone());
+        // If the input is required, drop senders if appropriate tracks do not
+        // come within 2 seconds.
+        if queue_input.required() {
+            wait_for_tracks(video_sender.clone(), audio_sender.clone());
+        }
 
         peer_connection.on_track(move |track_ctx| {
             let ctx = WhipTrackContext::new(track_ctx, &state, &buffer);

--- a/smelter-core/src/pipeline/webrtc/whip_input/on_track.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/on_track.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use tracing::{Instrument, debug, info_span, trace, warn};
 use webrtc::rtp_transceiver::rtp_codec::RTPCodecType;
 
@@ -26,8 +28,8 @@ pub(super) fn handle_on_track(
     ctx: WhipTrackContext,
     input_ref: Ref<InputId>,
     video_preferences: Vec<VideoDecoderOptions>,
-    video_sender: &mut Option<QueueSender<Frame>>,
-    audio_sender: &mut Option<QueueSender<InputAudioSamples>>,
+    video_sender: &Arc<Mutex<Option<QueueSender<Frame>>>>,
+    audio_sender: &Arc<Mutex<Option<QueueSender<InputAudioSamples>>>>,
 ) {
     let kind = ctx.track.kind();
     let span = info_span!("WHIP input track", ?kind, input_id=%input_ref);
@@ -37,8 +39,8 @@ pub(super) fn handle_on_track(
     }
     match kind {
         RTPCodecType::Audio => {
-            let Some(audio_sender) = audio_sender.take() else {
-                warn!("Audio track already started");
+            let Some(audio_sender) = audio_sender.lock().unwrap().take() else {
+                warn!("Audio sender not available, track already started or dropped after timeout");
                 return;
             };
             let task = async move {
@@ -50,8 +52,8 @@ pub(super) fn handle_on_track(
             tokio::spawn(task.instrument(span));
         }
         RTPCodecType::Video => {
-            let Some(video_sender) = video_sender.take() else {
-                warn!("Audio track already started");
+            let Some(video_sender) = video_sender.lock().unwrap().take() else {
+                warn!("Video sender not available, track already started or dropped after timeout");
                 return;
             };
             let task = async move {

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -282,6 +282,10 @@ impl QueueInput {
         self.0.lock().unwrap().resume();
     }
 
+    pub fn required(&self) -> bool {
+        self.0.lock().unwrap().required
+    }
+
     pub fn downgrade(&self) -> WeakQueueInput {
         WeakQueueInput(Arc::downgrade(&self.0))
     }


### PR DESCRIPTION
Fixes the issue where the video or audio only required track stalls the whole queue.