### PR TITLE
Re-sync rtcp based on time

### DIFF
--- a/smelter-core/src/pipeline/rtp/rtp_input/jitter_buffer.rs
+++ b/smelter-core/src/pipeline/rtp/rtp_input/jitter_buffer.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     fmt,
     sync::{Arc, Mutex},
     time::{Duration, Instant},
@@ -125,7 +125,10 @@ impl RtpJitterBuffer {
             ntp_sync_point,
             input_buffer,
         } = shared_ctx;
-        let timestamp_sync = RtpTimestampSync::new(ntp_sync_point.clone(), clock_rate);
+        // Real-time mode treats RTP timestamps as wall-clock-aligned and
+        // enables synchronization features better for that use case.
+        let real_time = matches!(mode, RtpJitterBufferMode::RealTime { .. });
+        let timestamp_sync = RtpTimestampSync::new(ntp_sync_point.clone(), clock_rate, real_time);
 
         Self {
             mode,
@@ -175,6 +178,16 @@ impl RtpJitterBuffer {
         // reorders and minimize large jumps
         //
         self.input_buffer.on_new_packet(pts);
+
+        // Receive-time margin: how far in the future this packet's output
+        // PTS sits compared to wall clock the moment it lands. The pop-side
+        // counterpart is emitted in `read_packet` after `apply_offset` runs.
+        let reference_time = self.ntp_sync_point.reference_time;
+        let effective_buffer =
+            (pts + self.input_buffer.size()).saturating_sub(reference_time.elapsed());
+        (self.on_stats_event)(RtpJitterBufferStatsEvent::EffectiveBufferOnWrite(
+            effective_buffer,
+        ));
 
         trace!(packet=?packet.header, ?pts, buffer_size=self.packets.len(), "Writing packet to jitter buffer");
         self.packets
@@ -231,7 +244,7 @@ impl RtpJitterBuffer {
         let timestamp = self.input_buffer.apply_offset(packet.pts);
 
         let reference_time = self.ntp_sync_point.reference_time;
-        (self.on_stats_event)(RtpJitterBufferStatsEvent::EffectiveBuffer(
+        (self.on_stats_event)(RtpJitterBufferStatsEvent::EffectiveBufferOnPop(
             timestamp.saturating_sub(reference_time.elapsed()),
         ));
         (self.on_stats_event)(RtpJitterBufferStatsEvent::InputBufferSize(
@@ -312,10 +325,11 @@ pub(crate) struct LatencyOptimizedBuffer {
 }
 
 impl LatencyOptimizedBuffer {
-    /// Linear convergence rate. The per-track `size` moves toward `target_size` by at
-    /// most `stream_delta * CONVERGENCE_RATE` per call (~50 ms per second of stream
-    /// time). Slow enough that target jumps don't translate into per-track jolts.
-    const CONVERGENCE_RATE: f64 = 0.04;
+    const MAX_CONVERGENCE_RATE: f64 = 0.04;
+    /// Below this threshold, convergence rate scales linearly from 0 to
+    /// `MAX_CONVERGENCE_RATE` based on `|size - target|`. Prevents burst
+    /// catch-up after a hold from exceeding the inner buffer's actual rate.
+    const LINEAR_THRESHOLD: Duration = Duration::from_millis(50);
     /// If the target diverges from the per-track size by more than this, snap
     /// directly to the target instead of rate-limiting. Avoids long catch-up
     /// after a `JumpGrow` or any other large target shift.
@@ -350,15 +364,20 @@ impl LatencyOptimizedBuffer {
                 Duration::ZERO
             }
         };
-        if target_size.abs_diff(self.size) > Self::SNAP_THRESHOLD {
+        let diff = target_size.abs_diff(self.size);
+        if diff > Self::SNAP_THRESHOLD {
             self.size = target_size;
         } else {
-            let max_step = stream_delta.mul_f64(Self::CONVERGENCE_RATE);
-            self.size = if target_size > self.size {
-                Duration::min(self.size + max_step, target_size)
-            } else {
-                Duration::max(self.size.saturating_sub(max_step), target_size)
-            };
+            let rate = Self::MAX_CONVERGENCE_RATE
+                * f64::min(
+                    1.0,
+                    diff.as_secs_f64() / Self::LINEAR_THRESHOLD.as_secs_f64(),
+                );
+            let max_step = stream_delta.mul_f64(rate);
+            self.size = target_size.clamp(
+                self.size.saturating_sub(max_step),
+                self.size.saturating_add(max_step),
+            );
         }
         pts + self.size
     }
@@ -390,9 +409,15 @@ struct InnerLatencyOptimizedBuffer {
 
     /// Largest PTS observed so far. Target-size changes only run when a new packet exceeds it.
     max_pts: Option<Duration>,
-    /// PTS at which the last `+GROW_JUMP` was applied. Drives the rate-limit on
-    /// jumps; not used as a zone observation.
-    last_jump_pts: Option<Duration>,
+    /// PTS at which the last `+GROW_JUMP` was applied. Drives the rate-limit
+    /// on jumps; not used as a zone observation. Initialized to `ZERO` and
+    /// re-anchored to the first observed PTS in `on_new_packet` so the same
+    /// `GROW_JUMP_INTERVAL` throttle also blocks an early jump in the first
+    /// `GROW_JUMP_INTERVAL` of stream — startup transients (initial SR
+    /// slew, NTP-snap, fill-buffer bursts) routinely produce a low
+    /// effective_buffer that would otherwise instantly inflate the target
+    /// before the proportional grow rates have a chance to react.
+    last_jump_pts: Duration,
 
     /// Largest PTS observed with each grow-side zone classification. The effective
     /// `trend` returns the most-grow-leaning zone whose timestamp still lies within
@@ -413,20 +438,15 @@ struct InnerLatencyOptimizedBuffer {
     /// alive; a plain Shrink (or any grow-side observation) clears it.
     shrink_fast_streak_start: Option<Duration>,
 
-    thresholds: LatencyThresholds,
-}
+    /// Stream-time PTS of recent successful grow jumps within the last
+    /// `JUMP_RECURRENCE_WINDOW`. Once the count exceeds
+    /// `JUMP_RECURRENCE_THRESHOLD` we treat the spikes as a recurring pattern,
+    /// shift every threshold (except `grow_jump`) up by `THRESHOLD_BUMP` to
+    /// raise the comfort zone, and clear the deque so the next bump requires
+    /// a fresh window of recurrence.
+    recent_jump_pts: VecDeque<Duration>,
 
-struct LatencyThresholds {
-    /// Above this effective_buffer the buffer shrinks at the fast rate.
-    shrink_fast: Duration,
-    /// Above this effective_buffer the buffer shrinks at the slow rate.
-    shrink: Duration,
-    /// Below this effective_buffer the buffer grows proportionally at the slow rate.
-    grow: Duration,
-    /// Below this effective_buffer the buffer grows proportionally at the fast rate.
-    grow_fast: Duration,
-    /// Below this effective_buffer the buffer must jump up immediately.
-    grow_jump: Duration,
+    thresholds: LatencyThresholds,
 }
 
 impl InnerLatencyOptimizedBuffer {
@@ -441,11 +461,22 @@ impl InnerLatencyOptimizedBuffer {
     /// Fixed amount applied when the effective buffer drops below `grow_jump`.
     const GROW_JUMP: Duration = Duration::from_millis(1000);
     /// Minimum stream-time spacing between two grow jumps.
-    const GROW_JUMP_INTERVAL: Duration = Duration::from_millis(3000);
+    const GROW_JUMP_INTERVAL: Duration = Duration::from_millis(4000);
     /// Stream-time window during which a per-zone observation still influences the
     /// effective trend. Equivalent to "no contradicting trend in N seconds" — when this
     /// window expires for a zone its observation is forgotten.
     const TREND_WINDOW: Duration = Duration::from_secs(10);
+    /// Sliding stream-time window over which grow jumps are counted to
+    /// detect recurring spike patterns.
+    const JUMP_RECURRENCE_WINDOW: Duration = Duration::from_secs(240);
+    /// Strictly-greater-than this many grow jumps within the window flips the
+    /// thresholds up by `THRESHOLD_BUMP` and resets the count.
+    const JUMP_RECURRENCE_THRESHOLD: usize = 5;
+    /// Amount each non-`grow_jump` threshold is raised by when the recurrence
+    /// trigger fires. Shifts the stable / shrink / grow zones up while
+    /// leaving the JumpGrow trigger pinned, so the buffer biases toward a
+    /// larger steady-state size after seeing enough spikes.
+    const THRESHOLD_BUMP: Duration = Duration::from_millis(100);
 
     fn new(reference_time: Instant, desired_size: (Duration, Duration)) -> Self {
         // Thresholds are anchored to the configured stable band:
@@ -464,19 +495,21 @@ impl InnerLatencyOptimizedBuffer {
             ),
             grow,
             shrink,
-            shrink_fast: shrink.saturating_add(Duration::from_millis(1500)),
+            shrink_fast: shrink.saturating_add(Duration::from_millis(2000)),
+            bump_count: 0,
         };
         Self {
             reference_time,
             target_size: shrink,
             max_pts: None,
-            last_jump_pts: None,
+            last_jump_pts: Duration::ZERO,
             last_jump_grow_pts: None,
             last_grow_fast_pts: None,
             last_grow_pts: None,
             last_stable_pts: None,
             shrink_streak_start: None,
             shrink_fast_streak_start: None,
+            recent_jump_pts: VecDeque::new(),
             thresholds,
         }
     }
@@ -506,6 +539,8 @@ impl InnerLatencyOptimizedBuffer {
             }
             None => {
                 self.max_pts = Some(pts);
+                // Block grow jumps in initial `GROW_JUMP_INTERVAL`
+                self.last_jump_pts = pts;
                 Duration::ZERO
             }
         };
@@ -516,7 +551,7 @@ impl InnerLatencyOptimizedBuffer {
             LatencyTrend::Stable => {}
             LatencyTrend::Grow => self.scale_target(Self::GROW_RATE, stream_delta),
             LatencyTrend::GrowFast => self.scale_target(Self::GROW_FAST_RATE, stream_delta),
-            LatencyTrend::JumpGrow => self.try_grow_jump(pts),
+            LatencyTrend::JumpGrow => self.try_grow_jump(pts, stream_delta),
         }
     }
 
@@ -599,18 +634,35 @@ impl InnerLatencyOptimizedBuffer {
         self.reset_grow_observations();
     }
 
-    fn try_grow_jump(&mut self, pts: Duration) {
+    fn try_grow_jump(&mut self, pts: Duration, stream_delta: Duration) {
         self.reset_grow_observations();
-        if let Some(last) = self.last_jump_pts
-            && pts.saturating_sub(last) < Self::GROW_JUMP_INTERVAL
-        {
+        if pts.saturating_sub(self.last_jump_pts) < Self::GROW_JUMP_INTERVAL {
+            // Fallback to regular buffer growth if jumps are throttled
+            self.scale_target(Self::GROW_FAST_RATE, stream_delta);
             return;
         }
 
-        self.last_jump_pts = Some(pts);
+        self.last_jump_pts = pts;
         let new_size = self.target_size + Self::GROW_JUMP;
         debug!(?new_size, "Grow latency optimized target (jump)");
         self.target_size = new_size;
+        self.record_jump_grow_event(pts);
+    }
+
+    /// Track grow jumps in a sliding stream-time window. Once the count
+    /// exceeds the recurrence threshold, raise every non-`grow_jump`
+    /// threshold by `THRESHOLD_BUMP` and reset the window so the next bump
+    /// only fires after a fresh round of recurrence.
+    fn record_jump_grow_event(&mut self, pts: Duration) {
+        self.recent_jump_pts.push_back(pts);
+        let cutoff = pts.saturating_sub(Self::JUMP_RECURRENCE_WINDOW);
+        while self.recent_jump_pts.front().is_some_and(|p| *p < cutoff) {
+            self.recent_jump_pts.pop_front();
+        }
+        if self.recent_jump_pts.len() > Self::JUMP_RECURRENCE_THRESHOLD {
+            self.recent_jump_pts.clear();
+            self.thresholds.bump(Self::THRESHOLD_BUMP);
+        }
     }
 
     /// All grow-side observations were measured against the old target
@@ -624,6 +676,49 @@ impl InnerLatencyOptimizedBuffer {
         self.last_jump_grow_pts = None;
         self.last_grow_fast_pts = None;
         self.last_grow_pts = None;
+    }
+}
+
+struct LatencyThresholds {
+    /// Above this effective_buffer the buffer shrinks at the fast rate.
+    shrink_fast: Duration,
+    /// Above this effective_buffer the buffer shrinks at the slow rate.
+    shrink: Duration,
+    /// Below this effective_buffer the buffer grows proportionally at the slow rate.
+    grow: Duration,
+    /// Below this effective_buffer the buffer grows proportionally at the fast rate.
+    grow_fast: Duration,
+    /// Below this effective_buffer the buffer must jump up immediately.
+    grow_jump: Duration,
+    /// How many times `bump()` has applied its shift. Capped at `MAX_BUMPS`
+    /// so the cumulative shift stays bounded.
+    bump_count: usize,
+}
+
+impl LatencyThresholds {
+    /// Cap on how many cumulative bumps `bump()` will apply. With the
+    /// caller's `THRESHOLD_BUMP = 100ms`, bounds total shift to 2s.
+    const MAX_BUMPS: usize = 20;
+
+    /// Raise every threshold except `grow_jump` by `by`. Silently no-ops
+    /// once `MAX_BUMPS` bumps have already been applied.
+    fn bump(&mut self, by: Duration) {
+        if self.bump_count >= Self::MAX_BUMPS {
+            return;
+        }
+        self.shrink_fast += by;
+        self.shrink += by;
+        self.grow += by;
+        self.grow_fast += by;
+        self.bump_count += 1;
+        debug!(
+            shrink_fast = ?self.shrink_fast,
+            shrink = ?self.shrink,
+            grow = ?self.grow,
+            grow_fast = ?self.grow_fast,
+            bump_count = self.bump_count,
+            "Latency thresholds raised"
+        );
     }
 }
 

--- a/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync.rs
+++ b/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync.rs
@@ -12,10 +12,27 @@ mod sync_test;
 
 const POW_2_32: f64 = (1i64 << 32) as f64;
 
-/// Maximum amount `sync_offset_secs` is shifted toward `target_offset_secs` on
-/// every media packet. Smooths out per-SR jumps so PTS values change
-/// continuously instead of stepping on each SenderReport.
-const MAX_OFFSET_INCREMENT: Duration = Duration::from_micros(100);
+/// Per-packet share of the (target − current) offset that `sync_offset_secs`
+/// is slewed by. Sized to the inter-packet RTP-time delta so convergence
+/// speed scales with media time rather than packet count, making it
+/// bitrate-independent.
+const CONVERGENCE_RATIO: f64 = 0.01;
+
+/// If a fresh SR implies an offset more than this far from the current
+/// best-effort, snap instead of slewing. Catches cases the slew can't recover
+/// from in reasonable time (SFU rewriting RTP but not RTCP, or audio
+/// resuming after a long pause).
+const SNAP_THRESHOLD: Duration = Duration::from_millis(300);
+
+/// In wall-clock-aligned modes (RealTime), if wall-clock advance between two
+/// forward-moving packets exceeds the inter-packet RTP-time advance by more
+/// than this, snap `sync_offset_secs` forward by the skew. Catches
+/// sender-side resume after a real-time gap the sender failed to reflect in
+/// RTP timestamps (Chrome WHEP on mute/unmute). Only enabled for sources
+/// whose RTP timestamps are intended to track wall clock — buffered/file
+/// sources (FixedWindow mode) intentionally use media-time RTP and must not
+/// be snapped.
+const RESUME_SKEW_SNAP_THRESHOLD: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 /// State that should be shared between different RTP tracks to use for synchronization.
@@ -102,8 +119,22 @@ pub(crate) struct RtpTimestampSync {
     sync_offset_secs: Option<f64>,
     /// NTP-derived target for `sync_offset_secs`, refreshed on every
     /// SenderReport. `pts_from_timestamp` slews `sync_offset_secs` toward this
-    /// value by at most `MAX_OFFSET_INCREMENT` per packet.
+    /// value by at most `CONVERGENCE_RATIO` of the inter-packet RTP-time delta
+    /// per packet.
     target_offset_secs: Option<f64>,
+    /// Largest rolled RTP timestamp observed so far. Used to size the slew
+    /// step from the inter-packet RTP-time delta — packets arriving out of
+    /// order produce a zero step rather than nudging backwards.
+    last_max_rolled_rtp_timestamp: Option<u64>,
+    /// Wall-clock receive time paired with `last_max_rolled_rtp_timestamp`.
+    /// Used by the resume-skew snap to detect sender-side resume after a
+    /// real-time gap.
+    last_max_recv_time: Option<Instant>,
+    /// Whether the source is treated as live / wall-clock-aligned. Enables
+    /// the resume-skew snap (RTP timestamps are expected to track wall
+    /// clock). Cleared for buffered sources where RTP carries media time
+    /// and a long receiver block must not shift PTS.
+    real_time: bool,
     clock_rate: u32,
     rollover_state: TimestampRolloverState,
 
@@ -118,10 +149,13 @@ pub(crate) struct RtpTimestampSync {
 }
 
 impl RtpTimestampSync {
-    pub fn new(ntp_sync_point: Arc<RtpNtpSyncPoint>, clock_rate: u32) -> Self {
+    pub fn new(ntp_sync_point: Arc<RtpNtpSyncPoint>, clock_rate: u32, real_time: bool) -> Self {
         Self {
             sync_offset_secs: None,
             target_offset_secs: None,
+            last_max_rolled_rtp_timestamp: None,
+            last_max_recv_time: None,
+            real_time,
             rtp_timestamp_offset: None,
 
             clock_rate,
@@ -133,7 +167,29 @@ impl RtpTimestampSync {
     }
 
     pub fn pts_from_timestamp(&mut self, rtp_timestamp: u32) -> Duration {
-        let mut sync_offset_secs = *self.sync_offset_secs.get_or_insert_with(|| {
+        let rolled_timestamp = self.rollover_state.timestamp(rtp_timestamp);
+
+        // Detect sender-side resume after a wall-clock gap the sender did not
+        // reflect in RTP timestamps (Chrome WHEP on mute/unmute keeps RTP
+        // continuous). When wall-clock advance outpaces RTP-time advance by
+        // more than RESUME_SKEW_SNAP_THRESHOLD, snap sync_offset_secs forward
+        // immediately so PTS lines up with wall clock — otherwise the next
+        // SR is up to ~5s away and the buffer would balloon in the meantime.
+        //
+        // Gated on `real_time` because the heuristic is only valid when RTP
+        // timestamps are intended to track wall clock. For buffered/file
+        // inputs RTP carries media time and a long receiver block — e.g., a
+        // queue offset that delays consumption — would otherwise be mistaken
+        // for a sender-side resume and shift PTS by the block duration.
+        self.maybe_snap_on_resume(rolled_timestamp);
+
+        // Slew toward the latest NTP-derived target. Step size is
+        // CONVERGENCE_RATIO * inter-packet RTP-time delta, so convergence
+        // happens at a fixed rate per second of media regardless of bitrate.
+        // Out-of-order packets (current < last_max) produce a zero step.
+        self.maybe_converge_on_target(rolled_timestamp);
+
+        let sync_offset_secs = *self.sync_offset_secs.get_or_insert_with(|| {
             let sync_offset = self.ntp_sync_point.reference_time.elapsed();
             debug!(
                 ?sync_offset,
@@ -143,17 +199,11 @@ impl RtpTimestampSync {
             sync_offset.as_secs_f64()
         });
 
-        // Slew toward the latest NTP-derived target. Each packet shifts the
-        // offset by at most MAX_OFFSET_INCREMENT so PTS values change
-        // continuously instead of jumping on each SenderReport.
-        if let Some(target) = self.target_offset_secs {
-            let max_step_secs = MAX_OFFSET_INCREMENT.as_secs_f64();
-            let nudge = (target - sync_offset_secs).clamp(-max_step_secs, max_step_secs);
-            sync_offset_secs += nudge;
-            self.sync_offset_secs = Some(sync_offset_secs);
+        if rolled_timestamp > self.last_max_rolled_rtp_timestamp.unwrap_or(0) {
+            self.last_max_rolled_rtp_timestamp = Some(rolled_timestamp);
         }
+        self.last_max_recv_time = Some(Instant::now());
 
-        let rolled_timestamp = self.rollover_state.timestamp(rtp_timestamp);
         let rtp_timestamp_offset = *self.rtp_timestamp_offset.get_or_insert(rolled_timestamp);
 
         if rtp_timestamp_offset > rolled_timestamp {
@@ -172,6 +222,70 @@ impl RtpTimestampSync {
         } else {
             Duration::from_secs_f64(pts_secs)
         }
+    }
+
+    /// Implementation of the slew toward `target_offset_secs`. Mutates
+    /// `self.sync_offset_secs` in place by at most
+    /// `CONVERGENCE_RATIO * inter-packet RTP-time delta`. No-op when no
+    /// target is set or `sync_offset_secs` hasn't been initialized — in the
+    /// latter case there's nothing to slew yet, the first packet sets the
+    /// initial value downstream.
+    fn maybe_converge_on_target(&mut self, rolled_timestamp: u64) {
+        let (Some(target), Some(sync_offset_secs)) =
+            (self.target_offset_secs, self.sync_offset_secs)
+        else {
+            return;
+        };
+        let last_max = self
+            .last_max_rolled_rtp_timestamp
+            .unwrap_or(rolled_timestamp);
+        let rtp_delta_secs =
+            rolled_timestamp.saturating_sub(last_max) as f64 / self.clock_rate as f64;
+        let max_step_secs = rtp_delta_secs * CONVERGENCE_RATIO;
+        let new_sync_offset_secs = target.clamp(
+            sync_offset_secs - max_step_secs,
+            sync_offset_secs + max_step_secs,
+        );
+        self.sync_offset_secs = Some(new_sync_offset_secs);
+    }
+
+    /// Implementation of the resume-skew snap. Mutates `self.sync_offset_secs`
+    /// and `self.target_offset_secs` in place when the skew exceeds the
+    /// threshold; otherwise no-op. Both `sync_offset_secs` and
+    /// `target_offset_secs` are pinned to the snapped value so the slew that
+    /// runs next can't drag us back to a stale target before the next SR
+    /// arrives. Safe to call before `sync_offset_secs` is initialized — the
+    /// early-out on `last_max_recv_time` / `sync_offset_secs` ensures the
+    /// snap can only fire after at least one prior packet has set them.
+    fn maybe_snap_on_resume(&mut self, rolled_timestamp: u64) {
+        if !self.real_time {
+            return;
+        }
+        let (Some(prev_recv_time), Some(prev_rolled), Some(sync_offset_secs)) = (
+            self.last_max_recv_time,
+            self.last_max_rolled_rtp_timestamp,
+            self.sync_offset_secs,
+        ) else {
+            return;
+        };
+        if rolled_timestamp <= prev_rolled {
+            return;
+        }
+
+        let wall_gap_secs = prev_recv_time.elapsed().as_secs_f64();
+        let rtp_gap_secs = (rolled_timestamp - prev_rolled) as f64 / self.clock_rate as f64;
+        let skew_secs = wall_gap_secs - rtp_gap_secs;
+        if skew_secs <= RESUME_SKEW_SNAP_THRESHOLD.as_secs_f64() {
+            return;
+        }
+
+        warn!(
+            skew_secs,
+            "Sender resumed without RTP-time gap, snapping sync offset forward"
+        );
+        let new_sync_offset = sync_offset_secs + skew_secs;
+        self.sync_offset_secs = Some(new_sync_offset);
+        self.target_offset_secs = Some(new_sync_offset);
     }
 
     pub fn on_sender_report(&mut self, sr_ntp_time: u64, sr_rtp_timestamp: u32) {
@@ -207,7 +321,7 @@ impl RtpTimestampSync {
         // - receiving stream from SFU that modifies RTP packet but not RTCP packets.
         // - BroadcastBox if you connect to server over WHEP before starting stream
         let offset_diff_secs = new_offset_secs - self.sync_offset_secs.unwrap_or(0.0);
-        if offset_diff_secs.abs() > 2.0 {
+        if offset_diff_secs.abs() > SNAP_THRESHOLD.as_secs_f64() {
             warn!(
                 offset_diff_secs,
                 "NTP sync offset differs too much from initial estimate, forcing update"

--- a/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync/sync_test.rs
+++ b/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync/sync_test.rs
@@ -591,17 +591,17 @@ fn test_rtcp_sync_snaps_on_sender_resume_without_rtp_gap() {
     let pts_first = stream.pts_from_timestamp(0);
     assert_duration_eq(pts_first, Duration::ZERO, PREC_RUNTIME);
 
-    // Pause for 6s (above `RESUME_SKEW_SNAP_THRESHOLD`), then resume with a
-    // continuous RTP timestamp (only +20 RTP units = 20ms of media).
-    thread::sleep(Duration::from_secs(6));
+    // Pause for 11s (above `RESUME_SKEW_SNAP_THRESHOLD` = 10s), then resume
+    // with a continuous RTP timestamp (only +20 RTP units = 20ms of media).
+    thread::sleep(Duration::from_secs(11));
     let pts_after_resume = stream.pts_from_timestamp(20);
 
     // Without the snap, PTS would be ≈ 20ms. With the snap, the wall-clock
-    // gap (~6s) minus the RTP-time gap (20ms) gets added to sync_offset_secs,
+    // gap (~11s) minus the RTP-time gap (20ms) gets added to sync_offset_secs,
     // so PTS lands near the real elapsed time.
     assert_duration_eq(
         pts_after_resume,
-        Duration::from_secs(6),
+        Duration::from_secs(11),
         Duration::from_millis(20),
     );
 }
@@ -620,10 +620,11 @@ fn test_rtcp_sync_does_not_snap_when_not_real_time() {
     let pts_first = stream.pts_from_timestamp(0);
     assert_duration_eq(pts_first, Duration::ZERO, PREC_RUNTIME);
 
-    // Simulate the receiver being blocked for 6s (queue offset, slow
+    // Simulate the receiver being blocked for 11s (queue offset, slow
     // consumer, etc.) while sender's RTP timestamps stayed continuous in
-    // media time.
-    thread::sleep(Duration::from_secs(6));
+    // media time. Must exceed `RESUME_SKEW_SNAP_THRESHOLD` (10s) so that the
+    // test verifies the `real_time` guard, not just the threshold.
+    thread::sleep(Duration::from_secs(11));
     let pts_after_block = stream.pts_from_timestamp(20);
 
     // No snap: PTS reflects the 20ms RTP-time advance, not the 6s wall gap.
@@ -640,8 +641,8 @@ fn test_rtcp_sync_does_not_snap_when_rtp_gap_matches_wall_gap() {
     let pts_first = stream.pts_from_timestamp(0);
     assert_duration_eq(pts_first, Duration::ZERO, PREC_RUNTIME);
 
-    // Sender pauses 6s (above `RESUME_SKEW_SNAP_THRESHOLD`) and advances
-    // RTP timestamps to match (6000 RTP units at clock 1000 = 6s).
+    // Sender pauses 6s and advances RTP timestamps to match (6000 RTP
+    // units at clock 1000 = 6s), so skew ≈ 0 — well below any threshold.
     thread::sleep(Duration::from_secs(6));
     let pts_after_resume = stream.pts_from_timestamp(6_000);
 

--- a/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync/sync_test.rs
+++ b/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync/sync_test.rs
@@ -17,8 +17,8 @@ const REFERENCE_NTP_TIME: u64 = 3966409461 * POW_2_32;
 fn test_rtcp_sync_pts_from_zero() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     let stream_1_first_pts = stream_1.pts_from_timestamp(0);
     thread::sleep(Duration::from_millis(100));
@@ -77,8 +77,8 @@ fn test_rtcp_sync_pts_from_zero() {
 fn test_rtcp_sync_pts_from_non_zero() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     let stream_1_first_pts = stream_1.pts_from_timestamp(60_000);
     thread::sleep(Duration::from_millis(100));
@@ -139,8 +139,8 @@ fn test_rtcp_sync_pts_from_non_zero() {
 fn test_rtcp_sync_pts_from_non_zero_different_clocks() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 3_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 3_000, true);
 
     let stream_1_first_pts = stream_1.pts_from_timestamp(60_000);
     thread::sleep(Duration::from_millis(100));
@@ -201,8 +201,8 @@ fn test_rtcp_sync_pts_from_non_zero_different_clocks() {
 fn test_rtcp_sync_pts_with_rollover_before_sender_report_first_stream() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     let stream_1_first_rtp_timestamp = u32::MAX - 5_000 + 1;
     let stream_2_first_rtp_timestamp = 100_000;
@@ -269,8 +269,8 @@ fn test_rtcp_sync_pts_with_rollover_before_sender_report_first_stream() {
 fn test_rtcp_sync_pts_with_rollover_before_sender_report_second_stream() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     let stream_1_first_rtp_timestamp = 100_000;
     let stream_2_first_rtp_timestamp = u32::MAX - 5_000 + 1;
@@ -337,8 +337,8 @@ fn test_rtcp_sync_pts_with_rollover_before_sender_report_second_stream() {
 fn test_rtcp_sync_pts_with_rollover_after_sender_report_first_stream() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     let stream_1_first_rtp_timestamp = 5_000;
     let stream_2_first_rtp_timestamp = 100_000;
@@ -405,8 +405,8 @@ fn test_rtcp_sync_pts_with_rollover_after_sender_report_first_stream() {
 fn test_rtcp_sync_pts_with_rollover_after_sender_report_second_stream() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     let stream_1_first_rtp_timestamp = 100_000;
     let stream_2_first_rtp_timestamp = 5_000;
@@ -469,17 +469,18 @@ fn test_rtcp_sync_pts_with_rollover_after_sender_report_second_stream() {
     );
 }
 
-/// When an SR implies an offset more than 2s away from the current best-effort
-/// estimate (e.g. SFU mangling timestamps, or audio resuming after a long
-/// pause), `sync_offset_secs` snaps to the new target instead of slewing.
-/// After the snap, consecutive packets must still advance by their RTP-time
-/// delta — i.e. the timeline stays self-consistent past the discontinuity.
+/// When an SR implies an offset more than `SNAP_THRESHOLD` away from the
+/// current best-effort estimate (e.g. SFU mangling timestamps, or audio
+/// resuming after a long pause), `sync_offset_secs` snaps to the new target
+/// instead of slewing. After the snap, consecutive packets must still
+/// advance by their RTP-time delta — i.e. the timeline stays self-consistent
+/// past the discontinuity.
 #[test]
 fn test_rtcp_sync_snaps_on_large_offset_diff() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
 
-    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 48_000);
-    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 90_000);
+    let mut stream_1 = RtpTimestampSync::new(sync_point.clone(), 48_000, true);
+    let mut stream_2 = RtpTimestampSync::new(sync_point.clone(), 90_000, true);
 
     let stream_1_first_pts = stream_1.pts_from_timestamp(100_000_000);
     let stream_2_first_pts = stream_2.pts_from_timestamp(200_000_000);
@@ -515,14 +516,18 @@ fn test_rtcp_sync_snaps_on_large_offset_diff() {
 }
 
 /// SR sets `target_offset_secs`; `pts_from_timestamp` then slews
-/// `sync_offset_secs` toward it by ≤100µs per packet. To assert the converged
-/// state (rather than the per-packet step), pump enough packets to drain any
-/// outstanding diff. 1500 packets × 100µs = 150ms — covers any drift in these
-/// tests. Once `current == target`, further calls clamp to a 0-step.
+/// `sync_offset_secs` toward it by `CONVERGENCE_RATIO` of the inter-packet
+/// RTP-time delta. To converge, packets must actually advance — same-timestamp
+/// calls produce a zero step. We pump packets stepping by `clock_rate / 10`
+/// (= 100ms of media per packet → ~1ms slew step), then issue `rtp_timestamp`
+/// once at the end so subsequent assertions read at a known timestamp.
+/// 3000 × 1ms = 3s of cumulative drain — covers any drift in these tests.
 fn drain_slew(stream: &mut RtpTimestampSync, rtp_timestamp: u32) {
-    for _ in 0..1500 {
-        stream.pts_from_timestamp(rtp_timestamp);
+    let step = stream.clock_rate / 10;
+    for i in 0..3000 {
+        stream.pts_from_timestamp(rtp_timestamp.wrapping_add(i * step));
     }
+    stream.pts_from_timestamp(rtp_timestamp);
 }
 
 /// Verifies the slew mechanism itself: an SR sets a non-trivial target, after
@@ -537,7 +542,7 @@ fn drain_slew(stream: &mut RtpTimestampSync, rtp_timestamp: u32) {
 #[test]
 fn test_rtcp_sync_offset_slews_per_packet() {
     let sync_point = RtpNtpSyncPoint::new(Instant::now());
-    let mut stream = RtpTimestampSync::new(sync_point.clone(), 1_000);
+    let mut stream = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
 
     stream.pts_from_timestamp(0);
     stream.pts_from_timestamp(1_000);
@@ -552,21 +557,108 @@ fn test_rtcp_sync_offset_slews_per_packet() {
     let shifted_ntp = REFERENCE_NTP_TIME + (POW_2_32 / 20); // +50 ms
     stream.on_sender_report(shifted_ntp, 0);
 
-    // First packet after the second SR: shifts by exactly one slew step.
-    let pts_after_one = stream.pts_from_timestamp(2_000);
+    // First packet after the second SR with RTP delta of 10 (= 10ms at clock
+    // 1000). Slew step = 1% × 10ms = 100µs. The PTS also advances by the
+    // intrinsic 10ms RTP delta, so isolate the slew contribution.
+    let pts_after_one = stream.pts_from_timestamp(2_010);
     assert_duration_eq(
-        pts_after_one - pts_pre_sr,
+        pts_after_one - pts_pre_sr - Duration::from_millis(10),
         Duration::from_micros(100),
         Duration::from_micros(10),
     );
 
-    // After draining: full +50ms target reached.
+    // After draining: full +50ms target reached. Read back at rtp=2_000 to
+    // line up with `pts_pre_sr`.
     drain_slew(&mut stream, 2_000);
     let pts_after_drain = stream.pts_from_timestamp(2_000);
     assert_duration_eq(
         pts_after_drain - pts_pre_sr,
         Duration::from_millis(50),
         Duration::from_micros(200),
+    );
+}
+
+/// Sender pauses long enough to exceed the resume-skew threshold but keeps
+/// RTP timestamps continuous on resume (Chrome WHEP mute/unmute behavior).
+/// The first post-resume packet should snap `sync_offset_secs` forward by
+/// the wall-clock/RTP-time skew so PTS reflects real time without waiting
+/// for the next SR.
+#[test]
+fn test_rtcp_sync_snaps_on_sender_resume_without_rtp_gap() {
+    let sync_point = RtpNtpSyncPoint::new(Instant::now());
+    let mut stream = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+
+    let pts_first = stream.pts_from_timestamp(0);
+    assert_duration_eq(pts_first, Duration::ZERO, PREC_RUNTIME);
+
+    // Pause for 6s (above `RESUME_SKEW_SNAP_THRESHOLD`), then resume with a
+    // continuous RTP timestamp (only +20 RTP units = 20ms of media).
+    thread::sleep(Duration::from_secs(6));
+    let pts_after_resume = stream.pts_from_timestamp(20);
+
+    // Without the snap, PTS would be ≈ 20ms. With the snap, the wall-clock
+    // gap (~6s) minus the RTP-time gap (20ms) gets added to sync_offset_secs,
+    // so PTS lands near the real elapsed time.
+    assert_duration_eq(
+        pts_after_resume,
+        Duration::from_secs(6),
+        Duration::from_millis(20),
+    );
+}
+
+/// When `real_time` is false (FixedWindow / buffered modes), a long
+/// receiver block — e.g., a queue offset that delays consumption for
+/// minutes — must NOT shift PTS. RTP timestamps in this mode carry media
+/// time, so the post-block packet's PTS should reflect its RTP-time progress
+/// only, regardless of how long the receiver was blocked. Same input that
+/// would trigger a snap in the live-mode test stays untouched here.
+#[test]
+fn test_rtcp_sync_does_not_snap_when_not_real_time() {
+    let sync_point = RtpNtpSyncPoint::new(Instant::now());
+    let mut stream = RtpTimestampSync::new(sync_point.clone(), 1_000, false);
+
+    let pts_first = stream.pts_from_timestamp(0);
+    assert_duration_eq(pts_first, Duration::ZERO, PREC_RUNTIME);
+
+    // Simulate the receiver being blocked for 6s (queue offset, slow
+    // consumer, etc.) while sender's RTP timestamps stayed continuous in
+    // media time.
+    thread::sleep(Duration::from_secs(6));
+    let pts_after_block = stream.pts_from_timestamp(20);
+
+    // No snap: PTS reflects the 20ms RTP-time advance, not the 6s wall gap.
+    assert_duration_eq(pts_after_block, Duration::from_millis(20), PREC_RUNTIME);
+}
+
+/// A well-behaved sender that *does* advance RTP timestamps to reflect a
+/// pause (rtp_gap ≈ wall_gap → skew ≈ 0) must not trip the resume snap.
+#[test]
+fn test_rtcp_sync_does_not_snap_when_rtp_gap_matches_wall_gap() {
+    let sync_point = RtpNtpSyncPoint::new(Instant::now());
+    let mut stream = RtpTimestampSync::new(sync_point.clone(), 1_000, true);
+
+    let pts_first = stream.pts_from_timestamp(0);
+    assert_duration_eq(pts_first, Duration::ZERO, PREC_RUNTIME);
+
+    // Sender pauses 6s (above `RESUME_SKEW_SNAP_THRESHOLD`) and advances
+    // RTP timestamps to match (6000 RTP units at clock 1000 = 6s).
+    thread::sleep(Duration::from_secs(6));
+    let pts_after_resume = stream.pts_from_timestamp(6_000);
+
+    // No snap: PTS comes purely from RTP-time advance.
+    assert_duration_eq(
+        pts_after_resume,
+        Duration::from_secs(6),
+        Duration::from_millis(20),
+    );
+
+    // And the next packet keeps stepping at the RTP rate, not at any
+    // snapped offset.
+    let pts_next = stream.pts_from_timestamp(7_000);
+    assert_duration_eq(
+        pts_next - pts_after_resume,
+        Duration::from_secs(1),
+        PREC_RUNTIME,
     );
 }
 

--- a/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync/sync_test.rs
+++ b/smelter-core/src/pipeline/rtp/rtp_input/rtcp_sync/sync_test.rs
@@ -627,7 +627,7 @@ fn test_rtcp_sync_does_not_snap_when_not_real_time() {
     thread::sleep(Duration::from_secs(11));
     let pts_after_block = stream.pts_from_timestamp(20);
 
-    // No snap: PTS reflects the 20ms RTP-time advance, not the 6s wall gap.
+    // No snap: PTS reflects the 20ms RTP-time advance, not the 11s wall gap.
     assert_duration_eq(pts_after_block, Duration::from_millis(20), PREC_RUNTIME);
 }
 

--- a/smelter-core/src/stats/input/rtp.rs
+++ b/smelter-core/src/stats/input/rtp.rs
@@ -65,7 +65,14 @@ pub(crate) enum RtpJitterBufferStatsEvent {
     RtpPacketLost,
     RtpPacketReceived,
     BytesReceived(usize),
-    EffectiveBuffer(Duration),
+    /// Effective buffer measured at write time — how much margin a packet has
+    /// between its output PTS and wall clock the moment it lands in the
+    /// jitter buffer. Reflects the network-side picture (jitter, RTT).
+    EffectiveBufferOnWrite(Duration),
+    /// Effective buffer measured at pop time — same metric, but observed when
+    /// the packet leaves the jitter buffer toward the queue. Reflects how
+    /// much slack is left after waiting for reorder/buffering.
+    EffectiveBufferOnPop(Duration),
     InputBufferSize(Duration),
 }
 
@@ -75,7 +82,8 @@ pub struct RtpJitterBufferState {
     pub packets_lost_10_secs: SlidingWindowValue<u64>,
     pub packets_received: u64,
     pub packets_received_10_secs: SlidingWindowValue<u64>,
-    pub effective_buffer_10_secs: SlidingWindowValue<Duration>,
+    pub effective_buffer_on_write_10_secs: SlidingWindowValue<Duration>,
+    pub effective_buffer_on_pop_10_secs: SlidingWindowValue<Duration>,
     pub input_buffer_10_secs: SlidingWindowValue<Duration>,
 
     pub bitrate_1_sec: SlidingWindowValue<u64>,
@@ -89,7 +97,8 @@ impl RtpJitterBufferState {
             packets_lost_10_secs: SlidingWindowValue::new(Duration::from_secs(10)),
             packets_received: 0,
             packets_received_10_secs: SlidingWindowValue::new(Duration::from_secs(10)),
-            effective_buffer_10_secs: SlidingWindowValue::new(Duration::from_secs(10)),
+            effective_buffer_on_write_10_secs: SlidingWindowValue::new(Duration::from_secs(10)),
+            effective_buffer_on_pop_10_secs: SlidingWindowValue::new(Duration::from_secs(10)),
             input_buffer_10_secs: SlidingWindowValue::new(Duration::from_secs(10)),
             bitrate_1_sec: SlidingWindowValue::new(Duration::from_secs(1)),
             bitrate_1_min: SlidingWindowValue::new(Duration::from_mins(1)),
@@ -106,8 +115,11 @@ impl RtpJitterBufferState {
                 self.packets_received += 1;
                 self.packets_received_10_secs.push(1);
             }
-            RtpJitterBufferStatsEvent::EffectiveBuffer(duration) => {
-                self.effective_buffer_10_secs.push(duration);
+            RtpJitterBufferStatsEvent::EffectiveBufferOnWrite(duration) => {
+                self.effective_buffer_on_write_10_secs.push(duration);
+            }
+            RtpJitterBufferStatsEvent::EffectiveBufferOnPop(duration) => {
+                self.effective_buffer_on_pop_10_secs.push(duration);
             }
             RtpJitterBufferStatsEvent::InputBufferSize(duration) => {
                 self.input_buffer_10_secs.push(duration);
@@ -132,9 +144,30 @@ impl RtpJitterBufferState {
             last_10_seconds: RtpJitterBufferSlidingWindowStatsReport {
                 packets_lost: self.packets_lost_10_secs.sum(),
                 packets_received: self.packets_received_10_secs.sum(),
-                effective_buffer_avg_seconds: self.effective_buffer_10_secs.avg().as_secs_f64(),
-                effective_buffer_max_seconds: self.effective_buffer_10_secs.max().as_secs_f64(),
-                effective_buffer_min_seconds: self.effective_buffer_10_secs.min().as_secs_f64(),
+                effective_buffer_on_write_avg_seconds: self
+                    .effective_buffer_on_write_10_secs
+                    .avg()
+                    .as_secs_f64(),
+                effective_buffer_on_write_max_seconds: self
+                    .effective_buffer_on_write_10_secs
+                    .max()
+                    .as_secs_f64(),
+                effective_buffer_on_write_min_seconds: self
+                    .effective_buffer_on_write_10_secs
+                    .min()
+                    .as_secs_f64(),
+                effective_buffer_on_pop_avg_seconds: self
+                    .effective_buffer_on_pop_10_secs
+                    .avg()
+                    .as_secs_f64(),
+                effective_buffer_on_pop_max_seconds: self
+                    .effective_buffer_on_pop_10_secs
+                    .max()
+                    .as_secs_f64(),
+                effective_buffer_on_pop_min_seconds: self
+                    .effective_buffer_on_pop_10_secs
+                    .min()
+                    .as_secs_f64(),
                 input_buffer_avg_seconds: self.input_buffer_10_secs.avg().as_secs_f64(),
                 input_buffer_max_seconds: self.input_buffer_10_secs.max().as_secs_f64(),
                 input_buffer_min_seconds: self.input_buffer_10_secs.min().as_secs_f64(),

--- a/smelter-core/src/stats/input_reports.rs
+++ b/smelter-core/src/stats/input_reports.rs
@@ -69,15 +69,28 @@ pub struct RtpJitterBufferSlidingWindowStatsReport {
     /// Count of packets received during the given time window.
     pub packets_received: u64,
 
+    /// Measured when packet enters jitter buffer. This value represents how
+    /// much time packet has to reach the queue to be processed, before
+    /// jitter-buffer reorder/wait is applied.
+    pub effective_buffer_on_write_avg_seconds: f64,
+    /// Measured when packet enters jitter buffer. This value represents how
+    /// much time packet has to reach the queue to be processed, before
+    /// jitter-buffer reorder/wait is applied.
+    pub effective_buffer_on_write_max_seconds: f64,
+    /// Measured when packet enters jitter buffer. This value represents how
+    /// much time packet has to reach the queue to be processed, before
+    /// jitter-buffer reorder/wait is applied.
+    pub effective_buffer_on_write_min_seconds: f64,
+
     /// Measured when packet leaves jitter buffer. This value represents
     /// how much time packet has to reach the queue to be processed.
-    pub effective_buffer_avg_seconds: f64,
+    pub effective_buffer_on_pop_avg_seconds: f64,
     /// Measured when packet leaves jitter buffer. This value represents
     /// how much time packet has to reach the queue to be processed.
-    pub effective_buffer_max_seconds: f64,
+    pub effective_buffer_on_pop_max_seconds: f64,
     /// Measured when packet leaves jitter buffer. This value represents
     /// how much time packet has to reach the queue to be processed.
-    pub effective_buffer_min_seconds: f64,
+    pub effective_buffer_on_pop_min_seconds: f64,
 
     /// Size of the input buffer.
     pub input_buffer_avg_seconds: f64,

--- a/tools/schemas/openapi_specification.json
+++ b/tools/schemas/openapi_specification.json
@@ -4546,9 +4546,12 @@
         "required": [
           "packets_lost",
           "packets_received",
-          "effective_buffer_avg_seconds",
-          "effective_buffer_max_seconds",
-          "effective_buffer_min_seconds",
+          "effective_buffer_on_write_avg_seconds",
+          "effective_buffer_on_write_max_seconds",
+          "effective_buffer_on_write_min_seconds",
+          "effective_buffer_on_pop_avg_seconds",
+          "effective_buffer_on_pop_max_seconds",
+          "effective_buffer_on_pop_min_seconds",
           "input_buffer_avg_seconds",
           "input_buffer_max_seconds",
           "input_buffer_min_seconds"
@@ -4566,17 +4569,32 @@
             "description": "Count of packets received during the given time window.",
             "minimum": 0
           },
-          "effective_buffer_avg_seconds": {
+          "effective_buffer_on_write_avg_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Measured when packet enters jitter buffer. This value represents how\nmuch time packet has to reach the queue to be processed, before\njitter-buffer reorder/wait is applied."
+          },
+          "effective_buffer_on_write_max_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Measured when packet enters jitter buffer. This value represents how\nmuch time packet has to reach the queue to be processed, before\njitter-buffer reorder/wait is applied."
+          },
+          "effective_buffer_on_write_min_seconds": {
+            "type": "number",
+            "format": "double",
+            "description": "Measured when packet enters jitter buffer. This value represents how\nmuch time packet has to reach the queue to be processed, before\njitter-buffer reorder/wait is applied."
+          },
+          "effective_buffer_on_pop_avg_seconds": {
             "type": "number",
             "format": "double",
             "description": "Measured when packet leaves jitter buffer. This value represents\nhow much time packet has to reach the queue to be processed."
           },
-          "effective_buffer_max_seconds": {
+          "effective_buffer_on_pop_max_seconds": {
             "type": "number",
             "format": "double",
             "description": "Measured when packet leaves jitter buffer. This value represents\nhow much time packet has to reach the queue to be processed."
           },
-          "effective_buffer_min_seconds": {
+          "effective_buffer_on_pop_min_seconds": {
             "type": "number",
             "format": "double",
             "description": "Measured when packet leaves jitter buffer. This value represents\nhow much time packet has to reach the queue to be processed."

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -1881,17 +1881,29 @@ export interface RtpJitterBufferSlidingWindowStatsReport {
    */
   packets_received: number;
   /**
-   * Measured when packet leaves jitter buffer. This value represents how much time packet has to reach the queue to be processed.
+   * Measured when packet enters jitter buffer. This value represents how much time packet has to reach the queue to be processed, before jitter-buffer reorder/wait is applied.
    */
-  effective_buffer_avg_seconds: number;
+  effective_buffer_on_write_avg_seconds: number;
+  /**
+   * Measured when packet enters jitter buffer. This value represents how much time packet has to reach the queue to be processed, before jitter-buffer reorder/wait is applied.
+   */
+  effective_buffer_on_write_max_seconds: number;
+  /**
+   * Measured when packet enters jitter buffer. This value represents how much time packet has to reach the queue to be processed, before jitter-buffer reorder/wait is applied.
+   */
+  effective_buffer_on_write_min_seconds: number;
   /**
    * Measured when packet leaves jitter buffer. This value represents how much time packet has to reach the queue to be processed.
    */
-  effective_buffer_max_seconds: number;
+  effective_buffer_on_pop_avg_seconds: number;
   /**
    * Measured when packet leaves jitter buffer. This value represents how much time packet has to reach the queue to be processed.
    */
-  effective_buffer_min_seconds: number;
+  effective_buffer_on_pop_max_seconds: number;
+  /**
+   * Measured when packet leaves jitter buffer. This value represents how much time packet has to reach the queue to be processed.
+   */
+  effective_buffer_on_pop_min_seconds: number;
   /**
    * Size of the input buffer.
    */


### PR DESCRIPTION
When recalculating RTCP sync based on the new sender report
- configure only new target value and converge on target with increment based on timestamp change (not per packet)
- detect large real-time gaps without a packet. If timestamps are continuous, assume that they need to be shifted by the real-time offset. Normally, the next sender report would do that, but it might take too long to wait for the next one.
  - disabled for RTP input
  - it triggers a false positive (shift offset and immediately shift it back on sender report), however this can only happen if thre is not packets on that track for 10 seconds
  
In jitter buffer logic:
- update stats to show both the effective buffer for packets entering the buffer, and leaving
- if we need to grow, jump to much within 4 minutes, increase offset by 100ms (this will never shrink back)
- grow jump now bumps buffer by 1000ms at most every 4000ms
- do not grow jump in first 4000ms