### PR TITLE
[integration-tests] Move tests to GPU VM

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,8 @@ retries = 0
 
 [profile.ci]
 retries = 1
-slow-timeout = "60s"
+global-timeout = "30m"
+slow-timeout = { period = "60s", terminate-after = 2 }
 fail-fast = false
 
 [[profile.ci.overrides]]

--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -11,7 +11,7 @@ concurrency:
     cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-    build_and_test_linux:
+    build_linux:
         runs-on: ubuntu-24.04
         steps:
             - name: 🛠 Install system dependencies
@@ -31,22 +31,8 @@ jobs:
               with:
                   toolchain: 1.95
 
-            - name: 🔬 Install nextest
-              uses: taiki-e/install-action@v2
-              with:
-                  tool: cargo-nextest
-
             - name: 📥 Checkout repo
               uses: actions/checkout@v6
-
-            - name: 🧩 Git submodules update
-              run: |
-                  cat > .gitmodules << EOF
-                  [submodule "snapshots"]
-                          path = integration-tests/snapshots
-                          url = https://github.com/smelter-labs/smelter-snapshot-tests.git
-                  EOF
-                  git submodule update --init
 
             - name: 📁 Rust cache
               uses: Swatinem/rust-cache@v2
@@ -60,21 +46,6 @@ jobs:
               run: |
                   cargo build --features decklink
                   cargo build --no-default-features
-
-            - name: 🧪 Run tests
-              run: |
-                  cargo nextest run --workspace --profile ci
-
-            - name: 📦 Upload failed snapshot test artifacts
-              if: failure()
-              uses: actions/upload-artifact@v4
-              with:
-                  name: test_workdir
-                  path: integration-tests/test_workdir
-                  retention-days: 2
-
-            - name: 📚 Run doctests
-              run: cargo test --workspace --doc
 
     build_macos:
         runs-on: macos-15
@@ -155,3 +126,61 @@ jobs:
             - name: 📄 Generate JSON schema
               run: |
                   cargo run -p tools --bin generate_from_types -- --check
+
+    test_linux:
+        needs: [build_linux, lint]
+        runs-on: gpu-gh-hosted-runner
+        steps:
+            - name: 🛠 Install system dependencies
+              run: |
+                  set -e
+                  sudo apt-get update -y -qq
+                  sudo apt-get install -y mesa-vulkan-drivers libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev ffmpeg libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libopus-dev pkg-config libssl-dev libclang-dev
+                  sudo apt-get clean
+                  sudo rm -rf /var/lib/apt/lists/*
+
+            - name: "Increase disk space"
+              run: |
+                  df -h && docker system prune -a -f && sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/.ghcup && df -h
+
+            - name: 🔧 Install the rust toolchain
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                  toolchain: 1.95
+
+            - name: 🔬 Install nextest
+              uses: taiki-e/install-action@v2
+              with:
+                  tool: cargo-nextest
+
+            - name: 📥 Checkout repo
+              uses: actions/checkout@v6
+
+            - name: 🧩 Git submodules update
+              run: |
+                  cat > .gitmodules << EOF
+                  [submodule "snapshots"]
+                          path = integration-tests/snapshots
+                          url = https://github.com/smelter-labs/smelter-snapshot-tests.git
+                  EOF
+                  git submodule update --init
+
+            - name: 📁 Rust cache
+              uses: Swatinem/rust-cache@v2
+              with:
+                  shared-key: "linux-build"
+                  
+            - name: 🧪 Run tests
+              run: |
+                  cargo nextest run --workspace --profile ci
+
+            - name: 📦 Upload failed snapshot test artifacts
+              if: failure()
+              uses: actions/upload-artifact@v4
+              with:
+                  name: test_workdir
+                  path: integration-tests/test_workdir
+                  retention-days: 2
+
+            - name: 📚 Run doctests
+              run: cargo test --workspace --doc

--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -11,7 +11,7 @@ concurrency:
     cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-    build_linux:
+    build_and_lint_linux:
         runs-on: ubuntu-24.04
         steps:
             - name: 🛠 Install system dependencies
@@ -30,6 +30,7 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
               with:
                   toolchain: 1.95
+                  components: rustfmt, clippy
 
             - name: 📥 Checkout repo
               uses: actions/checkout@v6
@@ -46,6 +47,22 @@ jobs:
               run: |
                   cargo build --features decklink
                   cargo build --no-default-features
+
+            - name: 📖 Check formatting
+              run: cargo fmt --all --check
+
+            - name: 📎 Run clippy (all-features)
+              run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+            - name: 📎 Run clippy (no-default-features)
+              run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
+
+            - name: 📎 Run clippy (vk-video, no-default-features)
+              run: cargo clippy --package gpu-video --all-targets --no-default-features -- -D clippy::todo -D clippy::uninlined_format_args -D warnings
+
+            - name: 📄 Generate JSON schema
+              run: |
+                  cargo run -p tools --bin generate_from_types -- --check
 
     build_macos:
         runs-on: macos-15
@@ -79,56 +96,8 @@ jobs:
             - name: 📎 Run clippy (no-default-features)
               run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
 
-    lint:
-        runs-on: ubuntu-24.04
-        steps:
-            - name: 🛠 Install system dependencies
-              run: |
-                  sudo apt-get update -y -qq
-                  sudo apt-get install -y mesa-vulkan-drivers libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev ffmpeg libavcodec-dev libavformat-dev libavfilter-dev libavdevice-dev libopus-dev
-                  sudo apt-get clean
-                  sudo rm -rf /var/lib/apt/lists/*
-
-            - name: 🔧 Install the rust toolchain
-              uses: dtolnay/rust-toolchain@stable
-              with:
-                  toolchain: 1.95
-                  components: rustfmt, clippy
-
-            - name: Install pnpm
-              uses: pnpm/action-setup@v4
-              with:
-                  version: 9
-
-            - name: 📥 Checkout repo
-              uses: actions/checkout@v6
-
-            - name: 📁 Rust cache
-              uses: Swatinem/rust-cache@v2
-              with:
-                  shared-key: "linux-lint"
-
-            - name: 🪢 Generate Chromium Embedded Framework bindings
-              run: cargo build --package libcef
-
-            - name: 📖 Check formatting
-              run: cargo fmt --all --check
-
-            - name: 📎 Run clippy (all-features)
-              run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-
-            - name: 📎 Run clippy (no-default-features)
-              run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
-
-            - name: 📎 Run clippy (vk-video, no-default-features)
-              run: cargo clippy --package gpu-video --all-targets --no-default-features -- -D clippy::todo -D clippy::uninlined_format_args -D warnings
-
-            - name: 📄 Generate JSON schema
-              run: |
-                  cargo run -p tools --bin generate_from_types -- --check
-
     test_linux:
-        needs: [build_linux, lint]
+        needs: build_and_lint_linux
         runs-on: gpu-gh-hosted-runner
         steps:
             - name: 🛠 Install system dependencies

--- a/integration-tests/src/bin/audit_tests.rs
+++ b/integration-tests/src/bin/audit_tests.rs
@@ -23,7 +23,7 @@ enum Action {
     RunSpecific,
     #[strum(to_string = "Audit existing test results (no rerun)")]
     InspectExisting,
-    #[strum(to_string = "Restore test_workdir: from GitHub Actions (build_and_test_linux)")]
+    #[strum(to_string = "Restore test_workdir: from GitHub Actions (test_linux)")]
     DownloadCiArtifacts,
     #[strum(to_string = "Restore test_workdir: from snapshot submodule diff")]
     DiffSnapshotSubmodule,

--- a/integration-tests/src/compositor_instance.rs
+++ b/integration-tests/src/compositor_instance.rs
@@ -23,11 +23,17 @@ pub struct CompositorInstance {
     pub api_port: u16,
     pub http_client: reqwest::blocking::Client,
     pub should_close_sender: Sender<()>,
+    api_thread_handle: Option<thread::JoinHandle<()>>,
 }
 
 impl Drop for CompositorInstance {
     fn drop(&mut self) {
         self.should_close_sender.send(()).unwrap();
+        if let Some(handle) = self.api_thread_handle.take() {
+            handle.join().unwrap();
+        }
+
+        thread::sleep(Duration::from_millis(500));
     }
 }
 
@@ -47,7 +53,7 @@ impl CompositorInstance {
         let runtime = Arc::new(Runtime::new().unwrap());
         let state = ApiState::new(config, runtime.clone()).unwrap();
 
-        thread::Builder::new()
+        let api_thread_handle = thread::Builder::new()
             .name("HTTP server startup thread".to_string())
             .spawn(move || {
                 run_api(state, runtime.clone(), should_close_receiver).unwrap();
@@ -58,6 +64,7 @@ impl CompositorInstance {
             api_port,
             http_client: reqwest::blocking::Client::new(),
             should_close_sender,
+            api_thread_handle: Some(api_thread_handle),
         };
         instance.wait_for_start(Duration::from_secs(30)).unwrap();
         instance

--- a/integration-tests/src/render_tests/rescaler_tests.rs
+++ b/integration-tests/src/render_tests/rescaler_tests.rs
@@ -244,18 +244,16 @@ fn rescaler_tests() {
         rendering_mode: RenderingMode::CpuOptimized,
         ..default.clone()
     });
-    // TODO: Remove this CI check once lanczos3 snapshots are handled properly
-    if std::env::var("CI").is_err() {
-        runner.add(TestCase {
-            name: "rescaler/scaling_filter_lanczos3",
-            steps: test_steps_from_scene(include_str!(
-                "./rescaler/scaling_filter_lanczos3.scene.json"
-            )),
-            inputs: vec![grid_input.clone()],
-            resolution: output_1080p,
-            rendering_mode: RenderingMode::GpuOptimized,
-            ..default.clone()
-        });
-    }
+    runner.add(TestCase {
+        name: "rescaler/scaling_filter_lanczos3",
+        steps: test_steps_from_scene(include_str!(
+            "./rescaler/scaling_filter_lanczos3.scene.json"
+        )),
+        inputs: vec![grid_input.clone()],
+        resolution: output_1080p,
+        rendering_mode: RenderingMode::GpuOptimized,
+        ..default.clone()
+    });
+
     runner.run()
 }


### PR DESCRIPTION
Tests are run as a separate job which runs on a larger github machine that has access to nvidia gpu.
The job will only run after `build_linux` and `lint` jobs.

There was also a problem with segfaults and deadlocks in nvidia's driver, so I added sleep at the end so that the threads have a chance to finish.

Snapshots: https://github.com/smelter-labs/smelter-snapshot-tests/pull/84

Closes: https://github.com/software-mansion/smelter/issues/1864