### PR TITLE
`smelter-api` add deserialization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5061,6 +5061,7 @@ dependencies = [
  "itertools 0.14.0",
  "schemars",
  "serde",
+ "serde_json",
  "smelter-core",
  "smelter-render",
  "tracing",

--- a/decklink/src/enums.rs
+++ b/decklink/src/enums.rs
@@ -428,7 +428,7 @@ pub mod ffi {
         ModeUnknown,
     }
 
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub enum PixelFormat {
         FormatUnspecified,
         Format8BitYUV,

--- a/smelter-api/Cargo.toml
+++ b/smelter-api/Cargo.toml
@@ -21,5 +21,8 @@ itertools = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 smelter-core = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/smelter-api/src/common/id.rs
+++ b/smelter-api/src/common/id.rs
@@ -4,17 +4,41 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct ComponentId(Arc<str>);
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct RendererId(Arc<str>);
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct OutputId(Arc<str>);
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct InputId(Arc<str>);
+
+impl From<&str> for ComponentId {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&str> for RendererId {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&str> for InputId {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
+impl From<&str> for OutputId {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
 
 impl From<ComponentId> for smelter_render::scene::ComponentId {
     fn from(id: ComponentId) -> Self {

--- a/smelter-api/src/common/resolution.rs
+++ b/smelter-api/src/common/resolution.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use smelter_render::scene;
 use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, JsonSchema, ToSchema, PartialEq)]
 pub struct Resolution {
     /// Width in pixels.
     pub width: usize,

--- a/smelter-api/src/video.rs
+++ b/smelter-api/src/video.rs
@@ -18,7 +18,7 @@ pub use transition::*;
 
 use crate::*;
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct VideoScene {
     pub root: Component,

--- a/smelter-api/src/video/color.rs
+++ b/smelter-api/src/video/color.rs
@@ -8,6 +8,12 @@ use crate::*;
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct RGBAColor(pub String);
 
+impl From<&str> for RGBAColor {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}
+
 impl TryFrom<RGBAColor> for scene::RGBAColor {
     type Error = TypeError;
     fn try_from(value: RGBAColor) -> std::result::Result<Self, Self::Error> {

--- a/smelter-api/src/video/common.rs
+++ b/smelter-api/src/video/common.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HorizontalAlign {
     Left,
@@ -11,7 +11,7 @@ pub enum HorizontalAlign {
     Center,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum VerticalAlign {
     Top,
@@ -20,5 +20,11 @@ pub enum VerticalAlign {
     Justified,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct AspectRatio(pub(super) String);
+
+impl From<&str> for AspectRatio {
+    fn from(s: &str) -> Self {
+        Self(s.into())
+    }
+}

--- a/smelter-api/src/video/component.rs
+++ b/smelter-api/src/video/component.rs
@@ -6,7 +6,7 @@ use utoipa::ToSchema;
 
 use crate::*;
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Component {
     InputStream(InputStream),
@@ -19,7 +19,7 @@ pub enum Component {
     Rescaler(Rescaler),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct InputStream {
     /// Id of a component.
@@ -28,7 +28,7 @@ pub struct InputStream {
     pub input_id: InputId,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct View {
     /// Id of a component.
@@ -117,7 +117,7 @@ pub struct View {
     pub padding_left: Option<f32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct BoxShadow {
     pub offset_x: Option<f32>,
@@ -126,7 +126,7 @@ pub struct BoxShadow {
     pub blur_radius: Option<f32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Overflow {
     /// Render everything, including content that extends beyond their parent.
@@ -146,7 +146,7 @@ pub enum Overflow {
     Fit,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ViewDirection {
     /// Children positioned from left to right.
@@ -155,7 +155,7 @@ pub enum ViewDirection {
     Column,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Rescaler {
     /// Id of a component.
@@ -221,7 +221,7 @@ pub struct Rescaler {
     pub box_shadow: Option<Vec<BoxShadow>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RescaleMode {
     /// Resize the component proportionally, so one of the dimensions is the same as its parent,
@@ -233,7 +233,7 @@ pub enum RescaleMode {
 }
 
 /// WebView component renders a website using Chromium.
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct WebView {
     /// Id of a component.
@@ -252,7 +252,7 @@ pub struct WebView {
     pub instance_id: RendererId,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Image {
     /// Id of a component.
@@ -270,7 +270,7 @@ pub struct Image {
     pub height: Option<f32>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Shader {
     /// Id of a component.
@@ -298,7 +298,7 @@ pub struct Shader {
     pub resolution: Resolution,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(
     tag = "type",
     rename_all = "snake_case",
@@ -315,7 +315,7 @@ pub enum ShaderParam {
     Struct(Vec<ShaderParamStructField>),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct ShaderParamStructField {
     pub field_name: String,
     #[serde(flatten)]
@@ -323,7 +323,7 @@ pub struct ShaderParamStructField {
     pub value: ShaderParam,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Text {
     /// Id of a component.
@@ -367,7 +367,7 @@ pub struct Text {
     pub weight: Option<TextWeight>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TextStyle {
     Normal,
@@ -375,7 +375,7 @@ pub enum TextStyle {
     Oblique,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TextWrapMode {
     /// Disable text wrapping. Text that does not fit inside the texture will be cut off.
@@ -387,7 +387,7 @@ pub enum TextWrapMode {
 }
 
 /// Font weight, based on the [OpenType specification](https://learn.microsoft.com/en-gb/typography/opentype/spec/os2#usweightclass).
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum TextWeight {
     /// Weight 100.
@@ -410,14 +410,14 @@ pub enum TextWeight {
     Black,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Interpolation {
     Linear,
     Spring,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Tiles {
     /// Id of a component.

--- a/smelter-api/src/video/transition.rs
+++ b/smelter-api/src/video/transition.rs
@@ -7,7 +7,7 @@ use utoipa::ToSchema;
 
 use crate::*;
 
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 pub struct Transition {
     /// Duration of a transition in milliseconds.
     pub duration_ms: f64,
@@ -23,7 +23,7 @@ pub struct Transition {
 /// Custom easing functions can be implemented with cubic Bézier.
 /// The control points are defined with `points` field by providing four numerical values: `x1`, `y1`, `x2` and `y2`. The `x1` and `x2` values have to be in the range `[0; 1]`. The cubic Bézier result is clamped to the range `[0; 1]`.
 /// You can find example control point configurations [here](https://easings.net/).
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema, PartialEq)]
 #[serde(tag = "function_name", rename_all = "snake_case")]
 pub enum EasingFunction {
     Linear,

--- a/smelter-api/tests/input_deserialization.rs
+++ b/smelter-api/tests/input_deserialization.rs
@@ -4,14 +4,13 @@ use std::time::Duration;
 
 use serde_json::json;
 use smelter_api::*;
+use smelter_core::QueueInputOptions;
 use smelter_core::codecs::VideoDecoderOptions;
 use smelter_core::protocols::{
-    HlsInputOptions, HlsInputVideoDecoders, Mp4InputOptions, Mp4InputSource,
-    Mp4InputVideoDecoders, PortOrRange, RtmpServerInputDecoders, RtmpServerInputOptions,
-    RtpAudioOptions, RtpInputOptions, RtpInputTransportProtocol, WebrtcVideoDecoderOptions,
-    WhepInputOptions, WhipInputOptions,
+    HlsInputOptions, HlsInputVideoDecoders, Mp4InputOptions, Mp4InputSource, Mp4InputVideoDecoders,
+    PortOrRange, RtmpServerInputDecoders, RtmpServerInputOptions, RtpAudioOptions, RtpInputOptions,
+    RtpInputTransportProtocol, WebrtcVideoDecoderOptions, WhepInputOptions, WhipInputOptions,
 };
-use smelter_core::QueueInputOptions;
 
 #[cfg(target_os = "linux")]
 use smelter_core::protocols::{V4l2Format, V4l2InputOptions};

--- a/smelter-api/tests/input_deserialization.rs
+++ b/smelter-api/tests/input_deserialization.rs
@@ -1,0 +1,1032 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use smelter_api::*;
+use smelter_core::codecs::VideoDecoderOptions;
+use smelter_core::protocols::{
+    HlsInputOptions, HlsInputVideoDecoders, Mp4InputOptions, Mp4InputSource,
+    Mp4InputVideoDecoders, PortOrRange, RtmpServerInputDecoders, RtmpServerInputOptions,
+    RtpAudioOptions, RtpInputOptions, RtpInputTransportProtocol, WebrtcVideoDecoderOptions,
+    WhepInputOptions, WhipInputOptions,
+};
+use smelter_core::QueueInputOptions;
+
+#[cfg(target_os = "linux")]
+use smelter_core::protocols::{V4l2Format, V4l2InputOptions};
+
+type CoreInput = smelter_core::RegisterInputOptions;
+
+fn default_queue() -> QueueInputOptions {
+    QueueInputOptions {
+        required: false,
+        video_side_channel: false,
+        audio_side_channel: false,
+    }
+}
+
+#[track_caller]
+fn check_rtmp(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: RtmpInput = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_rtp(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: RtpInput = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_rtp_ok(raw: serde_json::Value) {
+    let input = raw.get("input").unwrap().clone();
+    let api: RtpInput = serde_json::from_value(input).unwrap();
+    CoreInput::try_from(api).unwrap();
+}
+
+#[track_caller]
+fn check_rtp_err(raw: serde_json::Value, expected_msg: &str) {
+    let input = raw.get("input").unwrap().clone();
+    let api: RtpInput = serde_json::from_value(input).unwrap();
+    let err = CoreInput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_mp4(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: Mp4Input = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_mp4_err(raw: serde_json::Value, expected_msg: &str) {
+    let input = raw.get("input").unwrap().clone();
+    let api: Mp4Input = serde_json::from_value(input).unwrap();
+    let err = CoreInput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_whip(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: WhipInput = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_whip_err(raw: serde_json::Value, expected_msg: &str) {
+    let input = raw.get("input").unwrap().clone();
+    let api: WhipInput = serde_json::from_value(input).unwrap();
+    let err = CoreInput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_whep(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: WhepInput = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_whep_err(raw: serde_json::Value, expected_msg: &str) {
+    let input = raw.get("input").unwrap().clone();
+    let api: WhepInput = serde_json::from_value(input).unwrap();
+    let err = CoreInput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_hls(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: HlsInput = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[cfg(target_os = "linux")]
+#[track_caller]
+fn check_v4l2(raw: serde_json::Value, expected: CoreInput) {
+    let input = raw.get("input").unwrap().clone();
+    let api: V4l2Input = serde_json::from_value(input).unwrap();
+    let actual = CoreInput::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_decklink(raw: serde_json::Value) {
+    let input = raw.get("input").unwrap().clone();
+    let api: DeckLink = serde_json::from_value(input).unwrap();
+    let _ = CoreInput::try_from(api);
+}
+
+#[track_caller]
+fn check_serde_err<T: serde::de::DeserializeOwned>(raw: serde_json::Value) {
+    let input = raw.get("input").unwrap().clone();
+    assert!(serde_json::from_value::<T>(input).is_err());
+}
+
+// ── RTMP Input ───────────────────────────────────────────────────────
+
+#[test]
+fn rtmp_minimal() {
+    check_rtmp(
+        json!({
+            "input": {
+                "app": "live",
+                "stream_key": "stream_1"
+            }
+        }),
+        CoreInput::RtmpServer(RtmpServerInputOptions {
+            app: Arc::from("live"),
+            stream_key: Arc::from("stream_1"),
+            decoders: RtmpServerInputDecoders { h264: None },
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn rtmp_with_all_options() {
+    check_rtmp(
+        json!({
+            "input": {
+                "app": "live",
+                "stream_key": "stream_1",
+                "required": true,
+                "decoder_map": {
+                    "h264": "ffmpeg_h264"
+                },
+                "side_channel": {
+                    "video": true,
+                    "audio": false
+                }
+            }
+        }),
+        CoreInput::RtmpServer(RtmpServerInputOptions {
+            app: Arc::from("live"),
+            stream_key: Arc::from("stream_1"),
+            decoders: RtmpServerInputDecoders {
+                h264: Some(VideoDecoderOptions::FfmpegH264),
+            },
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: true,
+                audio_side_channel: false,
+            },
+        }),
+    );
+}
+
+#[test]
+fn rtmp_vulkan_decoder() {
+    check_rtmp(
+        json!({
+            "input": {
+                "app": "live",
+                "stream_key": "stream_1",
+                "decoder_map": {
+                    "h264": "vulkan_h264"
+                }
+            }
+        }),
+        CoreInput::RtmpServer(RtmpServerInputOptions {
+            app: Arc::from("live"),
+            stream_key: Arc::from("stream_1"),
+            decoders: RtmpServerInputDecoders {
+                h264: Some(VideoDecoderOptions::VulkanH264),
+            },
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn err_serde_rtmp_missing_app() {
+    check_serde_err::<RtmpInput>(json!({
+        "input": {
+            "stream_key": "stream_1"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_rtmp_missing_stream_key() {
+    check_serde_err::<RtmpInput>(json!({
+        "input": {
+            "app": "live"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_rtmp_unknown_field() {
+    check_serde_err::<RtmpInput>(json!({
+        "input": {
+            "app": "live",
+            "stream_key": "stream_1",
+            "unknown": true
+        }
+    }));
+}
+
+// ── RTP Input ────────────────────────────────────────────────────────
+
+#[test]
+fn rtp_video_h264() {
+    check_rtp(
+        json!({
+            "input": {
+                "port": 9002,
+                "video": {
+                    "decoder": "ffmpeg_h264"
+                }
+            }
+        }),
+        CoreInput::Rtp(RtpInputOptions {
+            port: PortOrRange::Exact(9002),
+            transport_protocol: RtpInputTransportProtocol::Udp,
+            video: Some(VideoDecoderOptions::FfmpegH264),
+            audio: None,
+            queue_options: default_queue(),
+            offset: None,
+            buffer_duration: None,
+        }),
+    );
+}
+
+#[test]
+fn rtp_audio_opus() {
+    check_rtp(
+        json!({
+            "input": {
+                "port": 9002,
+                "audio": {
+                    "decoder": "opus"
+                }
+            }
+        }),
+        CoreInput::Rtp(RtpInputOptions {
+            port: PortOrRange::Exact(9002),
+            transport_protocol: RtpInputTransportProtocol::Udp,
+            video: None,
+            audio: Some(RtpAudioOptions::Opus),
+            queue_options: default_queue(),
+            offset: None,
+            buffer_duration: None,
+        }),
+    );
+}
+
+#[test]
+fn rtp_audio_aac() {
+    // AAC conversion involves AacAudioSpecificConfig::parse_from which is complex;
+    // just verify the conversion succeeds.
+    check_rtp_ok(json!({
+        "input": {
+            "port": 9002,
+            "audio": {
+                "decoder": "aac",
+                "audio_specific_config": "1190"
+            }
+        }
+    }));
+}
+
+#[test]
+fn rtp_audio_aac_low_bitrate() {
+    // AAC conversion involves AacAudioSpecificConfig::parse_from which is complex;
+    // just verify the conversion succeeds.
+    check_rtp_ok(json!({
+        "input": {
+            "port": 9002,
+            "audio": {
+                "decoder": "aac",
+                "audio_specific_config": "1190",
+                "rtp_mode": "low_bitrate"
+            }
+        }
+    }));
+}
+
+#[test]
+fn rtp_video_and_audio() {
+    check_rtp(
+        json!({
+            "input": {
+                "port": 9002,
+                "transport_protocol": "udp",
+                "video": {
+                    "decoder": "ffmpeg_h264"
+                },
+                "audio": {
+                    "decoder": "opus"
+                },
+                "required": true,
+                "offset_ms": 500.0,
+                "buffer_size_ms": 200.0,
+                "side_channel": { "video": true }
+            }
+        }),
+        CoreInput::Rtp(RtpInputOptions {
+            port: PortOrRange::Exact(9002),
+            transport_protocol: RtpInputTransportProtocol::Udp,
+            video: Some(VideoDecoderOptions::FfmpegH264),
+            audio: Some(RtpAudioOptions::Opus),
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: true,
+                audio_side_channel: false,
+            },
+            offset: Some(Duration::from_millis(500)),
+            buffer_duration: Some(Duration::from_millis(200)),
+        }),
+    );
+}
+
+#[test]
+fn rtp_port_range() {
+    check_rtp(
+        json!({
+            "input": {
+                "port": "9000:9010",
+                "transport_protocol": "tcp_server",
+                "video": {
+                    "decoder": "ffmpeg_vp8"
+                }
+            }
+        }),
+        CoreInput::Rtp(RtpInputOptions {
+            port: PortOrRange::Range((9000, 9010)),
+            transport_protocol: RtpInputTransportProtocol::TcpServer,
+            video: Some(VideoDecoderOptions::FfmpegVp8),
+            audio: None,
+            queue_options: default_queue(),
+            offset: None,
+            buffer_duration: None,
+        }),
+    );
+}
+
+#[test]
+fn rtp_video_vp9() {
+    check_rtp(
+        json!({
+            "input": {
+                "port": 9002,
+                "video": {
+                    "decoder": "ffmpeg_vp9"
+                }
+            }
+        }),
+        CoreInput::Rtp(RtpInputOptions {
+            port: PortOrRange::Exact(9002),
+            transport_protocol: RtpInputTransportProtocol::Udp,
+            video: Some(VideoDecoderOptions::FfmpegVp9),
+            audio: None,
+            queue_options: default_queue(),
+            offset: None,
+            buffer_duration: None,
+        }),
+    );
+}
+
+#[test]
+fn rtp_video_vulkan_h264() {
+    check_rtp(
+        json!({
+            "input": {
+                "port": 9002,
+                "video": {
+                    "decoder": "vulkan_h264"
+                }
+            }
+        }),
+        CoreInput::Rtp(RtpInputOptions {
+            port: PortOrRange::Exact(9002),
+            transport_protocol: RtpInputTransportProtocol::Udp,
+            video: Some(VideoDecoderOptions::VulkanH264),
+            audio: None,
+            queue_options: default_queue(),
+            offset: None,
+            buffer_duration: None,
+        }),
+    );
+}
+
+#[test]
+fn err_rtp_no_video_no_audio() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": 9002
+            }
+        }),
+        "At least one of `video` and `audio` has to be specified in `register_input` request.",
+    );
+}
+
+#[test]
+fn err_rtp_negative_buffer() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": 9002,
+                "video": { "decoder": "ffmpeg_h264" },
+                "buffer_size_ms": -100.0
+            }
+        }),
+        "Invalid buffer_size_ms. cannot convert float seconds to Duration: value is negative",
+    );
+}
+
+#[test]
+fn err_rtp_aac_empty_config() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": 9002,
+                "audio": {
+                    "decoder": "aac",
+                    "audio_specific_config": ""
+                }
+            }
+        }),
+        "The AudioSpecificConfig field is empty.",
+    );
+}
+
+#[test]
+fn err_rtp_aac_non_hex_config() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": 9002,
+                "audio": {
+                    "decoder": "aac",
+                    "audio_specific_config": "ZZZZ"
+                }
+            }
+        }),
+        "Not all of the provided string are hex digits.",
+    );
+}
+
+#[test]
+fn err_rtp_port_zero() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": 0,
+                "video": { "decoder": "ffmpeg_h264" }
+            }
+        }),
+        "Port needs to be a number between 1 and 65535 or a string in the \"START:END\" format, where START and END represent a range of ports.",
+    );
+}
+
+#[test]
+fn err_rtp_port_range_reversed() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": "9010:9000",
+                "video": { "decoder": "ffmpeg_h264" }
+            }
+        }),
+        "Port needs to be a number between 1 and 65535 or a string in the \"START:END\" format, where START and END represent a range of ports.",
+    );
+}
+
+#[test]
+fn err_rtp_port_range_bad_format() {
+    check_rtp_err(
+        json!({
+            "input": {
+                "port": "not_a_port",
+                "video": { "decoder": "ffmpeg_h264" }
+            }
+        }),
+        "Port needs to be a number between 1 and 65535 or a string in the \"START:END\" format, where START and END represent a range of ports.",
+    );
+}
+
+// ── MP4 Input ────────────────────────────────────────────────────────
+
+#[test]
+fn mp4_with_url() {
+    check_mp4(
+        json!({
+            "input": {
+                "url": "https://example.com/video.mp4"
+            }
+        }),
+        CoreInput::Mp4(Mp4InputOptions {
+            source: Mp4InputSource::Url(Arc::from("https://example.com/video.mp4")),
+            should_loop: false,
+            video_decoders: Mp4InputVideoDecoders { h264: None },
+            seek: None,
+            offset: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn mp4_with_path() {
+    check_mp4(
+        json!({
+            "input": {
+                "path": "/tmp/video.mp4"
+            }
+        }),
+        CoreInput::Mp4(Mp4InputOptions {
+            source: Mp4InputSource::File(Arc::from(Path::new("/tmp/video.mp4"))),
+            should_loop: false,
+            video_decoders: Mp4InputVideoDecoders { h264: None },
+            seek: None,
+            offset: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn mp4_with_all_options() {
+    check_mp4(
+        json!({
+            "input": {
+                "url": "https://example.com/video.mp4",
+                "loop": true,
+                "required": true,
+                "offset_ms": 1000.0,
+                "seek_ms": 5000.0,
+                "decoder_map": {
+                    "h264": "ffmpeg_h264"
+                },
+                "side_channel": { "audio": true }
+            }
+        }),
+        CoreInput::Mp4(Mp4InputOptions {
+            source: Mp4InputSource::Url(Arc::from("https://example.com/video.mp4")),
+            should_loop: true,
+            video_decoders: Mp4InputVideoDecoders {
+                h264: Some(VideoDecoderOptions::FfmpegH264),
+            },
+            seek: Some(Duration::from_secs(5)),
+            offset: Some(Duration::from_secs(1)),
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: false,
+                audio_side_channel: true,
+            },
+        }),
+    );
+}
+
+#[test]
+fn mp4_vulkan_decoder() {
+    check_mp4(
+        json!({
+            "input": {
+                "path": "/tmp/video.mp4",
+                "decoder_map": {
+                    "h264": "vulkan_h264"
+                }
+            }
+        }),
+        CoreInput::Mp4(Mp4InputOptions {
+            source: Mp4InputSource::File(Arc::from(Path::new("/tmp/video.mp4"))),
+            should_loop: false,
+            video_decoders: Mp4InputVideoDecoders {
+                h264: Some(VideoDecoderOptions::VulkanH264),
+            },
+            seek: None,
+            offset: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn err_mp4_both_url_and_path() {
+    check_mp4_err(
+        json!({
+            "input": {
+                "url": "https://example.com/video.mp4",
+                "path": "/tmp/video.mp4"
+            }
+        }),
+        "Exactly one of `url` or `path` has to be specified in a register request for an mp4 input.",
+    );
+}
+
+#[test]
+fn err_mp4_neither_url_nor_path() {
+    check_mp4_err(
+        json!({
+            "input": {}
+        }),
+        "Exactly one of `url` or `path` has to be specified in a register request for an mp4 input.",
+    );
+}
+
+#[test]
+fn err_mp4_negative_seek() {
+    check_mp4_err(
+        json!({
+            "input": {
+                "url": "https://example.com/video.mp4",
+                "seek_ms": -1000.0
+            }
+        }),
+        "Invalid duration. cannot convert float seconds to Duration: value is negative",
+    );
+}
+
+// ── WHIP Input ───────────────────────────────────────────────────────
+
+#[test]
+fn whip_minimal() {
+    check_whip(
+        json!({
+            "input": {}
+        }),
+        CoreInput::Whip(WhipInputOptions {
+            video_preferences: vec![WebrtcVideoDecoderOptions::Any],
+            bearer_token: None,
+            endpoint_override: None,
+            jitter_buffer_size: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn whip_with_all_options() {
+    check_whip(
+        json!({
+            "input": {
+                "bearer_token": "secret",
+                "video": {
+                    "decoder_preferences": ["ffmpeg_h264", "ffmpeg_vp8"]
+                },
+                "required": true,
+                "buffer_size_ms": 200.0,
+                "side_channel": { "video": true, "audio": true }
+            }
+        }),
+        CoreInput::Whip(WhipInputOptions {
+            video_preferences: vec![
+                WebrtcVideoDecoderOptions::FfmpegH264,
+                WebrtcVideoDecoderOptions::FfmpegVp8,
+            ],
+            bearer_token: Some(Arc::from("secret")),
+            endpoint_override: None,
+            jitter_buffer_size: Some(Duration::from_millis(200)),
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: true,
+                audio_side_channel: true,
+            },
+        }),
+    );
+}
+
+#[test]
+fn whip_video_decoder_preferences() {
+    check_whip(
+        json!({
+            "input": {
+                "video": {
+                    "decoder_preferences": ["ffmpeg_vp9", "vulkan_h264", "any"]
+                }
+            }
+        }),
+        CoreInput::Whip(WhipInputOptions {
+            video_preferences: vec![
+                WebrtcVideoDecoderOptions::FfmpegVp9,
+                WebrtcVideoDecoderOptions::VulkanH264,
+                WebrtcVideoDecoderOptions::Any,
+            ],
+            bearer_token: None,
+            endpoint_override: None,
+            jitter_buffer_size: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn whip_empty_decoder_preferences_defaults_to_any() {
+    check_whip(
+        json!({
+            "input": {
+                "video": {
+                    "decoder_preferences": []
+                }
+            }
+        }),
+        CoreInput::Whip(WhipInputOptions {
+            video_preferences: vec![WebrtcVideoDecoderOptions::Any],
+            bearer_token: None,
+            endpoint_override: None,
+            jitter_buffer_size: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn err_whip_negative_buffer() {
+    check_whip_err(
+        json!({
+            "input": {
+                "buffer_size_ms": -50.0
+            }
+        }),
+        "Invalid buffer_size_ms. cannot convert float seconds to Duration: value is negative",
+    );
+}
+
+// ── WHEP Input ───────────────────────────────────────────────────────
+
+#[test]
+fn whep_minimal() {
+    check_whep(
+        json!({
+            "input": {
+                "endpoint_url": "https://example.com/whep"
+            }
+        }),
+        CoreInput::Whep(WhepInputOptions {
+            video_preferences: vec![WebrtcVideoDecoderOptions::Any],
+            bearer_token: None,
+            endpoint_url: Arc::from("https://example.com/whep"),
+            jitter_buffer_size: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn whep_with_all_options() {
+    check_whep(
+        json!({
+            "input": {
+                "endpoint_url": "https://example.com/whep",
+                "bearer_token": "token123",
+                "video": {
+                    "decoder_preferences": ["ffmpeg_h264"]
+                },
+                "required": true,
+                "buffer_size_ms": 300.0,
+                "side_channel": { "video": true }
+            }
+        }),
+        CoreInput::Whep(WhepInputOptions {
+            video_preferences: vec![WebrtcVideoDecoderOptions::FfmpegH264],
+            bearer_token: Some(Arc::from("token123")),
+            endpoint_url: Arc::from("https://example.com/whep"),
+            jitter_buffer_size: Some(Duration::from_millis(300)),
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: true,
+                audio_side_channel: false,
+            },
+        }),
+    );
+}
+
+#[test]
+fn err_serde_whep_missing_endpoint() {
+    check_serde_err::<WhepInput>(json!({
+        "input": {}
+    }));
+}
+
+#[test]
+fn err_whep_negative_buffer() {
+    check_whep_err(
+        json!({
+            "input": {
+                "endpoint_url": "https://example.com/whep",
+                "buffer_size_ms": -50.0
+            }
+        }),
+        "Invalid buffer_size_ms. cannot convert float seconds to Duration: value is negative",
+    );
+}
+
+// ── HLS Input ────────────────────────────────────────────────────────
+
+#[test]
+fn hls_minimal() {
+    check_hls(
+        json!({
+            "input": {
+                "url": "https://example.com/stream.m3u8"
+            }
+        }),
+        CoreInput::Hls(HlsInputOptions {
+            url: Arc::from("https://example.com/stream.m3u8"),
+            video_decoders: HlsInputVideoDecoders { h264: None },
+            queue_options: default_queue(),
+            offset: None,
+        }),
+    );
+}
+
+#[test]
+fn hls_with_all_options() {
+    check_hls(
+        json!({
+            "input": {
+                "url": "https://example.com/stream.m3u8",
+                "required": true,
+                "offset_ms": 500.0,
+                "decoder_map": {
+                    "h264": "ffmpeg_h264"
+                },
+                "side_channel": { "video": true, "audio": true }
+            }
+        }),
+        CoreInput::Hls(HlsInputOptions {
+            url: Arc::from("https://example.com/stream.m3u8"),
+            video_decoders: HlsInputVideoDecoders {
+                h264: Some(VideoDecoderOptions::FfmpegH264),
+            },
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: true,
+                audio_side_channel: true,
+            },
+            offset: Some(Duration::from_millis(500)),
+        }),
+    );
+}
+
+#[test]
+fn hls_vulkan_decoder() {
+    check_hls(
+        json!({
+            "input": {
+                "url": "https://example.com/stream.m3u8",
+                "decoder_map": {
+                    "h264": "vulkan_h264"
+                }
+            }
+        }),
+        CoreInput::Hls(HlsInputOptions {
+            url: Arc::from("https://example.com/stream.m3u8"),
+            video_decoders: HlsInputVideoDecoders {
+                h264: Some(VideoDecoderOptions::VulkanH264),
+            },
+            queue_options: default_queue(),
+            offset: None,
+        }),
+    );
+}
+
+#[test]
+fn err_serde_hls_missing_url() {
+    check_serde_err::<HlsInput>(json!({
+        "input": {}
+    }));
+}
+
+// ── V4L2 Input ───────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+#[test]
+fn v4l2_minimal() {
+    check_v4l2(
+        json!({
+            "input": {
+                "path": "/dev/video0",
+                "format": "yuyv"
+            }
+        }),
+        CoreInput::V4l2(V4l2InputOptions {
+            path: Arc::from(Path::new("/dev/video0")),
+            resolution: None,
+            format: V4l2Format::Yuyv,
+            framerate: None,
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn v4l2_with_all_options() {
+    check_v4l2(
+        json!({
+            "input": {
+                "path": "/dev/video0",
+                "format": "nv12",
+                "resolution": { "width": 1920, "height": 1080 },
+                "framerate": 30,
+                "required": true,
+                "side_channel": { "video": true }
+            }
+        }),
+        CoreInput::V4l2(V4l2InputOptions {
+            path: Arc::from(Path::new("/dev/video0")),
+            resolution: Some(smelter_render::Resolution {
+                width: 1920,
+                height: 1080,
+            }),
+            format: V4l2Format::Nv12,
+            framerate: Some(smelter_render::Framerate { num: 30, den: 1 }),
+            queue_options: QueueInputOptions {
+                required: true,
+                video_side_channel: true,
+                audio_side_channel: false,
+            },
+        }),
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn v4l2_fractional_framerate() {
+    check_v4l2(
+        json!({
+            "input": {
+                "path": "/dev/video0",
+                "format": "yuyv",
+                "framerate": "30000/1001"
+            }
+        }),
+        CoreInput::V4l2(V4l2InputOptions {
+            path: Arc::from(Path::new("/dev/video0")),
+            resolution: None,
+            format: V4l2Format::Yuyv,
+            framerate: Some(smelter_render::Framerate {
+                num: 30000,
+                den: 1001,
+            }),
+            queue_options: default_queue(),
+        }),
+    );
+}
+
+#[test]
+fn err_serde_v4l2_missing_path() {
+    check_serde_err::<V4l2Input>(json!({
+        "input": {
+            "format": "yuyv"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_v4l2_missing_format() {
+    check_serde_err::<V4l2Input>(json!({
+        "input": {
+            "path": "/dev/video0"
+        }
+    }));
+}
+
+// ── DeckLink Input ───────────────────────────────────────────────────
+
+#[test]
+fn decklink_minimal() {
+    check_decklink(json!({
+        "input": {}
+    }));
+}
+
+#[test]
+fn decklink_with_all_options() {
+    check_decklink(json!({
+        "input": {
+            "subdevice_index": 0,
+            "display_name": "DeckLink Mini Recorder",
+            "persistent_id": "AABBCCDD",
+            "enable_audio": false,
+            "required": true,
+            "side_channel": { "video": true }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_decklink_unknown_field() {
+    check_serde_err::<DeckLink>(json!({
+        "input": {
+            "nonexistent": true
+        }
+    }));
+}

--- a/smelter-api/tests/output_deserialization.rs
+++ b/smelter-api/tests/output_deserialization.rs
@@ -1,0 +1,1901 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use smelter_api::*;
+
+type CoreOutput = smelter_core::RegisterOutputOptions;
+
+fn video_scene() -> serde_json::Value {
+    json!({ "root": { "type": "view" } })
+}
+
+fn audio_scene() -> serde_json::Value {
+    json!({ "inputs": [] })
+}
+
+fn default_video() -> smelter_core::RegisterOutputVideoOptions {
+    smelter_core::RegisterOutputVideoOptions {
+        initial: smelter_render::scene::Component::View(
+            smelter_render::scene::ViewComponent::default(),
+        ),
+        end_condition: smelter_core::PipelineOutputEndCondition::Never,
+    }
+}
+
+fn default_audio() -> smelter_core::RegisterOutputAudioOptions {
+    smelter_core::RegisterOutputAudioOptions {
+        initial: smelter_core::AudioMixerConfig { inputs: vec![] },
+        mixing_strategy: smelter_core::AudioMixingStrategy::SumClip,
+        channels: smelter_core::AudioChannels::Stereo,
+        end_condition: smelter_core::PipelineOutputEndCondition::Never,
+    }
+}
+
+fn default_keyframe_interval() -> Duration {
+    Duration::from_millis(5000)
+}
+
+#[track_caller]
+fn check_rtmp(raw: serde_json::Value, expected: CoreOutput) {
+    let output = raw.get("output").unwrap().clone();
+    let api: RtmpOutput = serde_json::from_value(output).unwrap();
+    let result = CoreOutput::try_from(api).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[track_caller]
+fn check_rtmp_err(raw: serde_json::Value, expected_msg: &str) {
+    let output = raw.get("output").unwrap().clone();
+    let api: RtmpOutput = serde_json::from_value(output).unwrap();
+    let err = CoreOutput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_rtp(raw: serde_json::Value, expected: CoreOutput) {
+    let output = raw.get("output").unwrap().clone();
+    let api: RtpOutput = serde_json::from_value(output).unwrap();
+    let result = CoreOutput::try_from(api).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[track_caller]
+fn check_rtp_err(raw: serde_json::Value, expected_msg: &str) {
+    let output = raw.get("output").unwrap().clone();
+    let api: RtpOutput = serde_json::from_value(output).unwrap();
+    let err = CoreOutput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_mp4(raw: serde_json::Value, expected: CoreOutput) {
+    let output = raw.get("output").unwrap().clone();
+    let api: Mp4Output = serde_json::from_value(output).unwrap();
+    let result = CoreOutput::try_from(api).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[track_caller]
+fn check_mp4_err(raw: serde_json::Value, expected_msg: &str) {
+    let output = raw.get("output").unwrap().clone();
+    let api: Mp4Output = serde_json::from_value(output).unwrap();
+    let err = CoreOutput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_whip(raw: serde_json::Value, expected: CoreOutput) {
+    let output = raw.get("output").unwrap().clone();
+    let api: WhipOutput = serde_json::from_value(output).unwrap();
+    let result = CoreOutput::try_from(api).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[track_caller]
+fn check_whip_err(raw: serde_json::Value, expected_msg: &str) {
+    let output = raw.get("output").unwrap().clone();
+    let api: WhipOutput = serde_json::from_value(output).unwrap();
+    let err = CoreOutput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_whep(raw: serde_json::Value, expected: CoreOutput) {
+    let output = raw.get("output").unwrap().clone();
+    let api: WhepOutput = serde_json::from_value(output).unwrap();
+    let result = CoreOutput::try_from(api).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[track_caller]
+fn check_whep_err(raw: serde_json::Value, expected_msg: &str) {
+    let output = raw.get("output").unwrap().clone();
+    let api: WhepOutput = serde_json::from_value(output).unwrap();
+    let err = CoreOutput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_hls(raw: serde_json::Value, expected: CoreOutput) {
+    let output = raw.get("output").unwrap().clone();
+    let api: HlsOutput = serde_json::from_value(output).unwrap();
+    let result = CoreOutput::try_from(api).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[track_caller]
+fn check_hls_err(raw: serde_json::Value, expected_msg: &str) {
+    let output = raw.get("output").unwrap().clone();
+    let api: HlsOutput = serde_json::from_value(output).unwrap();
+    let err = CoreOutput::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_serde_err<T: serde::de::DeserializeOwned>(raw: serde_json::Value) {
+    let output = raw.get("output").unwrap().clone();
+    assert!(serde_json::from_value::<T>(output).is_err());
+}
+
+// ── RTMP Output ──────────────────────────────────────────────────────
+
+#[test]
+fn rtmp_video_only() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::Avcc,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtmp_audio_only() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "audio": {
+                    "encoder": { "type": "aac" },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 44100,
+                        },
+                    )),
+                },
+            ),
+            video: None,
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn rtmp_video_and_audio() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1280, "height": 720 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "preset": "ultrafast",
+                        "bitrate": 4000000,
+                        "keyframe_interval_ms": 2000,
+                        "pixel_format": "yuv420p"
+                    },
+                    "initial": video_scene()
+                },
+                "audio": {
+                    "mixing_strategy": "sum_clip",
+                    "encoder": {
+                        "type": "aac",
+                        "sample_rate": 44100
+                    },
+                    "channels": "stereo",
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Ultrafast,
+                            bitrate: Some(smelter_core::codecs::VideoEncoderBitrate {
+                                average_bitrate: 4000000,
+                                max_bitrate: 5000000,
+                            }),
+                            keyframe_interval: Duration::from_millis(2000),
+                            resolution: smelter_render::Resolution {
+                                width: 1280,
+                                height: 720,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::Avcc,
+                        },
+                    )),
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 44100,
+                        },
+                    )),
+                },
+            ),
+            video: Some(default_video()),
+            audio: Some(smelter_core::RegisterOutputAudioOptions {
+                initial: smelter_core::AudioMixerConfig { inputs: vec![] },
+                mixing_strategy: smelter_core::AudioMixingStrategy::SumClip,
+                channels: smelter_core::AudioChannels::Stereo,
+                end_condition: smelter_core::PipelineOutputEndCondition::Never,
+            }),
+        },
+    );
+}
+
+#[test]
+fn rtmp_vulkan_h264_encoder() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "vulkan_h264",
+                        "keyframe_interval_ms": 3000
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::VulkanH264(
+                        smelter_core::codecs::VulkanH264EncoderOptions {
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            bitrate: None,
+                            keyframe_interval: Duration::from_millis(3000),
+                            preset: smelter_core::codecs::VulkanH264EncoderPreset::HighQuality,
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::Avcc,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtmp_vbr_bitrate() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "bitrate": {
+                            "average_bitrate": 4000000,
+                            "max_bitrate": 6000000
+                        }
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: Some(smelter_core::codecs::VideoEncoderBitrate {
+                                average_bitrate: 4000000,
+                                max_bitrate: 6000000,
+                            }),
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::Avcc,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtmp_send_eos_when_any_of() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "send_eos_when": {
+                        "any_of": ["input_1", "input_2"]
+                    },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::Avcc,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(smelter_core::RegisterOutputVideoOptions {
+                initial: smelter_render::scene::Component::View(
+                    smelter_render::scene::ViewComponent::default(),
+                ),
+                end_condition: smelter_core::PipelineOutputEndCondition::AnyOf(vec![
+                    smelter_render::InputId(Arc::from("input_1")),
+                    smelter_render::InputId(Arc::from("input_2")),
+                ]),
+            }),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtmp_send_eos_when_all_inputs() {
+    check_rtmp(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "send_eos_when": {
+                        "all_inputs": true
+                    },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtmp(
+                smelter_core::protocols::RtmpOutputOptions {
+                    connection: smelter_core::protocols::RtmpConnectionOptions {
+                        host: "localhost".into(),
+                        port: 1935,
+                        app: "live".into(),
+                        stream_key: "stream".into(),
+                        use_tls: false,
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::Avcc,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(smelter_core::RegisterOutputVideoOptions {
+                initial: smelter_render::scene::Component::View(
+                    smelter_render::scene::ViewComponent::default(),
+                ),
+                end_condition: smelter_core::PipelineOutputEndCondition::AllInputs,
+            }),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn err_rtmp_no_video_no_audio() {
+    check_rtmp_err(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream"
+            }
+        }),
+        "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+#[test]
+fn err_rtmp_vbr_max_less_than_average() {
+    check_rtmp_err(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "bitrate": {
+                            "average_bitrate": 6000000,
+                            "max_bitrate": 4000000
+                        }
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        "max_bitrate has to be greater than average_bitrate",
+    );
+}
+
+#[test]
+fn err_rtmp_negative_keyframe_interval() {
+    check_rtmp_err(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "keyframe_interval_ms": -1000
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        "Keyframe interval cannot be negative.",
+    );
+}
+
+#[test]
+fn err_rtmp_conflicting_end_conditions() {
+    check_rtmp_err(
+        json!({
+            "output": {
+                "url": "rtmp://localhost:1935/live/stream",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "send_eos_when": {
+                        "any_of": ["input_1"],
+                        "all_inputs": true
+                    },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        "Only one of \"any_of, all_of, any_input or all_inputs\" is allowed.",
+    );
+}
+
+// ── RTP Output ───────────────────────────────────────────────────────
+
+#[test]
+fn rtp_udp_video_only() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options: smelter_core::protocols::RtpOutputConnectionOptions::Udp {
+                        port: smelter_core::protocols::Port(9002),
+                        ip: Arc::from("127.0.0.1"),
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtp_tcp_server_video() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": 9002,
+                "transport_protocol": "tcp_server",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options:
+                        smelter_core::protocols::RtpOutputConnectionOptions::TcpServer {
+                            port: smelter_core::protocols::PortOrRange::Exact(9002),
+                        },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtp_tcp_server_port_range() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": "9000:9010",
+                "transport_protocol": "tcp_server",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options:
+                        smelter_core::protocols::RtpOutputConnectionOptions::TcpServer {
+                            port: smelter_core::protocols::PortOrRange::Range((9000, 9010)),
+                        },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtp_vp8_encoder() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_vp8",
+                        "bitrate": 5000000,
+                        "keyframe_interval_ms": 3000
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options: smelter_core::protocols::RtpOutputConnectionOptions::Udp {
+                        port: smelter_core::protocols::Port(9002),
+                        ip: Arc::from("127.0.0.1"),
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegVp8(
+                        smelter_core::codecs::FfmpegVp8EncoderOptions {
+                            bitrate: Some(smelter_core::codecs::VideoEncoderBitrate {
+                                average_bitrate: 5000000,
+                                max_bitrate: 6250000,
+                            }),
+                            keyframe_interval: Duration::from_millis(3000),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            raw_options: vec![],
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtp_vp9_encoder() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_vp9",
+                        "pixel_format": "yuv444p"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options: smelter_core::protocols::RtpOutputConnectionOptions::Udp {
+                        port: smelter_core::protocols::Port(9002),
+                        ip: Arc::from("127.0.0.1"),
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegVp9(
+                        smelter_core::codecs::FfmpegVp9EncoderOptions {
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV444P,
+                            raw_options: vec![],
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn rtp_audio_opus() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "audio": {
+                    "encoder": {
+                        "type": "opus",
+                        "preset": "voip",
+                        "sample_rate": 48000,
+                        "forward_error_correction": true,
+                        "expected_packet_loss": 10
+                    },
+                    "channels": "mono",
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options: smelter_core::protocols::RtpOutputConnectionOptions::Udp {
+                        port: smelter_core::protocols::Port(9002),
+                        ip: Arc::from("127.0.0.1"),
+                    },
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::Opus(
+                        smelter_core::codecs::OpusEncoderOptions {
+                            channels: smelter_core::AudioChannels::Mono,
+                            preset: smelter_core::codecs::OpusEncoderPreset::Voip,
+                            sample_rate: 48000,
+                            forward_error_correction: true,
+                            packet_loss: 10,
+                        },
+                    )),
+                },
+            ),
+            video: None,
+            audio: Some(smelter_core::RegisterOutputAudioOptions {
+                initial: smelter_core::AudioMixerConfig { inputs: vec![] },
+                mixing_strategy: smelter_core::AudioMixingStrategy::SumClip,
+                channels: smelter_core::AudioChannels::Mono,
+                end_condition: smelter_core::PipelineOutputEndCondition::Never,
+            }),
+        },
+    );
+}
+
+#[test]
+fn rtp_video_and_audio() {
+    check_rtp(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "video": {
+                    "resolution": { "width": 1280, "height": 720 },
+                    "encoder": { "type": "ffmpeg_h264", "preset": "medium" },
+                    "initial": video_scene()
+                },
+                "audio": {
+                    "encoder": { "type": "opus" },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Rtp(
+                smelter_core::protocols::RtpOutputOptions {
+                    connection_options: smelter_core::protocols::RtpOutputConnectionOptions::Udp {
+                        port: smelter_core::protocols::Port(9002),
+                        ip: Arc::from("127.0.0.1"),
+                    },
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Medium,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1280,
+                                height: 720,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::Opus(
+                        smelter_core::codecs::OpusEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            preset: smelter_core::codecs::OpusEncoderPreset::Voip,
+                            sample_rate: 48000,
+                            forward_error_correction: false,
+                            packet_loss: 0,
+                        },
+                    )),
+                },
+            ),
+            video: Some(default_video()),
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn err_rtp_no_video_no_audio() {
+    check_rtp_err(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1"
+            }
+        }),
+        "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+#[test]
+fn err_rtp_udp_port_range() {
+    check_rtp_err(
+        json!({
+            "output": {
+                "port": "9000:9010",
+                "ip": "127.0.0.1",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        "Port range can not be used with UDP output stream (transport_protocol=\"udp\").",
+    );
+}
+
+#[test]
+fn err_rtp_udp_missing_ip() {
+    check_rtp_err(
+        json!({
+            "output": {
+                "port": 9002,
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        "\"ip\" field is required when registering output UDP stream (transport_protocol=\"udp\").",
+    );
+}
+
+#[test]
+fn err_rtp_tcp_server_with_ip() {
+    check_rtp_err(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "transport_protocol": "tcp_server",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        "\"ip\" field is not allowed when registering TCP server connection (transport_protocol=\"tcp_server\").",
+    );
+}
+
+#[test]
+fn err_rtp_opus_packet_loss_out_of_range() {
+    check_rtp_err(
+        json!({
+            "output": {
+                "port": 9002,
+                "ip": "127.0.0.1",
+                "audio": {
+                    "encoder": {
+                        "type": "opus",
+                        "expected_packet_loss": 101
+                    },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        "Expected packet loss value must be from [0, 100] range.",
+    );
+}
+
+// ── MP4 Output ───────────────────────────────────────────────────────
+
+#[test]
+fn mp4_video_only() {
+    check_mp4(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "preset": "slow"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Mp4(
+                smelter_core::protocols::Mp4OutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/output.mp4")),
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Slow,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                    raw_options: vec![],
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn mp4_audio_only() {
+    check_mp4(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4",
+                "audio": {
+                    "encoder": { "type": "aac", "sample_rate": 48000 },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Mp4(
+                smelter_core::protocols::Mp4OutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/output.mp4")),
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 48000,
+                        },
+                    )),
+                    raw_options: vec![],
+                },
+            ),
+            video: None,
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn mp4_video_and_audio_with_ffmpeg_options() {
+    check_mp4(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4",
+                "video": {
+                    "resolution": { "width": 1280, "height": 720 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "ffmpeg_options": { "crf": "23" }
+                    },
+                    "initial": video_scene()
+                },
+                "audio": {
+                    "mixing_strategy": "sum_scale",
+                    "encoder": { "type": "aac" },
+                    "channels": "mono",
+                    "initial": audio_scene()
+                },
+                "ffmpeg_options": { "movflags": "faststart" }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Mp4(
+                smelter_core::protocols::Mp4OutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/output.mp4")),
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1280,
+                                height: 720,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![(Arc::from("crf"), Arc::from("23"))],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Mono,
+                            sample_rate: 44100,
+                        },
+                    )),
+                    raw_options: vec![(Arc::from("movflags"), Arc::from("faststart"))],
+                },
+            ),
+            video: Some(default_video()),
+            audio: Some(smelter_core::RegisterOutputAudioOptions {
+                initial: smelter_core::AudioMixerConfig { inputs: vec![] },
+                mixing_strategy: smelter_core::AudioMixingStrategy::SumScale,
+                channels: smelter_core::AudioChannels::Mono,
+                end_condition: smelter_core::PipelineOutputEndCondition::Never,
+            }),
+        },
+    );
+}
+
+#[test]
+fn mp4_vulkan_encoder() {
+    check_mp4(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": { "type": "vulkan_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Mp4(
+                smelter_core::protocols::Mp4OutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/output.mp4")),
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::VulkanH264(
+                        smelter_core::codecs::VulkanH264EncoderOptions {
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            preset: smelter_core::codecs::VulkanH264EncoderPreset::HighQuality,
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                    raw_options: vec![],
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn err_mp4_no_video_no_audio() {
+    check_mp4_err(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4"
+            }
+        }),
+        "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+// ── WHIP Output ──────────────────────────────────────────────────────
+
+#[test]
+fn whip_video_only() {
+    check_whip(
+        json!({
+            "output": {
+                "endpoint_url": "https://example.com/whip",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whip(
+                smelter_core::protocols::WhipOutputOptions {
+                    endpoint_url: Arc::from("https://example.com/whip"),
+                    bearer_token: None,
+                    video: Some(smelter_core::protocols::VideoWhipOptions {
+                        encoder_preferences: vec![
+                            smelter_core::protocols::WhipVideoEncoderOptions::Any(
+                                smelter_render::Resolution {
+                                    width: 1920,
+                                    height: 1080,
+                                },
+                            ),
+                        ],
+                    }),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn whip_video_with_encoder_preferences() {
+    check_whip(
+        json!({
+            "output": {
+                "endpoint_url": "https://example.com/whip",
+                "bearer_token": "token",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder_preferences": [
+                        { "type": "ffmpeg_h264", "preset": "fast" },
+                        { "type": "ffmpeg_vp8" },
+                        { "type": "any" }
+                    ],
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whip(
+                smelter_core::protocols::WhipOutputOptions {
+                    endpoint_url: Arc::from("https://example.com/whip"),
+                    bearer_token: Some(Arc::from("token")),
+                    video: Some(smelter_core::protocols::VideoWhipOptions {
+                        encoder_preferences: vec![
+                            smelter_core::protocols::WhipVideoEncoderOptions::FfmpegH264(
+                                smelter_core::codecs::FfmpegH264EncoderOptions {
+                                    preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                                    bitrate: None,
+                                    keyframe_interval: default_keyframe_interval(),
+                                    resolution: smelter_render::Resolution {
+                                        width: 1920,
+                                        height: 1080,
+                                    },
+                                    pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                                    raw_options: vec![],
+                                    bitstream_format:
+                                        smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                                },
+                            ),
+                            smelter_core::protocols::WhipVideoEncoderOptions::FfmpegVp8(
+                                smelter_core::codecs::FfmpegVp8EncoderOptions {
+                                    bitrate: None,
+                                    keyframe_interval: default_keyframe_interval(),
+                                    resolution: smelter_render::Resolution {
+                                        width: 1920,
+                                        height: 1080,
+                                    },
+                                    raw_options: vec![],
+                                },
+                            ),
+                            smelter_core::protocols::WhipVideoEncoderOptions::Any(
+                                smelter_render::Resolution {
+                                    width: 1920,
+                                    height: 1080,
+                                },
+                            ),
+                        ],
+                    }),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn whip_audio_only() {
+    check_whip(
+        json!({
+            "output": {
+                "endpoint_url": "https://example.com/whip",
+                "audio": {
+                    "encoder_preferences": [
+                        { "type": "opus", "preset": "quality" }
+                    ],
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whip(
+                smelter_core::protocols::WhipOutputOptions {
+                    endpoint_url: Arc::from("https://example.com/whip"),
+                    bearer_token: None,
+                    video: None,
+                    audio: Some(smelter_core::protocols::AudioWhipOptions {
+                        encoder_preferences: vec![
+                            smelter_core::protocols::WhipAudioEncoderOptions::Opus(
+                                smelter_core::codecs::OpusEncoderOptions {
+                                    channels: smelter_core::AudioChannels::Stereo,
+                                    preset: smelter_core::codecs::OpusEncoderPreset::Quality,
+                                    sample_rate: 48000,
+                                    forward_error_correction: true,
+                                    packet_loss: 0,
+                                },
+                            ),
+                        ],
+                    }),
+                },
+            ),
+            video: None,
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn whip_video_and_audio() {
+    check_whip(
+        json!({
+            "output": {
+                "endpoint_url": "https://example.com/whip",
+                "video": {
+                    "resolution": { "width": 1280, "height": 720 },
+                    "encoder_preferences": [
+                        { "type": "ffmpeg_vp9", "pixel_format": "yuv420p" }
+                    ],
+                    "initial": video_scene()
+                },
+                "audio": {
+                    "encoder_preferences": [{ "type": "opus" }, { "type": "any" }],
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whip(
+                smelter_core::protocols::WhipOutputOptions {
+                    endpoint_url: Arc::from("https://example.com/whip"),
+                    bearer_token: None,
+                    video: Some(smelter_core::protocols::VideoWhipOptions {
+                        encoder_preferences: vec![
+                            smelter_core::protocols::WhipVideoEncoderOptions::FfmpegVp9(
+                                smelter_core::codecs::FfmpegVp9EncoderOptions {
+                                    resolution: smelter_render::Resolution {
+                                        width: 1280,
+                                        height: 720,
+                                    },
+                                    bitrate: None,
+                                    keyframe_interval: default_keyframe_interval(),
+                                    pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                                    raw_options: vec![],
+                                },
+                            ),
+                        ],
+                    }),
+                    audio: Some(smelter_core::protocols::AudioWhipOptions {
+                        encoder_preferences: vec![
+                            smelter_core::protocols::WhipAudioEncoderOptions::Opus(
+                                smelter_core::codecs::OpusEncoderOptions {
+                                    channels: smelter_core::AudioChannels::Stereo,
+                                    preset: smelter_core::codecs::OpusEncoderPreset::Voip,
+                                    sample_rate: 48000,
+                                    forward_error_correction: true,
+                                    packet_loss: 0,
+                                },
+                            ),
+                            smelter_core::protocols::WhipAudioEncoderOptions::Any(
+                                smelter_core::AudioChannels::Stereo,
+                            ),
+                        ],
+                    }),
+                },
+            ),
+            video: Some(default_video()),
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn err_whip_no_video_no_audio() {
+    check_whip_err(
+        json!({
+            "output": {
+                "endpoint_url": "https://example.com/whip"
+            }
+        }),
+        "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+// ── WHEP Output ──────────────────────────────────────────────────────
+
+#[test]
+fn whep_video_only() {
+    check_whep(
+        json!({
+            "output": {
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whep(
+                smelter_core::protocols::WhepOutputOptions {
+                    bearer_token: None,
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn whep_audio_only() {
+    check_whep(
+        json!({
+            "output": {
+                "audio": {
+                    "encoder": {
+                        "type": "opus",
+                        "forward_error_correction": true,
+                        "expected_packet_loss": 50
+                    },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whep(
+                smelter_core::protocols::WhepOutputOptions {
+                    bearer_token: None,
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::Opus(
+                        smelter_core::codecs::OpusEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            preset: smelter_core::codecs::OpusEncoderPreset::Voip,
+                            sample_rate: 48000,
+                            forward_error_correction: true,
+                            packet_loss: 50,
+                        },
+                    )),
+                },
+            ),
+            video: None,
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn whep_video_and_audio_with_bearer_token() {
+    check_whep(
+        json!({
+            "output": {
+                "bearer_token": "secret",
+                "video": {
+                    "resolution": { "width": 1280, "height": 720 },
+                    "encoder": { "type": "ffmpeg_vp8" },
+                    "initial": video_scene()
+                },
+                "audio": {
+                    "encoder": { "type": "opus" },
+                    "channels": "stereo",
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whep(
+                smelter_core::protocols::WhepOutputOptions {
+                    bearer_token: Some(Arc::from("secret")),
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegVp8(
+                        smelter_core::codecs::FfmpegVp8EncoderOptions {
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1280,
+                                height: 720,
+                            },
+                            raw_options: vec![],
+                        },
+                    )),
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::Opus(
+                        smelter_core::codecs::OpusEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            preset: smelter_core::codecs::OpusEncoderPreset::Voip,
+                            sample_rate: 48000,
+                            forward_error_correction: true,
+                            packet_loss: 0,
+                        },
+                    )),
+                },
+            ),
+            video: Some(default_video()),
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn whep_vp9_encoder() {
+    check_whep(
+        json!({
+            "output": {
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_vp9",
+                        "pixel_format": "yuv422p",
+                        "bitrate": 5000000
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Whep(
+                smelter_core::protocols::WhepOutputOptions {
+                    bearer_token: None,
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegVp9(
+                        smelter_core::codecs::FfmpegVp9EncoderOptions {
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            bitrate: Some(smelter_core::codecs::VideoEncoderBitrate {
+                                average_bitrate: 5000000,
+                                max_bitrate: 6250000,
+                            }),
+                            keyframe_interval: default_keyframe_interval(),
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV422P,
+                            raw_options: vec![],
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn err_whep_no_video_no_audio() {
+    check_whep_err(
+        json!({
+            "output": {}
+        }),
+        "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+#[test]
+fn err_whep_opus_packet_loss_out_of_range() {
+    check_whep_err(
+        json!({
+            "output": {
+                "audio": {
+                    "encoder": {
+                        "type": "opus",
+                        "expected_packet_loss": 200
+                    },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        "Expected packet loss value must be from [0, 100] range.",
+    );
+}
+
+// ── HLS Output ───────────────────────────────────────────────────────
+
+#[test]
+fn hls_video_only() {
+    check_hls(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": {
+                        "type": "ffmpeg_h264",
+                        "preset": "veryfast"
+                    },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Hls(
+                smelter_core::protocols::HlsOutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/stream.m3u8")),
+                    max_playlist_size: None,
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Veryfast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn hls_audio_only() {
+    check_hls(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8",
+                "audio": {
+                    "encoder": { "type": "aac", "sample_rate": 48000 },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Hls(
+                smelter_core::protocols::HlsOutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/stream.m3u8")),
+                    max_playlist_size: None,
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 48000,
+                        },
+                    )),
+                },
+            ),
+            video: None,
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn hls_video_and_audio_with_playlist_size() {
+    check_hls(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8",
+                "max_playlist_size": 10,
+                "video": {
+                    "resolution": { "width": 1280, "height": 720 },
+                    "encoder": { "type": "ffmpeg_h264" },
+                    "initial": video_scene()
+                },
+                "audio": {
+                    "encoder": { "type": "aac" },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Hls(
+                smelter_core::protocols::HlsOutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/stream.m3u8")),
+                    max_playlist_size: Some(10),
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::FfmpegH264(
+                        smelter_core::codecs::FfmpegH264EncoderOptions {
+                            preset: smelter_core::codecs::FfmpegH264EncoderPreset::Fast,
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            resolution: smelter_render::Resolution {
+                                width: 1280,
+                                height: 720,
+                            },
+                            pixel_format: smelter_core::codecs::OutputPixelFormat::YUV420P,
+                            raw_options: vec![],
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 44100,
+                        },
+                    )),
+                },
+            ),
+            video: Some(default_video()),
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn hls_vulkan_encoder() {
+    check_hls(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8",
+                "video": {
+                    "resolution": { "width": 1920, "height": 1080 },
+                    "encoder": { "type": "vulkan_h264" },
+                    "initial": video_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Hls(
+                smelter_core::protocols::HlsOutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/stream.m3u8")),
+                    max_playlist_size: None,
+                    video: Some(smelter_core::codecs::VideoEncoderOptions::VulkanH264(
+                        smelter_core::codecs::VulkanH264EncoderOptions {
+                            resolution: smelter_render::Resolution {
+                                width: 1920,
+                                height: 1080,
+                            },
+                            bitrate: None,
+                            keyframe_interval: default_keyframe_interval(),
+                            preset: smelter_core::codecs::VulkanH264EncoderPreset::HighQuality,
+                            bitstream_format: smelter_core::codecs::H264BitstreamFormat::AnnexB,
+                        },
+                    )),
+                    audio: None,
+                },
+            ),
+            video: Some(default_video()),
+            audio: None,
+        },
+    );
+}
+
+#[test]
+fn err_hls_no_video_no_audio() {
+    check_hls_err(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8"
+            }
+        }),
+        "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+// ── Serde-level errors ──────────────────────────────────────────────
+
+#[test]
+fn err_serde_rtmp_missing_url() {
+    check_serde_err::<RtmpOutput>(json!({
+        "output": {
+            "video": {
+                "resolution": { "width": 1920, "height": 1080 },
+                "encoder": { "type": "ffmpeg_h264" },
+                "initial": video_scene()
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_rtp_missing_port() {
+    check_serde_err::<RtpOutput>(json!({
+        "output": {
+            "ip": "127.0.0.1",
+            "video": {
+                "resolution": { "width": 1920, "height": 1080 },
+                "encoder": { "type": "ffmpeg_h264" },
+                "initial": video_scene()
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_mp4_missing_path() {
+    check_serde_err::<Mp4Output>(json!({
+        "output": {
+            "video": {
+                "resolution": { "width": 1920, "height": 1080 },
+                "encoder": { "type": "ffmpeg_h264" },
+                "initial": video_scene()
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_rtmp_unknown_field() {
+    check_serde_err::<RtmpOutput>(json!({
+        "output": {
+            "url": "rtmp://localhost:1935/live/stream",
+            "unknown_field": true
+        }
+    }));
+}
+
+#[test]
+fn err_serde_rtp_unknown_encoder() {
+    check_serde_err::<RtpOutput>(json!({
+        "output": {
+            "port": 9002,
+            "ip": "127.0.0.1",
+            "video": {
+                "resolution": { "width": 1920, "height": 1080 },
+                "encoder": { "type": "unknown_encoder" },
+                "initial": video_scene()
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_whip_missing_endpoint() {
+    check_serde_err::<WhipOutput>(json!({
+        "output": {
+            "video": {
+                "resolution": { "width": 1920, "height": 1080 },
+                "initial": video_scene()
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_hls_missing_path() {
+    check_serde_err::<HlsOutput>(json!({
+        "output": {
+            "video": {
+                "resolution": { "width": 1920, "height": 1080 },
+                "encoder": { "type": "ffmpeg_h264" },
+                "initial": video_scene()
+            }
+        }
+    }));
+}

--- a/smelter-api/tests/resource_deserialization.rs
+++ b/smelter-api/tests/resource_deserialization.rs
@@ -1,0 +1,490 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use serde_json::json;
+use smelter_api::*;
+use smelter_render::image::{ImageSource, ImageType};
+use smelter_render::shader;
+use smelter_render::web_renderer::{WebEmbeddingMethod, WebRendererSpec as RenderWebRendererSpec};
+use smelter_render::Resolution;
+
+type RendererSpec = smelter_render::RendererSpec;
+
+#[track_caller]
+fn check_image(raw: serde_json::Value, expected: RendererSpec) {
+    let resource = raw.get("resource").unwrap().clone();
+    let api: ImageSpec = serde_json::from_value(resource).unwrap();
+    let actual = RendererSpec::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_image_err(raw: serde_json::Value, expected_msg: &str) {
+    let resource = raw.get("resource").unwrap().clone();
+    let api: ImageSpec = serde_json::from_value(resource).unwrap();
+    let err = RendererSpec::try_from(api).unwrap_err();
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_shader(raw: serde_json::Value, expected: RendererSpec) {
+    let resource = raw.get("resource").unwrap().clone();
+    let api: ShaderSpec = serde_json::from_value(resource).unwrap();
+    let actual = RendererSpec::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_web_renderer(raw: serde_json::Value, expected: RendererSpec) {
+    let resource = raw.get("resource").unwrap().clone();
+    let api: WebRendererSpec = serde_json::from_value(resource).unwrap();
+    let actual = RendererSpec::try_from(api).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_serde_err<T: serde::de::DeserializeOwned>(raw: serde_json::Value) {
+    let resource = raw.get("resource").unwrap().clone();
+    assert!(serde_json::from_value::<T>(resource).is_err());
+}
+
+fn image_url(url: &str, image_type: ImageType) -> RendererSpec {
+    RendererSpec::Image(smelter_render::image::ImageSpec {
+        src: ImageSource::Url {
+            url: Arc::from(url),
+        },
+        image_type,
+    })
+}
+
+fn image_path(path: &str, image_type: ImageType) -> RendererSpec {
+    RendererSpec::Image(smelter_render::image::ImageSpec {
+        src: ImageSource::LocalPath {
+            path: Arc::from(Path::new(path)),
+        },
+        image_type,
+    })
+}
+
+// ── Image: PNG ───────────────────────────────────────────────────────
+
+#[test]
+fn image_png_with_url() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "png",
+                "url": "https://example.com/image.png"
+            }
+        }),
+        image_url("https://example.com/image.png", ImageType::Png),
+    );
+}
+
+#[test]
+fn image_png_with_path() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "png",
+                "path": "/tmp/image.png"
+            }
+        }),
+        image_path("/tmp/image.png", ImageType::Png),
+    );
+}
+
+// ── Image: JPEG ──────────────────────────────────────────────────────
+
+#[test]
+fn image_jpeg_with_url() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "jpeg",
+                "url": "https://example.com/photo.jpg"
+            }
+        }),
+        image_url("https://example.com/photo.jpg", ImageType::Jpeg),
+    );
+}
+
+#[test]
+fn image_jpeg_with_path() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "jpeg",
+                "path": "/tmp/photo.jpg"
+            }
+        }),
+        image_path("/tmp/photo.jpg", ImageType::Jpeg),
+    );
+}
+
+// ── Image: SVG ───────────────────────────────────────────────────────
+
+#[test]
+fn image_svg_with_url() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "svg",
+                "url": "https://example.com/icon.svg"
+            }
+        }),
+        image_url("https://example.com/icon.svg", ImageType::Svg),
+    );
+}
+
+#[test]
+fn image_svg_with_path_and_resolution() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "svg",
+                "path": "/tmp/icon.svg",
+                "resolution": { "width": 200, "height": 200 }
+            }
+        }),
+        image_path("/tmp/icon.svg", ImageType::Svg),
+    );
+}
+
+// ── Image: GIF ───────────────────────────────────────────────────────
+
+#[test]
+fn image_gif_with_url() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "gif",
+                "url": "https://example.com/anim.gif"
+            }
+        }),
+        image_url("https://example.com/anim.gif", ImageType::Gif),
+    );
+}
+
+#[test]
+fn image_gif_with_path() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "gif",
+                "path": "/tmp/anim.gif"
+            }
+        }),
+        image_path("/tmp/anim.gif", ImageType::Gif),
+    );
+}
+
+// ── Image: Auto ──────────────────────────────────────────────────────
+
+#[test]
+fn image_auto_with_url() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "auto",
+                "url": "https://example.com/image"
+            }
+        }),
+        image_url("https://example.com/image", ImageType::Auto),
+    );
+}
+
+#[test]
+fn image_auto_with_path() {
+    check_image(
+        json!({
+            "resource": {
+                "asset_type": "auto",
+                "path": "/tmp/image"
+            }
+        }),
+        image_path("/tmp/image", ImageType::Auto),
+    );
+}
+
+// ── Image errors ─────────────────────────────────────────────────────
+
+#[test]
+fn err_image_neither_url_nor_path() {
+    check_image_err(
+        json!({
+            "resource": {
+                "asset_type": "png"
+            }
+        }),
+        "\"url\" or \"path\" field is required when registering an image.",
+    );
+}
+
+#[test]
+fn err_image_both_url_and_path() {
+    check_image_err(
+        json!({
+            "resource": {
+                "asset_type": "png",
+                "url": "https://example.com/image.png",
+                "path": "/tmp/image.png"
+            }
+        }),
+        "\"url\" and \"path\" fields are mutually exclusive when registering an image.",
+    );
+}
+
+#[test]
+fn err_image_jpeg_neither_url_nor_path() {
+    check_image_err(
+        json!({
+            "resource": {
+                "asset_type": "jpeg"
+            }
+        }),
+        "\"url\" or \"path\" field is required when registering an image.",
+    );
+}
+
+#[test]
+fn err_image_svg_both_url_and_path() {
+    check_image_err(
+        json!({
+            "resource": {
+                "asset_type": "svg",
+                "url": "https://example.com/icon.svg",
+                "path": "/tmp/icon.svg"
+            }
+        }),
+        "\"url\" and \"path\" fields are mutually exclusive when registering an image.",
+    );
+}
+
+#[test]
+fn err_image_gif_neither_url_nor_path() {
+    check_image_err(
+        json!({
+            "resource": {
+                "asset_type": "gif"
+            }
+        }),
+        "\"url\" or \"path\" field is required when registering an image.",
+    );
+}
+
+#[test]
+fn err_image_auto_neither_url_nor_path() {
+    check_image_err(
+        json!({
+            "resource": {
+                "asset_type": "auto"
+            }
+        }),
+        "\"url\" or \"path\" field is required when registering an image.",
+    );
+}
+
+#[test]
+fn err_serde_image_unknown_asset_type() {
+    check_serde_err::<ImageSpec>(json!({
+        "resource": {
+            "asset_type": "bmp",
+            "url": "https://example.com/image.bmp"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_image_missing_asset_type() {
+    check_serde_err::<ImageSpec>(json!({
+        "resource": {
+            "url": "https://example.com/image.png"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_image_unknown_field() {
+    check_serde_err::<ImageSpec>(json!({
+        "resource": {
+            "asset_type": "png",
+            "url": "https://example.com/image.png",
+            "unknown": true
+        }
+    }));
+}
+
+// ── Shader ───────────────────────────────────────────────────────────
+
+#[test]
+fn shader_basic() {
+    check_shader(
+        json!({
+            "resource": {
+                "source": "@vertex fn vs_main() -> @builtin(position) vec4<f32> { return vec4<f32>(0.0); }"
+            }
+        }),
+        RendererSpec::Shader(shader::ShaderSpec {
+            source: Arc::from(
+                "@vertex fn vs_main() -> @builtin(position) vec4<f32> { return vec4<f32>(0.0); }",
+            ),
+        }),
+    );
+}
+
+#[test]
+fn shader_empty_source() {
+    check_shader(
+        json!({
+            "resource": {
+                "source": ""
+            }
+        }),
+        RendererSpec::Shader(shader::ShaderSpec {
+            source: Arc::from(""),
+        }),
+    );
+}
+
+#[test]
+fn err_serde_shader_missing_source() {
+    check_serde_err::<ShaderSpec>(json!({
+        "resource": {}
+    }));
+}
+
+#[test]
+fn err_serde_shader_unknown_field() {
+    check_serde_err::<ShaderSpec>(json!({
+        "resource": {
+            "source": "code",
+            "extra": true
+        }
+    }));
+}
+
+// ── WebRenderer ──────────────────────────────────────────────────────
+
+#[test]
+fn web_renderer_minimal() {
+    check_web_renderer(
+        json!({
+            "resource": {
+                "url": "https://example.com",
+                "resolution": { "width": 1920, "height": 1080 }
+            }
+        }),
+        RendererSpec::WebRenderer(RenderWebRendererSpec {
+            url: Arc::from("https://example.com"),
+            resolution: Resolution {
+                width: 1920,
+                height: 1080,
+            },
+            embedding_method: WebEmbeddingMethod::NativeEmbeddingOverContent,
+        }),
+    );
+}
+
+#[test]
+fn web_renderer_chromium_embedding() {
+    check_web_renderer(
+        json!({
+            "resource": {
+                "url": "https://example.com",
+                "resolution": { "width": 1920, "height": 1080 },
+                "embedding_method": "chromium_embedding"
+            }
+        }),
+        RendererSpec::WebRenderer(RenderWebRendererSpec {
+            url: Arc::from("https://example.com"),
+            resolution: Resolution {
+                width: 1920,
+                height: 1080,
+            },
+            embedding_method: WebEmbeddingMethod::ChromiumEmbedding,
+        }),
+    );
+}
+
+#[test]
+fn web_renderer_native_over_content() {
+    check_web_renderer(
+        json!({
+            "resource": {
+                "url": "https://example.com",
+                "resolution": { "width": 1280, "height": 720 },
+                "embedding_method": "native_embedding_over_content"
+            }
+        }),
+        RendererSpec::WebRenderer(RenderWebRendererSpec {
+            url: Arc::from("https://example.com"),
+            resolution: Resolution {
+                width: 1280,
+                height: 720,
+            },
+            embedding_method: WebEmbeddingMethod::NativeEmbeddingOverContent,
+        }),
+    );
+}
+
+#[test]
+fn web_renderer_native_under_content() {
+    check_web_renderer(
+        json!({
+            "resource": {
+                "url": "https://example.com",
+                "resolution": { "width": 1280, "height": 720 },
+                "embedding_method": "native_embedding_under_content"
+            }
+        }),
+        RendererSpec::WebRenderer(RenderWebRendererSpec {
+            url: Arc::from("https://example.com"),
+            resolution: Resolution {
+                width: 1280,
+                height: 720,
+            },
+            embedding_method: WebEmbeddingMethod::NativeEmbeddingUnderContent,
+        }),
+    );
+}
+
+#[test]
+fn err_serde_web_renderer_missing_url() {
+    check_serde_err::<WebRendererSpec>(json!({
+        "resource": {
+            "resolution": { "width": 1920, "height": 1080 }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_web_renderer_missing_resolution() {
+    check_serde_err::<WebRendererSpec>(json!({
+        "resource": {
+            "url": "https://example.com"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_web_renderer_unknown_embedding_method() {
+    check_serde_err::<WebRendererSpec>(json!({
+        "resource": {
+            "url": "https://example.com",
+            "resolution": { "width": 1920, "height": 1080 },
+            "embedding_method": "unknown_method"
+        }
+    }));
+}
+
+#[test]
+fn err_serde_web_renderer_unknown_field() {
+    check_serde_err::<WebRendererSpec>(json!({
+        "resource": {
+            "url": "https://example.com",
+            "resolution": { "width": 1920, "height": 1080 },
+            "unknown": true
+        }
+    }));
+}

--- a/smelter-api/tests/resource_deserialization.rs
+++ b/smelter-api/tests/resource_deserialization.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use serde_json::json;
 use smelter_api::*;
+use smelter_render::Resolution;
 use smelter_render::image::{ImageSource, ImageType};
 use smelter_render::shader;
 use smelter_render::web_renderer::{WebEmbeddingMethod, WebRendererSpec as RenderWebRendererSpec};
-use smelter_render::Resolution;
 
 type RendererSpec = smelter_render::RendererSpec;
 

--- a/smelter-api/tests/scene_deserialization.rs
+++ b/smelter-api/tests/scene_deserialization.rs
@@ -9,6 +9,10 @@ fn component_id(id: &str) -> scene::ComponentId {
     scene::ComponentId(id.into())
 }
 
+fn renderer_id(id: &str) -> smelter_render::RendererId {
+    smelter_render::RendererId(id.into())
+}
+
 fn input_stream(id: Option<&str>, input_id: &str) -> scene::Component {
     scene::Component::InputStream(scene::InputStreamComponent {
         id: id.map(component_id),
@@ -57,6 +61,21 @@ fn check(raw: serde_json::Value, expected: scene::Component) {
     let api_scene: VideoScene = serde_json::from_value(video).unwrap();
     let actual: scene::Component = api_scene.try_into().unwrap();
     assert_eq!(actual, expected);
+}
+
+#[track_caller]
+fn check_err(raw: serde_json::Value, expected_msg: &str) {
+    let video = raw.get("video").unwrap().clone();
+    let api_scene: VideoScene = serde_json::from_value(video).unwrap();
+    let result: Result<scene::Component, _> = api_scene.try_into();
+    let err = result.expect_err("expected conversion to fail");
+    assert_eq!(err.to_string(), expected_msg);
+}
+
+#[track_caller]
+fn check_serde_err(raw: serde_json::Value) {
+    let video = raw.get("video").unwrap().clone();
+    assert!(serde_json::from_value::<VideoScene>(video).is_err());
 }
 
 #[test]
@@ -945,4 +964,667 @@ fn shader_param_full_enum_coverage() {
             children: vec![],
         }),
     );
+}
+
+// ── WebView ──────────────────────────────────────────────────────────
+
+#[test]
+fn web_view_empty() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "web_view",
+                    "instance_id": "browser_1"
+                }
+            }
+        }),
+        scene::Component::WebView(scene::WebViewComponent {
+            id: None,
+            children: vec![],
+            instance_id: renderer_id("browser_1"),
+        }),
+    );
+}
+
+#[test]
+fn web_view_with_children() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "web_view",
+                    "id": "web",
+                    "instance_id": "browser_1",
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1" }
+                    ]
+                }
+            }
+        }),
+        scene::Component::WebView(scene::WebViewComponent {
+            id: Some(component_id("web")),
+            children: vec![input_stream(None, "input_1")],
+            instance_id: renderer_id("browser_1"),
+        }),
+    );
+}
+
+// ── Text dimension variants ──────────────────────────────────────────
+
+#[test]
+fn text_fitted_column() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "Column text",
+                    "font_size": 40,
+                    "width": 600
+                }
+            }
+        }),
+        scene::Component::Text(scene::TextComponent {
+            dimensions: scene::TextDimensions::FittedColumn {
+                width: 600.0,
+                max_height: smelter_render::MAX_NODE_RESOLUTION.height as f32,
+            },
+            ..text_default("Column text", 40.0)
+        }),
+    );
+}
+
+#[test]
+fn text_fitted_column_with_max_height() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "Column text",
+                    "font_size": 40,
+                    "width": 600,
+                    "max_height": 300
+                }
+            }
+        }),
+        scene::Component::Text(scene::TextComponent {
+            dimensions: scene::TextDimensions::FittedColumn {
+                width: 600.0,
+                max_height: 300.0,
+            },
+            ..text_default("Column text", 40.0)
+        }),
+    );
+}
+
+// ── View position: bottom/right offsets ──────────────────────────────
+
+#[test]
+fn view_bottom_left_absolute() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "children": [
+                        {
+                            "type": "view",
+                            "bottom": 10,
+                            "left": 20,
+                            "width": 100,
+                            "height": 100
+                        }
+                    ]
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            children: vec![scene::Component::View(scene::ViewComponent {
+                position: scene::Position::Absolute(scene::AbsolutePosition {
+                    width: Some(100.0),
+                    height: Some(100.0),
+                    position_horizontal: scene::HorizontalPosition::LeftOffset(20.0),
+                    position_vertical: scene::VerticalPosition::BottomOffset(10.0),
+                    rotation_degrees: 0.0,
+                }),
+                ..view_default()
+            })],
+            ..view_default()
+        }),
+    );
+}
+
+// ── View rotation triggers absolute position ─────────────────────────
+
+#[test]
+fn view_rotation_absolute() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "top": 0,
+                    "left": 0,
+                    "width": 200,
+                    "height": 200,
+                    "rotation": 45
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(200.0),
+                height: Some(200.0),
+                position_horizontal: scene::HorizontalPosition::LeftOffset(0.0),
+                position_vertical: scene::VerticalPosition::TopOffset(0.0),
+                rotation_degrees: 45.0,
+            }),
+            ..view_default()
+        }),
+    );
+}
+
+// ── Error: View positioning ──────────────────────────────────────────
+
+#[test]
+fn err_view_top_and_bottom() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "top": 10,
+                    "bottom": 10,
+                    "left": 0
+                }
+            }
+        }),
+        "Fields \"top\" and \"bottom\" are mutually exclusive, you can only specify one on a \"View\" component.",
+    );
+}
+
+#[test]
+fn err_view_left_and_right() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "top": 10,
+                    "left": 10,
+                    "right": 10
+                }
+            }
+        }),
+        "Fields \"left\" and \"right\" are mutually exclusive, you can only specify one on a \"View\" component.",
+    );
+}
+
+#[test]
+fn err_view_rotation_missing_vertical() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "rotation": 45,
+                    "left": 0
+                }
+            }
+        }),
+        "\"View\" component with absolute positioning requires either \"top\" or \"bottom\" coordinate.",
+    );
+}
+
+#[test]
+fn err_view_rotation_missing_horizontal() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "rotation": 45,
+                    "top": 0
+                }
+            }
+        }),
+        "Non-static \"View\" component requires either \"left\" or \"right\" coordinate.",
+    );
+}
+
+// ── Error: Rescaler positioning ──────────────────────────────────────
+
+#[test]
+fn err_rescaler_top_and_bottom() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "top": 10,
+                    "bottom": 10,
+                    "left": 0,
+                    "child": { "type": "view" }
+                }
+            }
+        }),
+        "Fields \"top\" and \"bottom\" are mutually exclusive, you can only specify one on a \"Rescaler\" component.",
+    );
+}
+
+#[test]
+fn err_rescaler_left_and_right() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "top": 10,
+                    "left": 10,
+                    "right": 10,
+                    "child": { "type": "view" }
+                }
+            }
+        }),
+        "Fields \"left\" and \"right\" are mutually exclusive, you can only specify one on a \"Rescaler\" component.",
+    );
+}
+
+#[test]
+fn err_rescaler_rotation_missing_vertical() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "rotation": 45,
+                    "left": 0,
+                    "child": { "type": "view" }
+                }
+            }
+        }),
+        "\"Rescaler\" component with absolute positioning requires either \"top\" or \"bottom\" coordinate.",
+    );
+}
+
+#[test]
+fn err_rescaler_rotation_missing_horizontal() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "rotation": 45,
+                    "top": 0,
+                    "child": { "type": "view" }
+                }
+            }
+        }),
+        "Non-static \"Rescaler\" component requires either \"left\" or \"right\" coordinate.",
+    );
+}
+
+// ── Error: View negative padding ─────────────────────────────────────
+
+#[test]
+fn err_view_negative_padding() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "padding": -5
+                }
+            }
+        }),
+        "Padding values cannot be negative.",
+    );
+}
+
+#[test]
+fn err_view_negative_padding_top() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "padding_top": -1
+                }
+            }
+        }),
+        "Padding values cannot be negative.",
+    );
+}
+
+// ── Error: Text validation ───────────────────────────────────────────
+
+#[test]
+fn err_text_height_without_width() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "hello",
+                    "font_size": 20,
+                    "height": 100
+                }
+            }
+        }),
+        "\"height\" property on a Text component can only be provided if \"width\" is also defined.",
+    );
+}
+
+#[test]
+fn err_text_font_size_zero() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "hello",
+                    "font_size": 0
+                }
+            }
+        }),
+        "\"font_size\" property has to be larger than 0",
+    );
+}
+
+#[test]
+fn err_text_font_size_negative() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "hello",
+                    "font_size": -10
+                }
+            }
+        }),
+        "\"font_size\" property has to be larger than 0",
+    );
+}
+
+#[test]
+fn err_text_line_height_zero() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "hello",
+                    "font_size": 20,
+                    "line_height": 0
+                }
+            }
+        }),
+        "\"line_height\" property has to be larger than 0",
+    );
+}
+
+// ── Error: Color parsing ─────────────────────────────────────────────
+
+#[test]
+fn err_color_invalid_hex_length() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "#FFF"
+                }
+            }
+        }),
+        "Invalid format. Color has to be in #RRGGBB or #RRGGBBAA format.",
+    );
+}
+
+#[test]
+fn err_color_invalid_hex_digit() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "#ZZZZZZ"
+                }
+            }
+        }),
+        "Invalid format. Color representation is not a valid number.",
+    );
+}
+
+#[test]
+fn err_color_unsupported_format() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "not_a_color_name"
+                }
+            }
+        }),
+        "Unsupported color format.",
+    );
+}
+
+#[test]
+fn err_color_rgba_alpha_out_of_range() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "rgba(255,0,0,1.5)"
+                }
+            }
+        }),
+        "Alpha value out of range. It must be between 0.0 and 1.0",
+    );
+}
+
+#[test]
+fn err_color_rgb_wrong_components() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "rgb(255, 0)"
+                }
+            }
+        }),
+        "Invalid RGB format.",
+    );
+}
+
+#[test]
+fn err_color_rgba_wrong_components() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "rgba(255, 0, 0)"
+                }
+            }
+        }),
+        "Expected three color components and alpha channel.",
+    );
+}
+
+// ── Error: Aspect ratio ──────────────────────────────────────────────
+
+#[test]
+fn err_tiles_invalid_aspect_ratio_no_colon() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "tiles",
+                    "tile_aspect_ratio": "16x9"
+                }
+            }
+        }),
+        "Aspect ratio needs to be a string in the \"W:H\" format, where W and H are both unsigned integers.",
+    );
+}
+
+#[test]
+fn err_tiles_invalid_aspect_ratio_non_integer() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "tiles",
+                    "tile_aspect_ratio": "16:abc"
+                }
+            }
+        }),
+        "Aspect ratio needs to be a string in the \"W:H\" format, where W and H are both unsigned integers.",
+    );
+}
+
+// ── Error: Transition cubic bezier control points ────────────────────
+
+#[test]
+fn err_transition_cubic_bezier_x1_out_of_range() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "top": 0,
+                    "left": 0,
+                    "transition": {
+                        "duration_ms": 1000,
+                        "easing_function": {
+                            "function_name": "cubic_bezier",
+                            "points": [1.5, 0, 0.5, 1]
+                        }
+                    }
+                }
+            }
+        }),
+        "Control point x1 has to be in the range [0, 1].",
+    );
+}
+
+#[test]
+fn err_transition_cubic_bezier_x2_out_of_range() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "top": 0,
+                    "left": 0,
+                    "transition": {
+                        "duration_ms": 1000,
+                        "easing_function": {
+                            "function_name": "cubic_bezier",
+                            "points": [0.5, 0, -0.1, 1]
+                        }
+                    }
+                }
+            }
+        }),
+        "Control point x2 has to be in the range [0, 1].",
+    );
+}
+
+#[test]
+fn err_transition_negative_duration() {
+    check_err(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "top": 0,
+                    "left": 0,
+                    "transition": {
+                        "duration_ms": -1000
+                    }
+                }
+            }
+        }),
+        "Invalid duration. cannot convert float seconds to Duration: value is negative",
+    );
+}
+
+// ── Serde-level errors (malformed JSON for the schema) ───────────────
+
+#[test]
+fn err_serde_unknown_component_type() {
+    check_serde_err(json!({
+        "video": {
+            "root": {
+                "type": "unknown_component"
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_unknown_field_on_view() {
+    check_serde_err(json!({
+        "video": {
+            "root": {
+                "type": "view",
+                "nonexistent_field": true
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_rescaler_missing_child() {
+    check_serde_err(json!({
+        "video": {
+            "root": {
+                "type": "rescaler"
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_shader_missing_resolution() {
+    check_serde_err(json!({
+        "video": {
+            "root": {
+                "type": "shader",
+                "shader_id": "s1"
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_text_missing_text_field() {
+    check_serde_err(json!({
+        "video": {
+            "root": {
+                "type": "text",
+                "font_size": 20
+            }
+        }
+    }));
+}
+
+#[test]
+fn err_serde_text_missing_font_size() {
+    check_serde_err(json!({
+        "video": {
+            "root": {
+                "type": "text",
+                "text": "hello"
+            }
+        }
+    }));
 }

--- a/smelter-api/tests/scene_deserialization.rs
+++ b/smelter-api/tests/scene_deserialization.rs
@@ -1,0 +1,948 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use smelter_api::*;
+use smelter_render::scene;
+
+fn component_id(id: &str) -> scene::ComponentId {
+    scene::ComponentId(id.into())
+}
+
+fn input_stream(id: Option<&str>, input_id: &str) -> scene::Component {
+    scene::Component::InputStream(scene::InputStreamComponent {
+        id: id.map(component_id),
+        input_id: smelter_render::InputId(input_id.into()),
+    })
+}
+
+fn view_default() -> scene::ViewComponent {
+    scene::ViewComponent::default()
+}
+
+fn rescaler_default(child: scene::Component) -> scene::RescalerComponent {
+    scene::RescalerComponent {
+        child: Box::new(child),
+        ..scene::RescalerComponent::default()
+    }
+}
+
+fn tiles_default() -> scene::TilesComponent {
+    scene::TilesComponent::default()
+}
+
+fn text_default(text: &str, font_size: f32) -> scene::TextComponent {
+    scene::TextComponent {
+        id: None,
+        text: text.into(),
+        font_size,
+        line_height: font_size,
+        color: scene::RGBAColor(255, 255, 255, 255),
+        font_family: Arc::from("Verdana"),
+        style: scene::TextStyle::Normal,
+        align: scene::HorizontalAlign::Left,
+        weight: scene::TextWeight::Normal,
+        wrap: scene::TextWrap::None,
+        background_color: scene::RGBAColor(0, 0, 0, 0),
+        dimensions: scene::TextDimensions::Fitted {
+            max_width: smelter_render::MAX_NODE_RESOLUTION.width as f32,
+            max_height: smelter_render::MAX_NODE_RESOLUTION.height as f32,
+        },
+    }
+}
+
+#[track_caller]
+fn check(raw: serde_json::Value, expected: scene::Component) {
+    let video = raw.get("video").unwrap().clone();
+    let api_scene: VideoScene = serde_json::from_value(video).unwrap();
+    let actual: scene::Component = api_scene.try_into().unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn view_empty() {
+    check(
+        json!({ "video": { "root": { "type": "view" } } }),
+        scene::Component::View(view_default()),
+    );
+}
+
+#[test]
+fn view_with_background_color() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "#FF0000FF",
+                    "children": [
+                        {
+                            "type": "view",
+                            "top": 50,
+                            "right": 50,
+                            "width": 400,
+                            "height": 200,
+                            "background_color": "#00FF00FF"
+                        }
+                    ]
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            background_color: scene::RGBAColor(255, 0, 0, 255),
+            children: vec![scene::Component::View(scene::ViewComponent {
+                position: scene::Position::Absolute(scene::AbsolutePosition {
+                    width: Some(400.0),
+                    height: Some(200.0),
+                    position_horizontal: scene::HorizontalPosition::RightOffset(50.0),
+                    position_vertical: scene::VerticalPosition::TopOffset(50.0),
+                    rotation_degrees: 0.0,
+                }),
+                background_color: scene::RGBAColor(0, 255, 0, 255),
+                ..view_default()
+            })],
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn view_border_radius_border_box_shadow() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "#FFFF00FF",
+                    "children": [
+                        {
+                            "type": "view",
+                            "background_color": "#FF0000FF",
+                            "top": 50,
+                            "left": 50,
+                            "width": 400,
+                            "height": 200,
+                            "border_radius": 50,
+                            "border_width": 20,
+                            "border_color": "#FFFFFFFF",
+                            "box_shadow": [
+                                {
+                                    "offset_x": 60,
+                                    "offset_y": 30,
+                                    "blur_radius": 30,
+                                    "color": "#00FF00FF"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            background_color: scene::RGBAColor(255, 255, 0, 255),
+            children: vec![scene::Component::View(scene::ViewComponent {
+                background_color: scene::RGBAColor(255, 0, 0, 255),
+                position: scene::Position::Absolute(scene::AbsolutePosition {
+                    width: Some(400.0),
+                    height: Some(200.0),
+                    position_horizontal: scene::HorizontalPosition::LeftOffset(50.0),
+                    position_vertical: scene::VerticalPosition::TopOffset(50.0),
+                    rotation_degrees: 0.0,
+                }),
+                border_radius: scene::BorderRadius::new_with_radius(50.0),
+                border_width: 20.0,
+                border_color: scene::RGBAColor(255, 255, 255, 255),
+                box_shadow: vec![scene::BoxShadow {
+                    offset_x: 60.0,
+                    offset_y: 30.0,
+                    blur_radius: 30.0,
+                    color: scene::RGBAColor(0, 255, 0, 255),
+                }],
+                ..view_default()
+            })],
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn view_overflow_fit() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "overflow": "fit",
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1" }
+                    ]
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            overflow: scene::Overflow::Fit,
+            children: vec![input_stream(None, "input_1")],
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn view_overflow_hidden_and_visible() {
+    check(
+        json!({ "video": { "root": { "type": "view", "overflow": "hidden" } } }),
+        scene::Component::View(scene::ViewComponent {
+            overflow: scene::Overflow::Hidden,
+            ..view_default()
+        }),
+    );
+    check(
+        json!({ "video": { "root": { "type": "view", "overflow": "visible" } } }),
+        scene::Component::View(scene::ViewComponent {
+            overflow: scene::Overflow::Visible,
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn view_direction_row_and_column() {
+    check(
+        json!({ "video": { "root": { "type": "view", "direction": "row" } } }),
+        scene::Component::View(scene::ViewComponent {
+            direction: scene::ViewChildrenDirection::Row,
+            ..view_default()
+        }),
+    );
+    check(
+        json!({ "video": { "root": { "type": "view", "direction": "column" } } }),
+        scene::Component::View(scene::ViewComponent {
+            direction: scene::ViewChildrenDirection::Column,
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn view_nested_padding_static_children() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "background_color": "red",
+                    "direction": "row",
+                    "children": [
+                        {
+                            "type": "view",
+                            "border_width": 10,
+                            "border_color": "blue",
+                            "children": []
+                        },
+                        {
+                            "type": "view",
+                            "padding_top": 20,
+                            "padding_left": 20,
+                            "border_width": 10,
+                            "border_color": "blue",
+                            "children": [
+                                {
+                                    "type": "view",
+                                    "padding_vertical": 20,
+                                    "padding_left": 20,
+                                    "padding_right": 40,
+                                    "border_width": 10,
+                                    "border_color": "green",
+                                    "background_color": "blue",
+                                    "children": [
+                                        {
+                                            "type": "view",
+                                            "width": 150,
+                                            "height": 150,
+                                            "padding_left": 80,
+                                            "border_width": 10,
+                                            "border_color": "magenta",
+                                            "background_color": "yellow",
+                                            "children": []
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            background_color: scene::RGBAColor(255, 0, 0, 255),
+            direction: scene::ViewChildrenDirection::Row,
+            children: vec![
+                scene::Component::View(scene::ViewComponent {
+                    border_width: 10.0,
+                    border_color: scene::RGBAColor(0, 0, 255, 255),
+                    ..view_default()
+                }),
+                scene::Component::View(scene::ViewComponent {
+                    padding: scene::Padding {
+                        top: 20.0,
+                        right: 0.0,
+                        bottom: 0.0,
+                        left: 20.0,
+                    },
+                    border_width: 10.0,
+                    border_color: scene::RGBAColor(0, 0, 255, 255),
+                    children: vec![scene::Component::View(scene::ViewComponent {
+                        padding: scene::Padding {
+                            top: 20.0,
+                            right: 40.0,
+                            bottom: 20.0,
+                            left: 20.0,
+                        },
+                        border_width: 10.0,
+                        border_color: scene::RGBAColor(0, 128, 0, 255),
+                        background_color: scene::RGBAColor(0, 0, 255, 255),
+                        children: vec![scene::Component::View(scene::ViewComponent {
+                            position: scene::Position::Static {
+                                width: Some(150.0),
+                                height: Some(150.0),
+                            },
+                            padding: scene::Padding {
+                                top: 0.0,
+                                right: 0.0,
+                                bottom: 0.0,
+                                left: 80.0,
+                            },
+                            border_width: 10.0,
+                            border_color: scene::RGBAColor(255, 0, 255, 255),
+                            background_color: scene::RGBAColor(255, 255, 0, 255),
+                            ..view_default()
+                        })],
+                        ..view_default()
+                    })],
+                    ..view_default()
+                }),
+            ],
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn rescaler_fit_input_stream() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "mode": "fit",
+                    "top": 90,
+                    "left": 160,
+                    "width": 320,
+                    "height": 180,
+                    "child": { "type": "input_stream", "input_id": "input_1" }
+                }
+            }
+        }),
+        scene::Component::Rescaler(scene::RescalerComponent {
+            mode: scene::RescaleMode::Fit,
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(320.0),
+                height: Some(180.0),
+                position_horizontal: scene::HorizontalPosition::LeftOffset(160.0),
+                position_vertical: scene::VerticalPosition::TopOffset(90.0),
+                rotation_degrees: 0.0,
+            }),
+            ..rescaler_default(input_stream(None, "input_1"))
+        }),
+    );
+}
+
+#[test]
+fn rescaler_fill_input_stream_align_top_left() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "mode": "fill",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "top": 90,
+                    "left": 160,
+                    "width": 320,
+                    "height": 180,
+                    "child": { "type": "input_stream", "input_id": "input_1" }
+                }
+            }
+        }),
+        scene::Component::Rescaler(scene::RescalerComponent {
+            mode: scene::RescaleMode::Fill,
+            horizontal_align: scene::HorizontalAlign::Left,
+            vertical_align: scene::VerticalAlign::Top,
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(320.0),
+                height: Some(180.0),
+                position_horizontal: scene::HorizontalPosition::LeftOffset(160.0),
+                position_vertical: scene::VerticalPosition::TopOffset(90.0),
+                rotation_degrees: 0.0,
+            }),
+            ..rescaler_default(input_stream(None, "input_1"))
+        }),
+    );
+}
+
+#[test]
+fn rescaler_border_radius_box_shadow() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "top": 50,
+                    "left": 50,
+                    "width": 400,
+                    "height": 200,
+                    "border_radius": 50,
+                    "box_shadow": [
+                        {
+                            "offset_x": 60,
+                            "offset_y": 30,
+                            "blur_radius": 30,
+                            "color": "#00FF00FF"
+                        }
+                    ],
+                    "child": { "type": "view", "background_color": "#FF0000FF" }
+                }
+            }
+        }),
+        scene::Component::Rescaler(scene::RescalerComponent {
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(400.0),
+                height: Some(200.0),
+                position_horizontal: scene::HorizontalPosition::LeftOffset(50.0),
+                position_vertical: scene::VerticalPosition::TopOffset(50.0),
+                rotation_degrees: 0.0,
+            }),
+            border_radius: scene::BorderRadius::new_with_radius(50.0),
+            box_shadow: vec![scene::BoxShadow {
+                offset_x: 60.0,
+                offset_y: 30.0,
+                blur_radius: 30.0,
+                color: scene::RGBAColor(0, 255, 0, 255),
+            }],
+            ..rescaler_default(scene::Component::View(scene::ViewComponent {
+                background_color: scene::RGBAColor(255, 0, 0, 255),
+                ..view_default()
+            }))
+        }),
+    );
+}
+
+#[test]
+fn transition_view_cubic_bezier() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "children": [
+                        {
+                            "id": "resize_1",
+                            "type": "view",
+                            "width": 200,
+                            "height": 200,
+                            "top": 0,
+                            "right": 440,
+                            "transition": {
+                                "duration_ms": 5000,
+                                "easing_function": {
+                                    "function_name": "cubic_bezier",
+                                    "points": [0.83, 0.4, 0.17, 1]
+                                }
+                            },
+                            "background_color": "#00FF00FF"
+                        }
+                    ]
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            children: vec![scene::Component::View(scene::ViewComponent {
+                id: Some(component_id("resize_1")),
+                position: scene::Position::Absolute(scene::AbsolutePosition {
+                    width: Some(200.0),
+                    height: Some(200.0),
+                    position_horizontal: scene::HorizontalPosition::RightOffset(440.0),
+                    position_vertical: scene::VerticalPosition::TopOffset(0.0),
+                    rotation_degrees: 0.0,
+                }),
+                transition: Some(scene::Transition {
+                    duration: Duration::from_millis(5000),
+                    interpolation_kind: scene::InterpolationKind::CubicBezier {
+                        x1: 0.83,
+                        y1: 0.4,
+                        x2: 0.17,
+                        y2: 1.0,
+                    },
+                    should_interrupt: false,
+                }),
+                background_color: scene::RGBAColor(0, 255, 0, 255),
+                ..view_default()
+            })],
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn transition_default_easing() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "rescaler",
+                    "id": "r",
+                    "width": 640,
+                    "height": 360,
+                    "top": 0,
+                    "right": 0,
+                    "transition": { "duration_ms": 10000 },
+                    "child": { "type": "view", "background_color": "#00FF00FF" }
+                }
+            }
+        }),
+        scene::Component::Rescaler(scene::RescalerComponent {
+            id: Some(component_id("r")),
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(640.0),
+                height: Some(360.0),
+                position_horizontal: scene::HorizontalPosition::RightOffset(0.0),
+                position_vertical: scene::VerticalPosition::TopOffset(0.0),
+                rotation_degrees: 0.0,
+            }),
+            transition: Some(scene::Transition {
+                duration: Duration::from_millis(10000),
+                interpolation_kind: scene::InterpolationKind::Linear,
+                should_interrupt: false,
+            }),
+            ..rescaler_default(scene::Component::View(scene::ViewComponent {
+                background_color: scene::RGBAColor(0, 255, 0, 255),
+                ..view_default()
+            }))
+        }),
+    );
+}
+
+#[test]
+fn transition_linear_with_should_interrupt() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "id": "v",
+                    "width": 200,
+                    "height": 200,
+                    "top": 0,
+                    "left": 0,
+                    "transition": {
+                        "duration_ms": 1000,
+                        "easing_function": { "function_name": "linear" },
+                        "should_interrupt": true
+                    },
+                    "background_color": "#00FF00FF"
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            id: Some(component_id("v")),
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(200.0),
+                height: Some(200.0),
+                position_horizontal: scene::HorizontalPosition::LeftOffset(0.0),
+                position_vertical: scene::VerticalPosition::TopOffset(0.0),
+                rotation_degrees: 0.0,
+            }),
+            transition: Some(scene::Transition {
+                duration: Duration::from_millis(1000),
+                interpolation_kind: scene::InterpolationKind::Linear,
+                should_interrupt: true,
+            }),
+            background_color: scene::RGBAColor(0, 255, 0, 255),
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn transition_bounce() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "view",
+                    "id": "v",
+                    "width": 200,
+                    "height": 200,
+                    "top": 0,
+                    "left": 0,
+                    "transition": {
+                        "duration_ms": 500,
+                        "easing_function": { "function_name": "bounce" }
+                    }
+                }
+            }
+        }),
+        scene::Component::View(scene::ViewComponent {
+            id: Some(component_id("v")),
+            position: scene::Position::Absolute(scene::AbsolutePosition {
+                width: Some(200.0),
+                height: Some(200.0),
+                position_horizontal: scene::HorizontalPosition::LeftOffset(0.0),
+                position_vertical: scene::VerticalPosition::TopOffset(0.0),
+                rotation_degrees: 0.0,
+            }),
+            transition: Some(scene::Transition {
+                duration: Duration::from_millis(500),
+                interpolation_kind: scene::InterpolationKind::Bounce,
+                should_interrupt: false,
+            }),
+            ..view_default()
+        }),
+    );
+}
+
+#[test]
+fn tiles_three_inputs() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "tiles",
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1" },
+                        { "type": "input_stream", "input_id": "input_2" },
+                        { "type": "input_stream", "input_id": "input_3" }
+                    ],
+                    "background_color": "#333333FF"
+                }
+            }
+        }),
+        scene::Component::Tiles(scene::TilesComponent {
+            children: vec![
+                input_stream(None, "input_1"),
+                input_stream(None, "input_2"),
+                input_stream(None, "input_3"),
+            ],
+            background_color: scene::RGBAColor(0x33, 0x33, 0x33, 255),
+            ..tiles_default()
+        }),
+    );
+}
+
+#[test]
+fn tiles_aspect_ratio_portrait() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "tiles",
+                    "tile_aspect_ratio": "1:2",
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1" }
+                    ],
+                    "background_color": "#333333FF"
+                }
+            }
+        }),
+        scene::Component::Tiles(scene::TilesComponent {
+            tile_aspect_ratio: (1, 2),
+            children: vec![input_stream(None, "input_1")],
+            background_color: scene::RGBAColor(0x33, 0x33, 0x33, 255),
+            ..tiles_default()
+        }),
+    );
+}
+
+#[test]
+fn tiles_align_top_left() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "tiles",
+                    "vertical_align": "top",
+                    "horizontal_align": "left",
+                    "margin": 10,
+                    "padding": 4,
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1" }
+                    ]
+                }
+            }
+        }),
+        scene::Component::Tiles(scene::TilesComponent {
+            vertical_align: scene::VerticalAlign::Top,
+            horizontal_align: scene::HorizontalAlign::Left,
+            margin: 10.0,
+            padding: 4.0,
+            children: vec![input_stream(None, "input_1")],
+            ..tiles_default()
+        }),
+    );
+}
+
+#[test]
+fn tiles_with_transition_nested_inputs() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "tiles",
+                    "id": "tiles",
+                    "transition": { "duration_ms": 500 },
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1", "id": "input_1" },
+                        { "type": "input_stream", "input_id": "input_2", "id": "input_2" }
+                    ]
+                }
+            }
+        }),
+        scene::Component::Tiles(scene::TilesComponent {
+            id: Some(component_id("tiles")),
+            transition: Some(scene::Transition {
+                duration: Duration::from_millis(500),
+                interpolation_kind: scene::InterpolationKind::Linear,
+                should_interrupt: false,
+            }),
+            children: vec![
+                input_stream(Some("input_1"), "input_1"),
+                input_stream(Some("input_2"), "input_2"),
+            ],
+            ..tiles_default()
+        }),
+    );
+}
+
+#[test]
+fn text_align_center() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "Example text",
+                    "font_size": 100,
+                    "font_family": "Inter",
+                    "align": "center",
+                    "width": 1000,
+                    "height": 200
+                }
+            }
+        }),
+        scene::Component::Text(scene::TextComponent {
+            font_family: Arc::from("Inter"),
+            align: scene::HorizontalAlign::Center,
+            dimensions: scene::TextDimensions::Fixed {
+                width: 1000.0,
+                height: 200.0,
+            },
+            ..text_default("Example text", 100.0)
+        }),
+    );
+}
+
+#[test]
+fn text_bold_right_aligned() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "Example text",
+                    "font_size": 100,
+                    "font_family": "Inter",
+                    "align": "right",
+                    "weight": "bold",
+                    "width": 1000,
+                    "height": 200
+                }
+            }
+        }),
+        scene::Component::Text(scene::TextComponent {
+            font_family: Arc::from("Inter"),
+            align: scene::HorizontalAlign::Right,
+            weight: scene::TextWeight::Bold,
+            dimensions: scene::TextDimensions::Fixed {
+                width: 1000.0,
+                height: 200.0,
+            },
+            ..text_default("Example text", 100.0)
+        }),
+    );
+}
+
+#[test]
+fn text_wrap_word_with_style_and_line_height() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "text",
+                    "text": "Lorem ipsum",
+                    "font_size": 50,
+                    "line_height": 60,
+                    "style": "italic",
+                    "wrap": "word",
+                    "max_width": 800,
+                    "max_height": 400,
+                    "color": "#FFFFFFFF",
+                    "background_color": "#000000FF"
+                }
+            }
+        }),
+        scene::Component::Text(scene::TextComponent {
+            line_height: 60.0,
+            style: scene::TextStyle::Italic,
+            wrap: scene::TextWrap::Word,
+            dimensions: scene::TextDimensions::Fitted {
+                max_width: 800.0,
+                max_height: 400.0,
+            },
+            color: scene::RGBAColor(255, 255, 255, 255),
+            background_color: scene::RGBAColor(0, 0, 0, 255),
+            ..text_default("Lorem ipsum", 50.0)
+        }),
+    );
+}
+
+#[test]
+fn image_jpeg_as_root() {
+    check(
+        json!({
+            "video": { "root": { "type": "image", "image_id": "image_jpeg" } }
+        }),
+        scene::Component::Image(scene::ImageComponent {
+            id: None,
+            image_id: smelter_render::RendererId("image_jpeg".into()),
+            width: None,
+            height: None,
+        }),
+    );
+}
+
+#[test]
+fn image_with_id_and_dimensions() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "image",
+                    "id": "gif",
+                    "image_id": "image_gif1",
+                    "width": 320,
+                    "height": 240
+                }
+            }
+        }),
+        scene::Component::Image(scene::ImageComponent {
+            id: Some(component_id("gif")),
+            image_id: smelter_render::RendererId("image_gif1".into()),
+            width: Some(320.0),
+            height: Some(240.0),
+        }),
+    );
+}
+
+#[test]
+fn shader_with_inputs_no_params() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "shader",
+                    "shader_id": "base_params_plane_id",
+                    "resolution": { "width": 640, "height": 360 },
+                    "children": [
+                        { "type": "input_stream", "input_id": "input_1" },
+                        { "type": "input_stream", "input_id": "input_2" }
+                    ]
+                }
+            }
+        }),
+        scene::Component::Shader(scene::ShaderComponent {
+            id: None,
+            shader_id: smelter_render::RendererId("base_params_plane_id".into()),
+            shader_param: None,
+            size: scene::Size {
+                width: 640.0,
+                height: 360.0,
+            },
+            children: vec![input_stream(None, "input_1"), input_stream(None, "input_2")],
+        }),
+    );
+}
+
+#[test]
+fn shader_param_full_enum_coverage() {
+    check(
+        json!({
+            "video": {
+                "root": {
+                    "type": "shader",
+                    "shader_id": "custom",
+                    "resolution": { "width": 640, "height": 360 },
+                    "shader_param": {
+                        "type": "struct",
+                        "value": [
+                            { "field_name": "intensity", "type": "f32", "value": 0.5 },
+                            { "field_name": "count", "type": "u32", "value": 7 },
+                            { "field_name": "offset", "type": "i32", "value": -3 },
+                            {
+                                "field_name": "weights",
+                                "type": "list",
+                                "value": [
+                                    { "type": "f32", "value": 0.25 },
+                                    { "type": "f32", "value": 0.5 },
+                                    { "type": "f32", "value": 0.125 }
+                                ]
+                            }
+                        ]
+                    },
+                    "children": []
+                }
+            }
+        }),
+        scene::Component::Shader(scene::ShaderComponent {
+            id: None,
+            shader_id: smelter_render::RendererId("custom".into()),
+            shader_param: Some(scene::ShaderParam::Struct(vec![
+                scene::ShaderParamStructField {
+                    field_name: "intensity".into(),
+                    value: scene::ShaderParam::F32(0.5),
+                },
+                scene::ShaderParamStructField {
+                    field_name: "count".into(),
+                    value: scene::ShaderParam::U32(7),
+                },
+                scene::ShaderParamStructField {
+                    field_name: "offset".into(),
+                    value: scene::ShaderParam::I32(-3),
+                },
+                scene::ShaderParamStructField {
+                    field_name: "weights".into(),
+                    value: scene::ShaderParam::List(vec![
+                        scene::ShaderParam::F32(0.25),
+                        scene::ShaderParam::F32(0.5),
+                        scene::ShaderParam::F32(0.125),
+                    ]),
+                },
+            ])),
+            size: scene::Size {
+                width: 640.0,
+                height: 360.0,
+            },
+            children: vec![],
+        }),
+    );
+}

--- a/smelter-core/src/input.rs
+++ b/smelter-core/src/input.rs
@@ -2,7 +2,7 @@ use std::{fmt, sync::Arc, time::Duration};
 
 use crate::prelude::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RegisterInputOptions {
     Rtp(RtpInputOptions),
     RtmpServer(RtmpServerInputOptions),

--- a/smelter-core/src/output.rs
+++ b/smelter-core/src/output.rs
@@ -4,7 +4,7 @@ use smelter_render::scene::Component;
 
 use crate::prelude::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RegisterOutputOptions {
     pub output_options: ProtocolOutputOptions,
     pub video: Option<RegisterOutputVideoOptions>,
@@ -25,7 +25,7 @@ pub struct RegisterRawDataOutputOptions {
     pub audio: Option<RegisterOutputAudioOptions>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ProtocolOutputOptions {
     Rtp(RtpOutputOptions),
     Rtmp(RtmpOutputOptions),
@@ -35,13 +35,13 @@ pub enum ProtocolOutputOptions {
     Whep(WhepOutputOptions),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RegisterOutputVideoOptions {
     pub initial: Component,
     pub end_condition: PipelineOutputEndCondition,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RegisterOutputAudioOptions {
     pub initial: AudioMixerConfig,
     pub mixing_strategy: AudioMixingStrategy,
@@ -49,25 +49,25 @@ pub struct RegisterOutputAudioOptions {
     pub end_condition: PipelineOutputEndCondition,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AudioMixerConfig {
     pub inputs: Vec<AudioMixerInputConfig>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AudioMixerInputConfig {
     pub input_id: InputId,
     // [0, 2] range of input volume
     pub volume: f32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AudioMixingStrategy {
     SumClip,
     SumScale,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PipelineOutputEndCondition {
     AnyOf(Vec<InputId>),
     AllOf(Vec<InputId>),

--- a/smelter-core/src/protocols/decklink.rs
+++ b/smelter-core/src/protocols/decklink.rs
@@ -2,7 +2,7 @@ pub use decklink::PixelFormat as DeckLinkPixelFormat;
 
 use crate::queue::QueueInputOptions;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeckLinkInputOptions {
     pub subdevice_index: Option<u32>,
     pub display_name: Option<String>,

--- a/smelter-core/src/protocols/hls.rs
+++ b/smelter-core/src/protocols/hls.rs
@@ -3,7 +3,7 @@ use std::{path::Path, sync::Arc, time::Duration};
 use crate::codecs::{AudioEncoderOptions, VideoDecoderOptions, VideoEncoderOptions};
 use crate::queue::QueueInputOptions;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HlsInputOptions {
     pub url: Arc<str>,
     pub video_decoders: HlsInputVideoDecoders,
@@ -11,7 +11,7 @@ pub struct HlsInputOptions {
     pub offset: Option<Duration>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HlsOutputOptions {
     pub output_path: Arc<Path>,
     pub max_playlist_size: Option<usize>,
@@ -19,7 +19,7 @@ pub struct HlsOutputOptions {
     pub audio: Option<AudioEncoderOptions>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HlsInputVideoDecoders {
     pub h264: Option<VideoDecoderOptions>,
 }

--- a/smelter-core/src/protocols/mp4.rs
+++ b/smelter-core/src/protocols/mp4.rs
@@ -3,7 +3,7 @@ use std::{path::Path, sync::Arc, time::Duration};
 use crate::codecs::{AudioEncoderOptions, VideoDecoderOptions, VideoEncoderOptions};
 use crate::queue::QueueInputOptions;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Mp4InputOptions {
     pub source: Mp4InputSource,
     pub should_loop: bool,
@@ -13,7 +13,7 @@ pub struct Mp4InputOptions {
     pub queue_options: QueueInputOptions,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Mp4OutputOptions {
     pub output_path: Arc<Path>,
     pub video: Option<VideoEncoderOptions>,
@@ -21,13 +21,13 @@ pub struct Mp4OutputOptions {
     pub raw_options: Vec<(Arc<str>, Arc<str>)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Mp4InputSource {
     Url(Arc<str>),
     File(Arc<Path>),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Mp4InputVideoDecoders {
     pub h264: Option<VideoDecoderOptions>,
 }

--- a/smelter-core/src/protocols/rtmp.rs
+++ b/smelter-core/src/protocols/rtmp.rs
@@ -6,14 +6,14 @@ use url::Url;
 use crate::codecs::{AudioEncoderOptions, VideoDecoderOptions, VideoEncoderOptions};
 use crate::queue::QueueInputOptions;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RtmpOutputOptions {
     pub connection: RtmpConnectionOptions,
     pub video: Option<VideoEncoderOptions>,
     pub audio: Option<AudioEncoderOptions>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RtmpConnectionOptions {
     pub host: String,
     pub port: u16,
@@ -59,7 +59,7 @@ impl RtmpConnectionOptions {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RtmpServerInputOptions {
     pub app: Arc<str>,
     pub stream_key: Arc<str>,
@@ -67,7 +67,7 @@ pub struct RtmpServerInputOptions {
     pub queue_options: QueueInputOptions,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RtmpServerInputDecoders {
     pub h264: Option<VideoDecoderOptions>,
 }

--- a/smelter-core/src/protocols/rtp.rs
+++ b/smelter-core/src/protocols/rtp.rs
@@ -12,7 +12,7 @@ use crate::{
     queue::QueueInputOptions,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RtpInputOptions {
     pub port: PortOrRange,
     pub transport_protocol: RtpInputTransportProtocol,
@@ -39,7 +39,7 @@ pub enum RtpInputTransportProtocol {
     TcpServer,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RtpOutputOptions {
     pub connection_options: RtpOutputConnectionOptions,
     pub video: Option<VideoEncoderOptions>,

--- a/smelter-core/src/protocols/v4l2.rs
+++ b/smelter-core/src/protocols/v4l2.rs
@@ -4,7 +4,7 @@ use smelter_render::{Framerate, Resolution};
 
 use crate::queue::QueueInputOptions;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct V4l2InputOptions {
     pub path: Arc<std::path::Path>,
     pub resolution: Option<Resolution>,

--- a/smelter-core/src/protocols/webrtc.rs
+++ b/smelter-core/src/protocols/webrtc.rs
@@ -13,7 +13,7 @@ use crate::{
     queue::QueueInputOptions,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhipInputOptions {
     pub video_preferences: Vec<WebrtcVideoDecoderOptions>,
     pub bearer_token: Option<Arc<str>>,
@@ -25,7 +25,7 @@ pub struct WhipInputOptions {
     pub queue_options: QueueInputOptions,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhepInputOptions {
     pub video_preferences: Vec<WebrtcVideoDecoderOptions>,
     pub bearer_token: Option<Arc<str>>,
@@ -46,7 +46,7 @@ pub enum WebrtcVideoDecoderOptions {
     Any,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhipOutputOptions {
     pub endpoint_url: Arc<str>,
     pub bearer_token: Option<Arc<str>>,
@@ -54,14 +54,14 @@ pub struct WhipOutputOptions {
     pub audio: Option<AudioWhipOptions>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhepOutputOptions {
     pub bearer_token: Option<Arc<str>>,
     pub video: Option<VideoEncoderOptions>,
     pub audio: Option<AudioEncoderOptions>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct VideoWhipOptions {
     pub encoder_preferences: Vec<WhipVideoEncoderOptions>,
 }
@@ -75,7 +75,7 @@ pub enum WhipVideoEncoderOptions {
     Any(Resolution),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AudioWhipOptions {
     pub encoder_preferences: Vec<WhipAudioEncoderOptions>,
 }

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -220,7 +220,7 @@ impl std::fmt::Debug for WeakQueueInput {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct QueueInputOptions {
     pub required: bool,
     pub audio_side_channel: bool,

--- a/smelter-render/src/scene.rs
+++ b/smelter-render/src/scene.rs
@@ -46,7 +46,7 @@ pub struct OutputScene {
     pub resolution: Resolution,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Component {
     InputStream(InputStreamComponent),
     Shader(ShaderComponent),

--- a/smelter-render/src/scene/components.rs
+++ b/smelter-render/src/scene/components.rs
@@ -19,13 +19,13 @@ impl Display for ComponentId {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputStreamComponent {
     pub id: Option<ComponentId>,
     pub input_id: InputId,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ShaderComponent {
     pub id: Option<ComponentId>,
     pub children: Vec<Component>,
@@ -36,7 +36,7 @@ pub struct ShaderComponent {
     pub size: Size,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ShaderParam {
     F32(f32),
     U32(u32),
@@ -45,13 +45,13 @@ pub enum ShaderParam {
     Struct(Vec<ShaderParamStructField>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ShaderParamStructField {
     pub field_name: String,
     pub value: ShaderParam,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WebViewComponent {
     pub id: Option<ComponentId>,
     pub children: Vec<Component>,
@@ -67,7 +67,7 @@ pub struct ImageComponent {
     pub height: Option<f32>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TextComponent {
     pub id: Option<ComponentId>,
     pub text: Arc<str>,
@@ -87,21 +87,21 @@ pub struct TextComponent {
     pub dimensions: TextDimensions,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TextStyle {
     Normal,
     Italic,
     Oblique,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TextWrap {
     None,
     Glyph,
     Word,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TextWeight {
     Thin,
     ExtraLight,
@@ -114,7 +114,7 @@ pub enum TextWeight {
     Black,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TextDimensions {
     /// Renders text and "trims" texture to smallest possible size
     Fitted {
@@ -133,7 +133,7 @@ pub enum TextDimensions {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ViewComponent {
     pub id: Option<ComponentId>,
     pub children: Vec<Component>,
@@ -161,7 +161,7 @@ pub enum Overflow {
     Fit,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Transition {
     pub duration: Duration,
     pub interpolation_kind: InterpolationKind,
@@ -208,7 +208,7 @@ impl Padding {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RescalerComponent {
     pub id: Option<ComponentId>,
     pub child: Box<Component>,
@@ -240,7 +240,7 @@ pub enum ImageScalingFilter {
     Lanczos3,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TilesComponent {
     pub id: Option<ComponentId>,
     pub children: Vec<Component>,

--- a/smelter-render/src/state.rs
+++ b/smelter-render/src/state.rs
@@ -84,7 +84,7 @@ pub(crate) struct RegisterCtx {
 /// RendererSpec provides configuration necessary to construct Renderer. Renderers
 /// are entities like shader, image or chromium_instance and can be used by nodes
 /// to transform or generate frames.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum RendererSpec {
     Shader(shader::ShaderSpec),
     WebRenderer(web_renderer::WebRendererSpec),

--- a/smelter-render/src/transformations/image.rs
+++ b/smelter-render/src/transformations/image.rs
@@ -21,20 +21,20 @@ mod animated_image;
 mod bitmap_image;
 mod svg_image;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ImageSpec {
     pub src: ImageSource,
     pub image_type: ImageType,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ImageSource {
     Url { url: Arc<str> },
     LocalPath { path: Arc<Path> },
     Bytes { bytes: Bytes },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ImageType {
     Png,
     Jpeg,

--- a/smelter-render/src/transformations/shader.rs
+++ b/smelter-render/src/transformations/shader.rs
@@ -20,7 +20,7 @@ pub struct Shader {
     clear_color: Option<wgpu::Color>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ShaderSpec {
     pub source: Arc<str>,
 }

--- a/smelter-render/src/transformations/web_renderer.rs
+++ b/smelter-render/src/transformations/web_renderer.rs
@@ -32,7 +32,7 @@ pub(crate) use node::WebRendererNode;
 
 pub use chromium_context::{ChromiumContext, ChromiumContextInitError};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WebRendererSpec {
     pub url: Arc<str>,
     pub resolution: Resolution,

--- a/smelter-render/src/transformations/web_renderer_fallback.rs
+++ b/smelter-render/src/transformations/web_renderer_fallback.rs
@@ -6,7 +6,7 @@ use crate::{
     state::{RegisterCtx, RenderCtx, node_texture::NodeTexture},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WebRendererSpec {
     pub url: Arc<str>,
     pub resolution: Resolution,

--- a/smelter-render/src/types.rs
+++ b/smelter-render/src/types.rs
@@ -92,7 +92,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Framerate {
     pub num: u32,
     pub den: u32,


### PR DESCRIPTION
In the past it was not worth it to maintain seprate test suite for parsing and serializing, and e2e tests handled testing parsing. Now it is a lot easier to maintain those tests, so I plan to remove using json values directlly from most places and use Rust types