### PR TITLE
Configure side channel delay per input

### DIFF
--- a/integration-tests/src/bin/benchmark/utils.rs
+++ b/integration-tests/src/bin/benchmark/utils.rs
@@ -44,7 +44,6 @@ pub fn benchmark_pipeline_options(
         webrtc_nat_1to1_ips: Arc::new(vec![]),
         rtmp_server: PipelineRtmpServerOptions::Disable,
         wgpu_options: PipelineWgpuOptions::Context(graphics_context),
-        side_channel_delay: Duration::ZERO,
         side_channel_socket_dir: None,
     }
 }

--- a/smelter-api/src/input/decklink_into.rs
+++ b/smelter-api/src/input/decklink_into.rs
@@ -28,10 +28,12 @@ impl TryFrom<DeckLink> for core::RegisterInputOptions {
                 pixel_format: Some(core::DeckLinkPixelFormat::Format8BitYUV),
                 queue_options: {
                     let side_channel = value.side_channel.unwrap_or_default();
+                    let side_channel_delay = side_channel.delay()?;
                     core::QueueInputOptions {
                         required: value.required.unwrap_or(false),
                         video_side_channel: side_channel.video.unwrap_or(false),
                         audio_side_channel: side_channel.audio.unwrap_or(false),
+                        side_channel_delay,
                     }
                 },
             },

--- a/smelter-api/src/input/hls_into.rs
+++ b/smelter-api/src/input/hls_into.rs
@@ -17,6 +17,7 @@ impl TryFrom<HlsInput> for core::RegisterInputOptions {
 
         let (required, offset) = new_queue_options(required, offset_ms)?;
         let side_channel = side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
 
         let h264 = decoder_map
             .as_ref()
@@ -36,6 +37,7 @@ impl TryFrom<HlsInput> for core::RegisterInputOptions {
                 required,
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
             offset,
         };

--- a/smelter-api/src/input/mp4_into.rs
+++ b/smelter-api/src/input/mp4_into.rs
@@ -24,6 +24,7 @@ impl TryFrom<Mp4Input> for core::RegisterInputOptions {
 
         let (required, offset) = new_queue_options(required, offset_ms)?;
         let side_channel = side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
 
         let source = match (url, path) {
             (Some(_), Some(_)) | (None, None) => {
@@ -59,6 +60,7 @@ impl TryFrom<Mp4Input> for core::RegisterInputOptions {
                 required,
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
         }))
     }

--- a/smelter-api/src/input/rtmp_into.rs
+++ b/smelter-api/src/input/rtmp_into.rs
@@ -14,6 +14,7 @@ impl TryFrom<RtmpInput> for core::RegisterInputOptions {
         } = value;
 
         let side_channel = side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
 
         let h264 = decoder_map
             .as_ref()
@@ -32,6 +33,7 @@ impl TryFrom<RtmpInput> for core::RegisterInputOptions {
                 required: required.unwrap_or(false),
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
         };
 

--- a/smelter-api/src/input/rtp_into.rs
+++ b/smelter-api/src/input/rtp_into.rs
@@ -26,6 +26,7 @@ impl TryFrom<RtpInput> for core::RegisterInputOptions {
 
         let (required, offset) = new_queue_options(required, offset_ms)?;
         let side_channel = side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
 
         let transport_protocol = transport_protocol.unwrap_or(TransportProtocol::Udp).into();
 
@@ -62,6 +63,7 @@ impl TryFrom<RtpInput> for core::RegisterInputOptions {
                 required,
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
             offset,
         }))

--- a/smelter-api/src/input/side_channel.rs
+++ b/smelter-api/src/input/side_channel.rs
@@ -1,6 +1,10 @@
+use std::time::Duration;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+
+use crate::TypeError;
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema, ToSchema)]
 #[serde(deny_unknown_fields)]
@@ -9,4 +13,18 @@ pub struct SideChannel {
     pub video: Option<bool>,
     /// Enable side channel for audio track.
     pub audio: Option<bool>,
+    /// Side channel delay in milliseconds. Frames are buffered for this duration ahead of
+    /// when the queue consumes them, so the side-channel subscriber receives them early
+    /// and has roughly this much time to process before the frame is due.
+    pub delay_ms: Option<f64>,
+}
+
+impl SideChannel {
+    pub(super) fn delay(&self) -> Result<Duration, TypeError> {
+        let Some(delay_ms) = self.delay_ms else {
+            return Ok(Duration::ZERO);
+        };
+        Duration::try_from_secs_f64(delay_ms / 1000.0)
+            .map_err(|err| TypeError::new(format!("Invalid side channel delay. {err}")))
+    }
 }

--- a/smelter-api/src/input/v4l2_into.rs
+++ b/smelter-api/src/input/v4l2_into.rs
@@ -7,6 +7,7 @@ impl TryFrom<V4l2Input> for core::RegisterInputOptions {
     #[cfg(target_os = "linux")]
     fn try_from(value: V4l2Input) -> Result<Self, Self::Error> {
         let side_channel = value.side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
         Ok(core::RegisterInputOptions::V4l2(core::V4l2InputOptions {
             path: value.path,
             format: value.format.into(),
@@ -19,6 +20,7 @@ impl TryFrom<V4l2Input> for core::RegisterInputOptions {
                 required: value.required.unwrap_or(false),
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
         }))
     }

--- a/smelter-api/src/input/whep_into.rs
+++ b/smelter-api/src/input/whep_into.rs
@@ -17,6 +17,7 @@ impl TryFrom<WhepInput> for core::RegisterInputOptions {
         } = value;
 
         let side_channel = side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
 
         let video_preferences = match video {
             Some(options) => match options.decoder_preferences.as_deref() {
@@ -40,6 +41,7 @@ impl TryFrom<WhepInput> for core::RegisterInputOptions {
                 required: required.unwrap_or(false),
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
         };
 

--- a/smelter-api/src/input/whip_into.rs
+++ b/smelter-api/src/input/whip_into.rs
@@ -17,6 +17,7 @@ impl TryFrom<WhipInput> for core::RegisterInputOptions {
         } = value;
 
         let side_channel = side_channel.unwrap_or_default();
+        let side_channel_delay = side_channel.delay()?;
 
         let video_preferences = match video {
             Some(options) => match options.decoder_preferences.as_deref() {
@@ -40,6 +41,7 @@ impl TryFrom<WhipInput> for core::RegisterInputOptions {
                 required: required.unwrap_or(false),
                 video_side_channel: side_channel.video.unwrap_or(false),
                 audio_side_channel: side_channel.audio.unwrap_or(false),
+                side_channel_delay,
             },
         };
 

--- a/smelter-api/tests/input_deserialization.rs
+++ b/smelter-api/tests/input_deserialization.rs
@@ -22,6 +22,7 @@ fn default_queue() -> QueueInputOptions {
         required: false,
         video_side_channel: false,
         audio_side_channel: false,
+        side_channel_delay: Duration::ZERO,
     }
 }
 
@@ -181,6 +182,7 @@ fn rtmp_with_all_options() {
                 required: true,
                 video_side_channel: true,
                 audio_side_channel: false,
+                side_channel_delay: Duration::ZERO,
             },
         }),
     );
@@ -345,6 +347,7 @@ fn rtp_video_and_audio() {
                 required: true,
                 video_side_channel: true,
                 audio_side_channel: false,
+                side_channel_delay: Duration::ZERO,
             },
             offset: Some(Duration::from_millis(500)),
             buffer_duration: Some(Duration::from_millis(200)),
@@ -587,6 +590,7 @@ fn mp4_with_all_options() {
                 required: true,
                 video_side_channel: false,
                 audio_side_channel: true,
+                side_channel_delay: Duration::ZERO,
             },
         }),
     );
@@ -696,6 +700,7 @@ fn whip_with_all_options() {
                 required: true,
                 video_side_channel: true,
                 audio_side_channel: true,
+                side_channel_delay: Duration::ZERO,
             },
         }),
     );
@@ -801,6 +806,7 @@ fn whep_with_all_options() {
                 required: true,
                 video_side_channel: true,
                 audio_side_channel: false,
+                side_channel_delay: Duration::ZERO,
             },
         }),
     );
@@ -868,6 +874,7 @@ fn hls_with_all_options() {
                 required: true,
                 video_side_channel: true,
                 audio_side_channel: true,
+                side_channel_delay: Duration::ZERO,
             },
             offset: Some(Duration::from_millis(500)),
         }),
@@ -951,6 +958,7 @@ fn v4l2_with_all_options() {
                 required: true,
                 video_side_channel: true,
                 audio_side_channel: false,
+                side_channel_delay: Duration::ZERO,
             },
         }),
     );

--- a/smelter-core/src/pipeline.rs
+++ b/smelter-core/src/pipeline.rs
@@ -57,7 +57,6 @@ pub struct PipelineOptions {
     pub run_late_scheduled_events: bool,
     pub never_drop_output_frames: bool,
     pub ahead_of_time_processing: bool,
-    pub side_channel_delay: Duration,
     pub side_channel_socket_dir: Option<Arc<Path>>,
 
     pub output_framerate: Framerate,

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -44,7 +44,6 @@ pub struct QueueOptions {
     pub ahead_of_time_processing: bool,
     pub run_late_scheduled_events: bool,
     pub never_drop_output_frames: bool,
-    pub side_channel_delay: Duration,
     pub side_channel_socket_dir: Option<Arc<Path>>,
 }
 
@@ -56,7 +55,6 @@ impl From<&PipelineOptions> for QueueOptions {
             ahead_of_time_processing: opt.ahead_of_time_processing,
             run_late_scheduled_events: opt.run_late_scheduled_events,
             never_drop_output_frames: opt.never_drop_output_frames,
-            side_channel_delay: opt.side_channel_delay,
             side_channel_socket_dir: opt.side_channel_socket_dir.clone(),
         }
     }
@@ -87,13 +85,13 @@ impl From<&PipelineOptions> for QueueOptions {
 ///     `sync_point.elapsed()` at that moment (via `drop_old_frames_before_start`), after
 ///     queue start to the current queue PTS at which the packet is observed.
 ///
-/// - Side channel (`side_channel_delay`):
-///   - Every input receiver (both with and without a side channel) shifts incoming PTS
-///     by `side_channel_delay`, so the whole pipeline runs that far behind the inputs.
-///   - Inputs with a side channel additionally allow their receiver buffer to grow up to
-///     `side_channel_delay` worth of data, so the side-channel subscriber receives frames
-///     ahead of when the queue consumes them — leaving the subscriber roughly
-///     `side_channel_delay` time to process before the frame is due.
+/// - Side channel (`QueueInputOptions::side_channel_delay`):
+///   - For inputs with a side channel, the receiver shifts incoming PTS by
+///     `side_channel_delay`, so that input runs that far behind real time.
+///   - The receiver buffer is allowed to grow up to `side_channel_delay` worth of data,
+///     so the side-channel subscriber receives frames ahead of when the queue consumes
+///     them — leaving the subscriber roughly `side_channel_delay` time to process
+///     before the frame is due.
 ///
 /// - Example usage scenarios:
 ///   - MP4 input:
@@ -142,7 +140,6 @@ pub struct QueueContext {
     /// the queue start
     start_pts: SharedPts,
     last_pts: SharedPts,
-    side_channel_delay: Duration,
     pub(crate) side_channel_socket_dir: Option<Arc<Path>>,
 }
 
@@ -224,7 +221,6 @@ impl Queue {
             sync_point: Instant::now(),
             start_pts: Default::default(),
             last_pts: Default::default(),
-            side_channel_delay: opts.side_channel_delay,
             side_channel_socket_dir: opts.side_channel_socket_dir,
         };
         let (queue_start_sender, queue_start_receiver) = bounded(0);

--- a/smelter-core/src/queue/audio_input.rs
+++ b/smelter-core/src/queue/audio_input.rs
@@ -53,9 +53,9 @@ impl AudioQueueInput {
         offset: Option<Duration>,
         track_offset: TrackOffset,
         side_channel: Option<AudioSideChannel>,
+        side_channel_delay: Duration,
     ) -> (Self, Sender<InputAudioSamples>) {
-        let (receiver, sender) =
-            AudioInputReceiver::new(ctx.queue_ctx.side_channel_delay, side_channel);
+        let (receiver, sender) = AudioInputReceiver::new(side_channel_delay, side_channel);
         let input = Self {
             queue_ctx: ctx.queue_ctx.clone(),
             required,

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -60,6 +60,7 @@ pub(super) struct InnerQueueInput {
     required: bool,
     video_side_channel: Option<VideoSideChannel>,
     audio_side_channel: Option<AudioSideChannel>,
+    side_channel_delay: Duration,
 }
 
 impl InnerQueueInput {
@@ -130,6 +131,7 @@ impl InnerQueueInput {
                 offset_from_start,
                 track_offset.clone(),
                 side_channel,
+                self.side_channel_delay,
             );
             (Some(video_input), Some(QueueSender::new(video_sender)))
         } else {
@@ -147,6 +149,7 @@ impl InnerQueueInput {
                 offset_from_start,
                 track_offset.clone(),
                 side_channel,
+                self.side_channel_delay,
             );
             (Some(audio_input), Some(QueueSender::new(audio_sender)))
         } else {
@@ -225,6 +228,7 @@ pub struct QueueInputOptions {
     pub required: bool,
     pub audio_side_channel: bool,
     pub video_side_channel: bool,
+    pub side_channel_delay: Duration,
 }
 
 impl QueueInput {
@@ -252,6 +256,7 @@ impl QueueInput {
             pause_state: PauseState::new(),
             video_side_channel,
             audio_side_channel,
+            side_channel_delay: opts.side_channel_delay,
         })))
     }
 

--- a/smelter-core/src/queue/video_input.rs
+++ b/smelter-core/src/queue/video_input.rs
@@ -51,9 +51,9 @@ impl VideoQueueInput {
         offset_from_start: Option<Duration>,
         track_offset: TrackOffset,
         side_channel: Option<VideoSideChannel>,
+        side_channel_delay: Duration,
     ) -> (Self, Sender<Frame>) {
-        let (receiver, sender) =
-            VideoInputReceiver::new(ctx.queue_ctx.side_channel_delay, side_channel);
+        let (receiver, sender) = VideoInputReceiver::new(side_channel_delay, side_channel);
         let input = Self {
             queue_ctx: ctx.queue_ctx.clone(),
             required,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,6 @@ pub struct Config {
     pub download_root: Arc<Path>,
     pub stream_fallback_timeout: Duration,
     pub default_buffer_duration: Duration,
-    pub side_channel_delay: Duration,
     pub side_channel_socket_dir: Option<Arc<Path>>,
 
     pub ahead_of_time_processing: bool,
@@ -243,20 +242,6 @@ fn try_read_config() -> Result<Config, String> {
         Err(_) => DEFAULT_BUFFER_DURATION,
     };
 
-    const DEFAULT_SIDE_CHANNEL_DELAY: Duration = Duration::ZERO;
-    let side_channel_delay = match env::var("SMELTER_SIDE_CHANNEL_DELAY_MS") {
-        Ok(duration) => match duration.parse::<f64>() {
-            Ok(duration) => Duration::from_secs_f64(duration / 1000.0),
-            Err(_) => {
-                println!(
-                    "CONFIG ERROR: Invalid value provided for \"SMELTER_SIDE_CHANNEL_DELAY_MS\". Falling back to default value {DEFAULT_SIDE_CHANNEL_DELAY:?}."
-                );
-                DEFAULT_SIDE_CHANNEL_DELAY
-            }
-        },
-        Err(_) => DEFAULT_SIDE_CHANNEL_DELAY,
-    };
-
     let side_channel_socket_dir = Some(read_side_channel_socket_dir());
 
     let load_system_fonts = match env::var("SMELTER_LOAD_SYSTEM_FONTS") {
@@ -381,7 +366,6 @@ fn try_read_config() -> Result<Config, String> {
             log_file,
         },
         default_buffer_duration,
-        side_channel_delay,
         side_channel_socket_dir,
         ahead_of_time_processing,
         output_framerate,

--- a/src/state.rs
+++ b/src/state.rs
@@ -110,7 +110,6 @@ pub fn pipeline_options_from_config(
         ahead_of_time_processing: opt.ahead_of_time_processing,
         run_late_scheduled_events: opt.run_late_scheduled_events,
         never_drop_output_frames: opt.never_drop_output_frames,
-        side_channel_delay: opt.side_channel_delay,
         side_channel_socket_dir: opt.side_channel_socket_dir.clone(),
 
         mixing_sample_rate: opt.mixing_sample_rate,

--- a/tools/schemas/openapi_specification.json
+++ b/tools/schemas/openapi_specification.json
@@ -5308,6 +5308,14 @@
               "null"
             ],
             "description": "Enable side channel for audio track."
+          },
+          "delay_ms": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "Side channel delay in milliseconds. Frames are buffered for this duration ahead of\nwhen the queue consumes them, so the side-channel subscriber receives them early\nand has roughly this much time to process before the frame is due."
           }
         },
         "additionalProperties": false

--- a/ts/smelter-core/src/api/input.ts
+++ b/ts/smelter-core/src/api/input.ts
@@ -101,7 +101,7 @@ function intoMp4RegisterInput(input: Inputs.RegisterMp4Input): RegisterInputRequ
     offset_ms: input.offsetMs,
     seek_ms: input.seekMs,
     decoder_map: input.decoderMap,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
   };
 }
 
@@ -112,7 +112,7 @@ function intoHlsRegisterInput(input: Inputs.RegisterHlsInput): RegisterInputRequ
     required: input.required,
     offset_ms: input.offsetMs,
     decoder_map: input.decoderMap,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
   };
 }
 
@@ -126,7 +126,7 @@ function intoRtpRegisterInput(input: Inputs.RegisterRtpInput): RegisterInputRequ
     required: input.required,
     offset_ms: input.offsetMs,
     buffer_size_ms: input.bufferSizeMs,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
   };
 }
 
@@ -141,7 +141,7 @@ function intoWhipRegisterInput(
     endpoint_override: inputId,
     required: input.required,
     buffer_size_ms: input.bufferSizeMs,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
   };
 }
 
@@ -153,7 +153,7 @@ function intoWhepRegisterInput(input: Inputs.RegisterWhepClientInput): RegisterI
     video: input.video && intoInputWhepVideoOptions(input.video),
     required: input.required,
     buffer_size_ms: input.bufferSizeMs,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
   };
 }
 
@@ -164,7 +164,7 @@ function intoRtmpRegisterInput(input: Inputs.RegisterRtmpServerInput): RegisterI
     stream_key: input.streamKey,
     required: input.required,
     decoder_map: input.decoderMap,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
   };
 }
 
@@ -176,7 +176,18 @@ function intoV4l2RegisterInput(input: Inputs.RegisterV4l2Input): RegisterInputRe
     format: input.format,
     framerate: input.framerate,
     required: input.required,
-    side_channel: input.sideChannel,
+    side_channel: intoSideChannel(input.sideChannel),
+  };
+}
+
+function intoSideChannel(sideChannel?: Inputs.SideChannel): Api.SideChannel | undefined {
+  if (!sideChannel) {
+    return undefined;
+  }
+  return {
+    video: sideChannel.video,
+    audio: sideChannel.audio,
+    delay_ms: sideChannel.delayMs,
   };
 }
 

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -1536,6 +1536,10 @@ export interface SideChannel {
    * Enable side channel for audio track.
    */
   audio?: boolean | null;
+  /**
+   * Side channel delay in milliseconds. Frames are buffered for this duration ahead of when the queue consumes them, so the side-channel subscriber receives them early and has roughly this much time to process before the frame is due.
+   */
+  delay_ms?: number | null;
 }
 export interface InputWhipVideoOptions {
   decoder_preferences?: WhipVideoDecoderOptions[] | null;

--- a/ts/smelter/src/types/input/common.ts
+++ b/ts/smelter/src/types/input/common.ts
@@ -9,4 +9,10 @@ export type SideChannel = {
    * Enable side channel for audio track.
    */
   audio?: boolean;
+  /**
+   * Side channel delay in milliseconds. Frames are buffered for this duration ahead of when
+   * the queue consumes them, so the side-channel subscriber receives them early and has
+   * roughly this much time to process before the frame is due.
+   */
+  delayMs?: number;
 };


### PR DESCRIPTION
Originally I wanted to have one value to make sure that all the streams are synced correctly. However this is causing a lot of issues, e.g.
- If we need speech to text, the delay has to be long, effectively in our demo adding new mp4 would have delay of 10 seconds
- Mp4 when looping, have a gap between start/end equal the value of the delay. I'll try to address that in follow up

Also supporting per input value is easy, so I'm leaning towards that approach.


I also considered different value for audio and video, but that would cause desync.