### PR TITLE
Remove `endpoint_override` option from WHIP input

### DIFF
--- a/smelter-api/src/input/whip.rs
+++ b/smelter-api/src/input/whip.rs
@@ -16,10 +16,6 @@ pub struct WhipInput {
     /// Token used for authentication in WHIP protocol. If not provided, the random value
     /// will be generated and returned in the response.
     pub bearer_token: Option<Arc<str>>,
-    /// Internal use only.
-    /// Overrides whip endpoint id which is used when referencing the input via whip server.
-    /// If not provided, it defaults to input id.
-    pub endpoint_override: Option<Arc<str>>,
     /// (**default=`false`**) If input is required and the stream is not delivered
     /// on time, then Smelter will delay producing output frames.
     pub required: Option<bool>,

--- a/smelter-api/src/input/whip_into.rs
+++ b/smelter-api/src/input/whip_into.rs
@@ -11,7 +11,6 @@ impl TryFrom<WhipInput> for core::RegisterInputOptions {
             video,
             required,
             bearer_token,
-            endpoint_override,
             buffer_size_ms,
             side_channel,
         } = value;
@@ -35,7 +34,6 @@ impl TryFrom<WhipInput> for core::RegisterInputOptions {
         let whip_options = core::WhipInputOptions {
             video_preferences,
             bearer_token,
-            endpoint_override,
             jitter_buffer_size,
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),

--- a/smelter-api/tests/input_deserialization.rs
+++ b/smelter-api/tests/input_deserialization.rs
@@ -667,7 +667,6 @@ fn whip_minimal() {
         CoreInput::Whip(WhipInputOptions {
             video_preferences: vec![WebrtcVideoDecoderOptions::Any],
             bearer_token: None,
-            endpoint_override: None,
             jitter_buffer_size: None,
             queue_options: default_queue(),
         }),
@@ -694,7 +693,6 @@ fn whip_with_all_options() {
                 WebrtcVideoDecoderOptions::FfmpegVp8,
             ],
             bearer_token: Some(Arc::from("secret")),
-            endpoint_override: None,
             jitter_buffer_size: Some(Duration::from_millis(200)),
             queue_options: QueueInputOptions {
                 required: true,
@@ -723,7 +721,6 @@ fn whip_video_decoder_preferences() {
                 WebrtcVideoDecoderOptions::Any,
             ],
             bearer_token: None,
-            endpoint_override: None,
             jitter_buffer_size: None,
             queue_options: default_queue(),
         }),
@@ -743,7 +740,6 @@ fn whip_empty_decoder_preferences_defaults_to_any() {
         CoreInput::Whip(WhipInputOptions {
             video_preferences: vec![WebrtcVideoDecoderOptions::Any],
             bearer_token: None,
-            endpoint_override: None,
             jitter_buffer_size: None,
             queue_options: default_queue(),
         }),

--- a/smelter-core/src/pipeline/webrtc/server.rs
+++ b/smelter-core/src/pipeline/webrtc/server.rs
@@ -96,22 +96,22 @@ impl WhipWhepServer {
     ) {
         let app = Router::new()
             .route("/status", get((StatusCode::OK, axum::Json(json!({})))))
-            .route("/whip/:endpoint_id", post(handle_create_whip_session))
+            .route("/whip/:input_id", post(handle_create_whip_session))
             .route(
-                "/whip/:endpoint_id/:session_id",
+                "/whip/:input_id/:session_id",
                 patch(handle_new_whip_ice_candidates),
             )
             .route(
-                "/whip/:endpoint_id/:session_id",
+                "/whip/:input_id/:session_id",
                 delete(handle_terminate_whip_session),
             )
-            .route("/whep/:endpoint_id", post(handle_create_whep_session))
+            .route("/whep/:input_id", post(handle_create_whep_session))
             .route(
-                "/whep/:endpoint_id/:session_id",
+                "/whep/:input_id/:session_id",
                 patch(handle_new_whep_ice_candidates),
             )
             .route(
-                "/whep/:endpoint_id/:session_id",
+                "/whep/:input_id/:session_id",
                 delete(handle_terminate_whep_session),
             )
             .layer(CorsLayer::permissive())

--- a/smelter-core/src/pipeline/webrtc/server/create_whep_session.rs
+++ b/smelter-core/src/pipeline/webrtc/server/create_whep_session.rs
@@ -22,13 +22,12 @@ use crate::pipeline::webrtc::{
 };
 
 pub async fn handle_create_whep_session(
-    Path(endpoint_id): Path<String>,
+    Path(output_id): Path<String>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
     offer: String,
 ) -> Result<Response<Body>, WhipWhepServerError> {
-    let endpoint_id = Arc::from(endpoint_id.clone());
-    let output_ref = state.outputs.find_by_endpoint_id(&endpoint_id)?;
+    let output_ref = state.outputs.resolve_output_ref(&output_id)?;
     let session_id: Arc<str> = Arc::from(Uuid::new_v4().to_string());
     debug!("SDP offer: {}", offer);
 
@@ -124,7 +123,7 @@ pub async fn handle_create_whep_session(
             "Location",
             format!(
                 "/whep/{}/{}",
-                urlencoding::encode(&endpoint_id),
+                urlencoding::encode(&output_id),
                 urlencoding::encode(&session_id),
             ),
         )

--- a/smelter-core/src/pipeline/webrtc/server/create_whip_session.rs
+++ b/smelter-core/src/pipeline/webrtc/server/create_whip_session.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::pipeline::webrtc::{
     WhipWhepServerState, error::WhipWhepServerError,
     whip_input::create_new_session::create_new_whip_session,
@@ -17,15 +15,14 @@ use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
 #[debug_handler]
 pub async fn handle_create_whip_session(
-    Path(endpoint_id): Path<String>,
+    Path(input_id): Path<String>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
     offer: String,
 ) -> Result<Response<Body>, WhipWhepServerError> {
-    let endpoint_id = Arc::from(endpoint_id.clone());
     debug!("SDP offer: {}", offer);
 
-    let input_ref = state.inputs.find_by_endpoint_id(&endpoint_id)?;
+    let input_ref = state.inputs.resolve_input_ref(&input_id)?;
 
     validate_sdp_content_type(&headers)?;
     state.inputs.validate_token(&input_ref, &headers).await?;
@@ -43,7 +40,7 @@ pub async fn handle_create_whip_session(
             "Location",
             format!(
                 "/whip/{}/{}",
-                urlencoding::encode(&endpoint_id),
+                urlencoding::encode(&input_id),
                 urlencoding::encode(&session_id)
             ),
         )

--- a/smelter-core/src/pipeline/webrtc/server/new_whep_ice_candidates.rs
+++ b/smelter-core/src/pipeline/webrtc/server/new_whep_ice_candidates.rs
@@ -13,13 +13,12 @@ use crate::pipeline::webrtc::{
 };
 
 pub async fn handle_new_whep_ice_candidates(
-    Path((endpoint_id, session_id)): Path<(String, String)>,
+    Path((output_id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
     sdp_fragment_content: String,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let endpoint_id = Arc::from(endpoint_id.clone());
-    let output_ref = state.outputs.find_by_endpoint_id(&endpoint_id)?;
+    let output_ref = state.outputs.resolve_output_ref(&output_id)?;
     let session_id = Arc::from(session_id);
 
     validate_content_type(&headers)?;
@@ -41,8 +40,7 @@ pub async fn handle_new_whep_ice_candidates(
         }
         info!(
             ?session_id,
-            output_id=?output_ref.id(),
-            "Added ICE candidate for WHEP session"
+            output_id, "Added ICE candidate for WHEP session"
         );
     }
 

--- a/smelter-core/src/pipeline/webrtc/server/new_whip_ice_candidates.rs
+++ b/smelter-core/src/pipeline/webrtc/server/new_whip_ice_candidates.rs
@@ -12,12 +12,12 @@ use std::sync::Arc;
 use tracing::info;
 
 pub async fn handle_new_whip_ice_candidates(
-    Path((endpoint_id, session_id)): Path<(String, String)>,
+    Path((input_id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
     sdp_fragment_content: String,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let input_ref = state.inputs.find_by_endpoint_id(&Arc::from(endpoint_id))?;
+    let input_ref = state.inputs.resolve_input_ref(&input_id)?;
     let session_id = Arc::from(session_id);
 
     validate_content_type(&headers)?;

--- a/smelter-core/src/pipeline/webrtc/server/terminate_whep_session.rs
+++ b/smelter-core/src/pipeline/webrtc/server/terminate_whep_session.rs
@@ -7,17 +7,16 @@ use std::sync::Arc;
 use tracing::info;
 
 pub async fn handle_terminate_whep_session(
-    Path((endpoint_id, session_id)): Path<(String, String)>,
+    Path((output_id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let endpoint_id = Arc::from(endpoint_id.clone());
-    let output_ref = state.outputs.find_by_endpoint_id(&endpoint_id)?;
+    let output_ref = state.outputs.resolve_output_ref(&output_id)?;
     let session_id = Arc::from(session_id);
 
     state.outputs.validate_token(&output_ref, &headers).await?;
     state.outputs.remove_session(&output_ref, &session_id)?;
 
-    info!(?session_id, output_id=?output_ref.id(), "WHEP session terminated");
+    info!(?session_id, output_id, "WHEP session terminated");
     Ok(StatusCode::OK)
 }

--- a/smelter-core/src/pipeline/webrtc/server/terminate_whip_session.rs
+++ b/smelter-core/src/pipeline/webrtc/server/terminate_whip_session.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 use tracing::info;
 
 pub async fn handle_terminate_whip_session(
-    Path((endpoint_id, session_id)): Path<(String, String)>,
+    Path((input_id, session_id)): Path<(String, String)>,
     State(state): State<WhipWhepServerState>,
     headers: HeaderMap,
 ) -> Result<StatusCode, WhipWhepServerError> {
-    let input_ref = state.inputs.find_by_endpoint_id(&Arc::from(endpoint_id))?;
+    let input_ref = state.inputs.resolve_input_ref(&input_id)?;
     let session_id = Arc::from(session_id);
 
     state.inputs.validate_token(&input_ref, &headers).await?;

--- a/smelter-core/src/pipeline/webrtc/whep_output/state.rs
+++ b/smelter-core/src/pipeline/webrtc/whep_output/state.rs
@@ -40,18 +40,18 @@ impl WhepOutputsState {
         }
     }
 
-    pub fn find_by_endpoint_id(
+    pub fn resolve_output_ref(
         &self,
-        endpoint_id: &Arc<str>,
+        output_id: &str,
     ) -> Result<Ref<OutputId>, WhipWhepServerError> {
         let guard = self.0.lock().unwrap();
         let entry = guard
             .iter()
-            .find(|(output_ref, _)| &output_ref.id().0 == endpoint_id);
+            .find(|(output_ref, _)| &*output_ref.id().0 == output_id);
         match entry {
             Some((output_ref, _)) => Ok(output_ref.clone()),
             None => Err(WhipWhepServerError::NotFound(format!(
-                "Output {endpoint_id} not found"
+                "Output {output_id} not found"
             ))),
         }
     }

--- a/smelter-core/src/pipeline/webrtc/whip_input/input.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/input.rs
@@ -64,11 +64,7 @@ impl WhipInput {
 
         let queue_input = QueueInput::new(&ctx, &input_ref, options.queue_options);
 
-        let endpoint_id = options
-            .endpoint_override
-            .unwrap_or(input_ref.id().0.clone());
-        let endpoint_route = Arc::from(format!("/whip/{}", urlencoding::encode(&endpoint_id)));
-
+        let endpoint_route = Arc::from(format!("/whip/{}", urlencoding::encode(&input_ref.id().0)));
         let bearer_token = options.bearer_token.unwrap_or_else(generate_token);
 
         let video_preferences = resolve_video_preferences(&ctx, options.video_preferences)?;
@@ -77,7 +73,6 @@ impl WhipInput {
             &input_ref,
             WhipInputStateOptions {
                 bearer_token: bearer_token.clone(),
-                endpoint_id,
                 video_preferences,
                 jitter_buffer_size: options.jitter_buffer_size,
                 queue_input: queue_input.downgrade(),

--- a/smelter-core/src/pipeline/webrtc/whip_input/state.rs
+++ b/smelter-core/src/pipeline/webrtc/whip_input/state.rs
@@ -51,18 +51,15 @@ impl WhipInputsState {
         }
     }
 
-    pub fn find_by_endpoint_id(
-        &self,
-        endpoint_id: &Arc<str>,
-    ) -> Result<Ref<InputId>, WhipWhepServerError> {
+    pub fn resolve_input_ref(&self, input_id: &str) -> Result<Ref<InputId>, WhipWhepServerError> {
         let guard = self.0.lock().unwrap();
         let entry = guard
-            .iter()
-            .find(|(_, input)| input.endpoint_id == *endpoint_id);
+            .keys()
+            .find(|input_ref| &*input_ref.id().0 == input_id);
         match entry {
-            Some((input_ref, _)) => Ok(input_ref.clone()),
+            Some(input_ref) => Ok(input_ref.clone()),
             None => Err(WhipWhepServerError::NotFound(format!(
-                "{endpoint_id:?} not found"
+                "{input_id:?} not found"
             ))),
         }
     }
@@ -73,12 +70,9 @@ impl WhipInputsState {
         options: WhipInputStateOptions,
     ) -> Result<(), WebrtcServerError> {
         let mut guard = self.0.lock().unwrap();
-        let is_endpoint_id_in_use = guard
-            .iter()
-            .any(|(_, input)| input.endpoint_id == options.endpoint_id);
-        if is_endpoint_id_in_use {
+        if guard.contains_key(input_ref) {
             return Err(WebrtcServerError::EndpointIdAlreadyInUse(
-                options.endpoint_id,
+                input_ref.id().0.clone(),
             ));
         }
         let old_value = guard.insert(input_ref.clone(), WhipInputState::new(options));
@@ -135,7 +129,6 @@ impl WhipInputsState {
 #[derive(Debug, Clone)]
 pub(crate) struct WhipInputStateOptions {
     pub bearer_token: Arc<str>,
-    pub endpoint_id: Arc<str>,
     pub video_preferences: Vec<VideoDecoderOptions>,
     pub jitter_buffer_size: Option<Duration>,
     pub queue_input: WeakQueueInput,
@@ -144,7 +137,6 @@ pub(crate) struct WhipInputStateOptions {
 #[derive(Debug)]
 pub(crate) struct WhipInputState {
     pub bearer_token: Arc<str>,
-    pub endpoint_id: Arc<str>,
     pub video_preferences: Vec<VideoDecoderOptions>,
     pub jitter_buffer_size: Option<Duration>,
     pub queue_input: WeakQueueInput,
@@ -161,7 +153,6 @@ impl WhipInputState {
     pub fn new(options: WhipInputStateOptions) -> Self {
         WhipInputState {
             bearer_token: options.bearer_token,
-            endpoint_id: options.endpoint_id,
             video_preferences: options.video_preferences,
             jitter_buffer_size: options.jitter_buffer_size,
             queue_input: options.queue_input,

--- a/smelter-core/src/protocols/webrtc.rs
+++ b/smelter-core/src/protocols/webrtc.rs
@@ -17,7 +17,6 @@ use crate::{
 pub struct WhipInputOptions {
     pub video_preferences: Vec<WebrtcVideoDecoderOptions>,
     pub bearer_token: Option<Arc<str>>,
-    pub endpoint_override: Option<Arc<str>>,
     /// Reference/desired jitter buffer size. Sets the lower edge of the adaptive
     /// buffer's stable band; the buffer converges toward this value when network
     /// conditions allow.
@@ -94,7 +93,7 @@ pub enum WebrtcUdpPortStrategy {
 
 #[derive(Debug, thiserror::Error)]
 pub enum WebrtcServerError {
-    #[error("Endpoint ID already in use (endpoint_id: {0})")]
+    #[error("Endpoint ID already in use (input_id: {0})")]
     EndpointIdAlreadyInUse(Arc<str>),
 
     #[error("WHIP/WHEP server is not running, cannot start WHIP input.")]

--- a/tools/schemas/openapi_specification.json
+++ b/tools/schemas/openapi_specification.json
@@ -6693,13 +6693,6 @@
             ],
             "description": "Token used for authentication in WHIP protocol. If not provided, the random value\nwill be generated and returned in the response."
           },
-          "endpoint_override": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Internal use only.\nOverrides whip endpoint id which is used when referencing the input via whip server.\nIf not provided, it defaults to input id."
-          },
           "required": {
             "type": [
               "boolean",

--- a/ts/smelter-core/src/api/input.ts
+++ b/ts/smelter-core/src/api/input.ts
@@ -58,7 +58,7 @@ export type RegisterInput =
  * Converts object passed by user (or modified by platform specific interface) into
  * HTTP request
  */
-export function intoRegisterInput(inputId: string, input: RegisterInput): RegisterInputRequest {
+export function intoRegisterInput(input: RegisterInput): RegisterInputRequest {
   if (input.type === 'mp4') {
     return intoMp4RegisterInput(input);
   } else if (input.type === 'hls') {
@@ -66,7 +66,7 @@ export function intoRegisterInput(inputId: string, input: RegisterInput): Regist
   } else if (input.type === 'rtp_stream') {
     return intoRtpRegisterInput(input);
   } else if (input.type === 'whip_server') {
-    return intoWhipRegisterInput(inputId, input);
+    return intoWhipRegisterInput(input);
   } else if (input.type === 'whep_client') {
     return intoWhepRegisterInput(input);
   } else if (input.type === 'rtmp_server') {
@@ -131,14 +131,12 @@ function intoRtpRegisterInput(input: Inputs.RegisterRtpInput): RegisterInputRequ
 }
 
 function intoWhipRegisterInput(
-  inputId: string,
   input: Inputs.RegisterWhipServerInput
 ): RegisterInputRequest {
   return {
     type: 'whip_server',
     video: input.video && intoInputWhipVideoOptions(input.video),
     bearer_token: input.bearerToken,
-    endpoint_override: inputId,
     required: input.required,
     buffer_size_ms: input.bufferSizeMs,
     side_channel: intoSideChannel(input.sideChannel),

--- a/ts/smelter-core/src/api/input.ts
+++ b/ts/smelter-core/src/api/input.ts
@@ -130,9 +130,7 @@ function intoRtpRegisterInput(input: Inputs.RegisterRtpInput): RegisterInputRequ
   };
 }
 
-function intoWhipRegisterInput(
-  input: Inputs.RegisterWhipServerInput
-): RegisterInputRequest {
+function intoWhipRegisterInput(input: Inputs.RegisterWhipServerInput): RegisterInputRequest {
   return {
     type: 'whip_server',
     video: input.video && intoInputWhipVideoOptions(input.video),

--- a/ts/smelter-core/src/live/compositor.ts
+++ b/ts/smelter-core/src/live/compositor.ts
@@ -87,7 +87,7 @@ export class Smelter {
     _smelterInternals.assertGlobalInputId(inputId);
     return this.store.runBlocking(async updateStore => {
       const inputRef = { type: 'global', id: inputId } as const;
-      const result = await this.api.registerInput(inputRef, intoRegisterInput(inputId, request));
+      const result = await this.api.registerInput(inputRef, intoRegisterInput(request));
       const handle = newInputHandle(inputRef, this.api, result, request.type);
       this.inputs[inputId] = handle;
 

--- a/ts/smelter-core/src/offline/compositor.ts
+++ b/ts/smelter-core/src/offline/compositor.ts
@@ -91,10 +91,7 @@ export class OfflineSmelter {
     _smelterInternals.assertGlobalInputId(inputId);
 
     const inputRef = { type: 'global', id: inputId } as const;
-    const result = await this.api.registerInput(inputRef, intoRegisterInput(inputId, request));
-    if (request.type === 'whip_server') {
-      result.endpoint_route = `/whip/${encodeURIComponent(inputId)}`;
-    }
+    const result = await this.api.registerInput(inputRef, intoRegisterInput(request));
 
     const offsetMs = 'offsetMs' in request && request.offsetMs ? request.offsetMs : 0;
 

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -126,10 +126,6 @@ export type RegisterInput =
        */
       bearer_token?: string | null;
       /**
-       * Internal use only. Overrides whip endpoint id which is used when referencing the input via whip server. If not provided, it defaults to input id.
-       */
-      endpoint_override?: string | null;
-      /**
        * (**default=`false`**) If input is required and the stream is not delivered on time, then Smelter will delay producing output frames.
        */
       required?: boolean | null;


### PR DESCRIPTION
we don't need override anymore because ts sdk wil now use the same value for input and route(no `global:` prefix). As a result we don't need concept of endpoint_id, because segment in webrtc path will always be input_id