### PR TITLE
Update workflows to Rust `1.96`

### DIFF
--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -29,7 +29,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.95
+                  toolchain: 1.96
                   components: rustfmt, clippy
 
             - name: 📥 Checkout repo
@@ -73,7 +73,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.95
+                  toolchain: 1.96
                   components: rustfmt, clippy
 
             - name: 📥 Checkout repo
@@ -115,7 +115,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.95
+                  toolchain: 1.96
 
             - name: 🔬 Install nextest
               uses: taiki-e/install-action@v2

--- a/.github/workflows/ts_check.yml
+++ b/.github/workflows/ts_check.yml
@@ -22,7 +22,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.95
+                  toolchain: 1.96
 
             - name: Install pnpm
               uses: pnpm/action-setup@v4

--- a/.github/workflows/ts_publish.yml
+++ b/.github/workflows/ts_publish.yml
@@ -24,7 +24,7 @@ jobs:
             - name: 🔧 Install the rust toolchain
               uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: 1.95
+                  toolchain: 1.96
 
             - name: Setup Node.js
               uses: actions/setup-node@v6

--- a/tools/docker/full.Dockerfile
+++ b/tools/docker/full.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20250716 as builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG USERNAME=smelter
-ARG RUST_VERSION=1.94
+ARG RUST_VERSION=1.96
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tools/docker/slim.Dockerfile
+++ b/tools/docker/slim.Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:noble-20250716 as builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG USERNAME=smelter
-ARG RUST_VERSION=1.94
+ARG RUST_VERSION=1.96
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
There is some annoying compiler bug in `1.95` maybe they fixed it by now.