### PR TITLE
Added Opus codec and LOC, Legacy containers to MoQ server input.

### DIFF
--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -49,11 +49,6 @@ struct AudioTrack {
     description: Option<Bytes>,
 }
 
-struct DiscoveredTracks {
-    video: Option<VideoTrack>,
-    audio: Option<AudioTrack>,
-}
-
 #[derive(Clone)]
 struct TrackCtx {
     ctx: Arc<PipelineCtx>,
@@ -117,13 +112,14 @@ async fn handle_broadcast(
 ) -> Result<(), MoqConnectionError> {
     info!("MoQ broadcast connection established");
 
-    let discovered = read_catalog(&broadcast).await?;
+    let (video, audio) = read_catalog(&broadcast).await?;
 
     let mut handler = BroadcastHandler::new(
         ctx.clone(),
         input_ref.clone(),
         broadcast,
-        discovered,
+        video,
+        audio,
         decoders,
         should_close,
     );
@@ -156,7 +152,8 @@ async fn handle_broadcast(
 
 struct BroadcastHandler {
     track_ctx: TrackCtx,
-    tracks: DiscoveredTracks,
+    video: Option<VideoTrack>,
+    audio: Option<AudioTrack>,
 }
 
 impl BroadcastHandler {
@@ -164,7 +161,8 @@ impl BroadcastHandler {
         ctx: Arc<PipelineCtx>,
         input_ref: Ref<InputId>,
         broadcast: BroadcastConsumer,
-        tracks: DiscoveredTracks,
+        video: Option<VideoTrack>,
+        audio: Option<AudioTrack>,
         decoders: MoqServerInputDecoders,
         should_close: Arc<AtomicBool>,
     ) -> Self {
@@ -184,22 +182,26 @@ impl BroadcastHandler {
             should_close,
             stats_sender,
         };
-        Self { track_ctx, tracks }
+        Self {
+            track_ctx,
+            video,
+            audio,
+        }
     }
 
     fn has_video(&self) -> bool {
-        self.tracks.video.is_some()
+        self.video.is_some()
     }
 
     fn has_audio(&self) -> bool {
-        self.tracks.audio.is_some()
+        self.audio.is_some()
     }
 
     fn handle_video_track(
         &mut self,
         frame_sender: Option<QueueSender<Frame>>,
     ) -> Option<tokio::task::JoinHandle<()>> {
-        let (Some(video), Some(frame_sender)) = (self.tracks.video.take(), frame_sender) else {
+        let (Some(video), Some(frame_sender)) = (self.video.take(), frame_sender) else {
             return None;
         };
 
@@ -223,7 +225,7 @@ impl BroadcastHandler {
         &mut self,
         sample_sender: Option<QueueSender<InputAudioSamples>>,
     ) -> Option<tokio::task::JoinHandle<()>> {
-        let (Some(audio), Some(sample_sender)) = (self.tracks.audio.take(), sample_sender) else {
+        let (Some(audio), Some(sample_sender)) = (self.audio.take(), sample_sender) else {
             return None;
         };
 

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -16,7 +16,9 @@ use crate::{
             decoder_thread_audio::{AudioDecoderThread, AudioDecoderThreadOptions},
             decoder_thread_video::{VideoDecoderThread, VideoDecoderThreadOptions},
             fdk_aac::FdkAacDecoder,
-            ffmpeg_h264, vulkan_h264,
+            ffmpeg_h264,
+            libopus::OpusDecoder,
+            vulkan_h264,
         },
         moq::state::MoqInputState,
     },
@@ -35,12 +37,14 @@ const MOQ_MAX_BUFFER: Duration = Duration::from_secs(20);
 
 struct DiscoveredVideo {
     name: String,
+    codec: VideoCodec,
     container: Container,
     description: Option<Bytes>,
 }
 
 struct DiscoveredAudio {
     name: String,
+    codec: AudioCodec,
     container: Container,
     description: Option<Bytes>,
 }
@@ -280,7 +284,7 @@ async fn run_video_track(
             data: payload,
             pts,
             dts: None,
-            kind: MediaKind::Video(VideoCodec::H264),
+            kind: MediaKind::Video(video.codec),
             present: true,
         };
 
@@ -343,7 +347,7 @@ async fn run_audio_track(
             data: payload,
             pts,
             dts: None,
-            kind: MediaKind::Audio(AudioCodec::Aac),
+            kind: MediaKind::Audio(audio.codec),
             present: true,
         };
 
@@ -374,17 +378,26 @@ fn spawn_video_decoder(
     video: &DiscoveredVideo,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    // Only CMAF H264 is allowed right now, other codecs are rejected before this function
-    let avcc_bytes = video
-        .description
-        .clone()
-        .ok_or(MoqConnectionError::InvalidAvcc)?;
+    let transformer = {
+        match &video.description {
+            Some(desc) => {
+                let h264_config = H264AvcDecoderConfig::parse(desc.clone())
+                    .map_err(|_| MoqConnectionError::InvalidAvcc)?;
 
-    let h264_config =
-        H264AvcDecoderConfig::parse(avcc_bytes).map_err(|_| MoqConnectionError::InvalidAvcc)?;
+                Some(H264AvccToAnnexB::new(h264_config))
+            }
+            None => None,
+        }
+    };
+    if let Container::Cmaf(_) = video.container
+        && transformer.is_none()
+    {
+        return Err(MoqConnectionError::MissingAvcc);
+    }
+
     let options = VideoDecoderThreadOptions {
         ctx: ctx.clone(),
-        transformer: Some(H264AvccToAnnexB::new(h264_config)),
+        transformer,
         frame_sender,
         input_buffer_size: MOQ_MAX_BUFFER,
     };
@@ -416,18 +429,18 @@ fn spawn_audio_decoder(
     audio: &DiscoveredAudio,
     sample_sender: QueueSender<InputAudioSamples>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    // Only AAC is allowed right now, different codecs are rejected before this function is called
-    let asc = audio
-        .description
-        .clone()
-        .ok_or(MoqConnectionError::MissingAsc)?;
-    let aac_decoder_options = AudioDecoderOptions::FdkAac(FdkAacDecoderOptions { asc: Some(asc) });
+    match &audio.codec {
+        AudioCodec::Aac => {
+            let asc = audio.description.clone();
+            if let Container::Cmaf(_) = audio.container
+                && asc.is_none()
+            {
+                return Err(MoqConnectionError::MissingAsc);
+            }
 
-    match aac_decoder_options {
-        AudioDecoderOptions::FdkAac(decoder_options) => {
             let options = AudioDecoderThreadOptions {
                 ctx: ctx.clone(),
-                decoder_options,
+                decoder_options: FdkAacDecoderOptions { asc },
                 samples_sender: sample_sender,
                 input_buffer_size: MOQ_MAX_BUFFER,
             };
@@ -436,7 +449,18 @@ fn spawn_audio_decoder(
                 options,
             )?)
         }
-        _ => Err(MoqConnectionError::UnsupportedAudioCodec),
+        AudioCodec::Opus => {
+            let options = AudioDecoderThreadOptions {
+                ctx: ctx.clone(),
+                decoder_options: (),
+                samples_sender: sample_sender,
+                input_buffer_size: MOQ_MAX_BUFFER,
+            };
+            Ok(AudioDecoderThread::<OpusDecoder>::spawn(
+                input_ref.clone(),
+                options,
+            )?)
+        }
     }
 }
 
@@ -457,8 +481,8 @@ enum MoqConnectionError {
     #[error("Invalid H264 decoder config.")]
     InvalidAvcc,
 
-    #[error("Unsupported audio codec, AAC expected.")]
-    UnsupportedAudioCodec,
+    #[error("Missing H264 decoder config.")]
+    MissingAvcc,
 
     #[error("Missing AAC decoder config.")]
     MissingAsc,

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -35,14 +35,14 @@ mod catalog;
 const MOQ_BUFFER: Duration = Duration::from_secs(1);
 const MOQ_MAX_BUFFER: Duration = Duration::from_secs(20);
 
-struct DiscoveredVideo {
+struct VideoTrack {
     name: String,
     codec: VideoCodec,
     container: Container,
     description: Option<Bytes>,
 }
 
-struct DiscoveredAudio {
+struct AudioTrack {
     name: String,
     codec: AudioCodec,
     container: Container,
@@ -50,8 +50,8 @@ struct DiscoveredAudio {
 }
 
 struct DiscoveredTracks {
-    video: Option<DiscoveredVideo>,
-    audio: Option<DiscoveredAudio>,
+    video: Option<VideoTrack>,
+    audio: Option<AudioTrack>,
 }
 
 #[derive(Clone)]
@@ -246,7 +246,7 @@ impl BroadcastHandler {
 
 async fn run_video_track(
     track_ctx: TrackCtx,
-    video: DiscoveredVideo,
+    video: VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<(), MoqConnectionError> {
     let TrackCtx {
@@ -310,7 +310,7 @@ async fn run_video_track(
 
 async fn run_audio_track(
     track_ctx: TrackCtx,
-    audio: DiscoveredAudio,
+    audio: AudioTrack,
     sample_sender: QueueSender<InputAudioSamples>,
 ) -> Result<(), MoqConnectionError> {
     let TrackCtx {
@@ -375,7 +375,7 @@ fn spawn_video_decoder(
     ctx: &Arc<PipelineCtx>,
     input_ref: &Ref<InputId>,
     decoders: &MoqServerInputDecoders,
-    video: &DiscoveredVideo,
+    video: &VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
     let transformer = {
@@ -426,7 +426,7 @@ fn spawn_video_decoder(
 fn spawn_audio_decoder(
     ctx: &Arc<PipelineCtx>,
     input_ref: &Ref<InputId>,
-    audio: &DiscoveredAudio,
+    audio: &AudioTrack,
     sample_sender: QueueSender<InputAudioSamples>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
     match &audio.codec {

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -120,7 +120,6 @@ fn discover_video(
     };
 
     let description = match (&config.description, &container) {
-        (Some(desc), _) => Some(desc.clone()),
         (None, Container::Cmaf(wire)) => match extract_codec_description(wire) {
             Ok(desc) => Some(desc),
             Err(error) => {
@@ -128,7 +127,7 @@ fn discover_video(
                 return Ok(None);
             }
         },
-        (None, _) => config.description.clone(),
+        _ => config.description.clone(),
     };
 
     Ok(Some(DiscoveredVideo {
@@ -164,16 +163,15 @@ fn discover_audio(
 
     // Decoder config extraction is necessary only for AAC. Opus is self-contained and does not need
     // description
-    let description = match (&config.description, &container) {
-        (Some(desc), _) => Some(desc.clone()),
-        (None, Container::Cmaf(wire)) => match extract_codec_description(wire) {
+    let description = match (&config.description, &codec, &container) {
+        (None, AudioCodec::Aac, Container::Cmaf(wire)) => match extract_codec_description(wire) {
             Ok(desc) => Some(desc),
             Err(error) => {
-                warn!(%error, "Failed to extract video decoder config from container; skipping video track.");
+                warn!(%error, "Failed to extract audio decoder config from container; skipping audio track.");
                 return Ok(None);
             }
         },
-        (None, _) => config.description.clone(),
+        _ => config.description.clone(),
     };
 
     Ok(Some(DiscoveredAudio {

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -7,7 +7,7 @@ use moq_mux::container::fmp4;
 use moq_native::moq_net::{BroadcastConsumer, Error as MoqError, Track};
 use tracing::{debug, warn};
 
-use crate::pipeline::moq::connection::{DiscoveredAudio, DiscoveredTracks, DiscoveredVideo};
+use crate::pipeline::moq::connection::{AudioTrack, DiscoveredTracks, VideoTrack};
 
 use crate::prelude::*;
 
@@ -97,9 +97,7 @@ async fn read_msf_catalog(
     Ok(DiscoveredTracks { video, audio })
 }
 
-fn discover_video(
-    video: &hang::catalog::Video,
-) -> Result<Option<DiscoveredVideo>, MoqCatalogError> {
+fn discover_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, MoqCatalogError> {
     let Some((name, config)) = video.renditions.first_key_value() else {
         return Ok(None);
     };
@@ -128,7 +126,7 @@ fn discover_video(
         _ => config.description.clone(),
     };
 
-    Ok(Some(DiscoveredVideo {
+    Ok(Some(VideoTrack {
         name: name.clone(),
         container,
         codec,
@@ -136,9 +134,7 @@ fn discover_video(
     }))
 }
 
-fn discover_audio(
-    audio: &hang::catalog::Audio,
-) -> Result<Option<DiscoveredAudio>, MoqCatalogError> {
+fn discover_audio(audio: &hang::catalog::Audio) -> Result<Option<AudioTrack>, MoqCatalogError> {
     let Some((name, config)) = audio.renditions.first_key_value() else {
         return Ok(None);
     };
@@ -170,7 +166,7 @@ fn discover_audio(
         _ => config.description.clone(),
     };
 
-    Ok(Some(DiscoveredAudio {
+    Ok(Some(AudioTrack {
         name: name.clone(),
         container,
         codec,

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -7,7 +7,7 @@ use moq_mux::container::fmp4;
 use moq_native::moq_net::{BroadcastConsumer, Error as MoqError, Track};
 use tracing::{debug, warn};
 
-use crate::pipeline::moq::connection::{AudioTrack, DiscoveredTracks, VideoTrack};
+use crate::pipeline::moq::connection::{AudioTrack, VideoTrack};
 
 use crate::prelude::*;
 
@@ -31,7 +31,7 @@ pub(super) enum MoqCatalogError {
 
 pub(super) async fn read_catalog(
     broadcast: &BroadcastConsumer,
-) -> Result<DiscoveredTracks, MoqCatalogError> {
+) -> Result<(Option<VideoTrack>, Option<AudioTrack>), MoqCatalogError> {
     match read_hang_catalog(broadcast).await {
         Ok(tracks) => Ok(tracks),
         Err(error) => {
@@ -46,7 +46,7 @@ pub(super) async fn read_catalog(
 
 async fn read_hang_catalog(
     broadcast: &BroadcastConsumer,
-) -> Result<DiscoveredTracks, MoqCatalogError> {
+) -> Result<(Option<VideoTrack>, Option<AudioTrack>), MoqCatalogError> {
     use moq_mux::catalog::hang::{Catalog, Consumer};
 
     let catalog_track = broadcast
@@ -61,19 +61,19 @@ async fn read_hang_catalog(
 
     debug!(?catalog, "Received MoQ Hang catalog");
 
-    let video = discover_video(&catalog.video)?;
-    let audio = discover_audio(&catalog.audio)?;
+    let video = find_first_video(&catalog.video)?;
+    let audio = find_first_audio(&catalog.audio)?;
 
     if video.is_none() && audio.is_none() {
         return Err(MoqCatalogError::CatalogNoTracks);
     }
 
-    Ok(DiscoveredTracks { video, audio })
+    Ok((video, audio))
 }
 
 async fn read_msf_catalog(
     broadcast: &BroadcastConsumer,
-) -> Result<DiscoveredTracks, MoqCatalogError> {
+) -> Result<(Option<VideoTrack>, Option<AudioTrack>), MoqCatalogError> {
     use moq_mux::catalog::msf::Consumer;
 
     let catalog_track = broadcast
@@ -87,17 +87,17 @@ async fn read_msf_catalog(
         .ok_or(MoqCatalogError::CatalogEmpty)?;
     debug!(?catalog, "Received MoQ MSF catalog");
 
-    let video = discover_video(&catalog.video)?;
-    let audio = discover_audio(&catalog.audio)?;
+    let video = find_first_video(&catalog.video)?;
+    let audio = find_first_audio(&catalog.audio)?;
 
     if video.is_none() && audio.is_none() {
         return Err(MoqCatalogError::CatalogNoTracks);
     }
 
-    Ok(DiscoveredTracks { video, audio })
+    Ok((video, audio))
 }
 
-fn discover_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, MoqCatalogError> {
+fn find_first_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, MoqCatalogError> {
     let Some((name, config)) = video.renditions.first_key_value() else {
         return Ok(None);
     };
@@ -134,7 +134,7 @@ fn discover_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, Mo
     }))
 }
 
-fn discover_audio(audio: &hang::catalog::Audio) -> Result<Option<AudioTrack>, MoqCatalogError> {
+fn find_first_audio(audio: &hang::catalog::Audio) -> Result<Option<AudioTrack>, MoqCatalogError> {
     let Some((name, config)) = audio.renditions.first_key_value() else {
         return Ok(None);
     };

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -123,7 +123,7 @@ fn discover_video(
         (None, Container::Cmaf(wire)) => match extract_codec_description(wire) {
             Ok(desc) => Some(desc),
             Err(error) => {
-                warn!(%error, "Failed to extract video decoder config from container; skipping audio track.");
+                warn!(%error, "Failed to extract video decoder config from container; skipping video track.");
                 return Ok(None);
             }
         },

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -113,10 +113,8 @@ fn discover_video(
     };
     let container = match &config.container {
         CatalogContainer::Cmaf { init, .. } => Container::Cmaf(fmp4::Wire::from_init(init)?),
-        _ => {
-            warn!("Unsupported video container. Only CMAF is supported.");
-            return Ok(None);
-        }
+        CatalogContainer::Legacy => Container::Legacy,
+        CatalogContainer::Loc => Container::Loc,
     };
 
     let description = match (&config.description, &container) {
@@ -155,10 +153,8 @@ fn discover_audio(
     };
     let container = match &config.container {
         CatalogContainer::Cmaf { init, .. } => Container::Cmaf(fmp4::Wire::from_init(init)?),
-        _ => {
-            warn!("Unsupported audio container. Only CMAF is supported.");
-            return Ok(None);
-        }
+        CatalogContainer::Legacy => Container::Legacy,
+        CatalogContainer::Loc => Container::Loc,
     };
 
     // Decoder config extraction is necessary only for AAC. Opus is self-contained and does not need

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -1,10 +1,15 @@
 use bytes::{Bytes, BytesMut};
-use hang::catalog::{AudioCodec, Container as CatalogContainer, VideoCodec};
+use hang::catalog::{
+    AudioCodec as MoqAudioCodec, Container as CatalogContainer, VideoCodec as MoqVideoCodec,
+};
+use moq_mux::catalog::hang::Container;
 use moq_mux::container::fmp4;
 use moq_native::moq_net::{BroadcastConsumer, Error as MoqError, Track};
 use tracing::{debug, warn};
 
 use crate::pipeline::moq::connection::{DiscoveredAudio, DiscoveredTracks, DiscoveredVideo};
+
+use crate::prelude::*;
 
 #[derive(thiserror::Error, Debug)]
 pub(super) enum MoqCatalogError {
@@ -29,14 +34,20 @@ pub(super) async fn read_catalog(
 ) -> Result<DiscoveredTracks, MoqCatalogError> {
     match read_hang_catalog(broadcast).await {
         Ok(tracks) => Ok(tracks),
-        Err(_) => read_msf_catalog(broadcast).await,
+        Err(error) => {
+            debug!(
+                %error,
+                "Failed to read Hang catalog, fall back to MSF catalog."
+            );
+            read_msf_catalog(broadcast).await
+        }
     }
 }
 
 async fn read_hang_catalog(
     broadcast: &BroadcastConsumer,
 ) -> Result<DiscoveredTracks, MoqCatalogError> {
-    use moq_mux::catalog::hang::{Catalog, Consumer, Container};
+    use moq_mux::catalog::hang::{Catalog, Consumer};
 
     let catalog_track = broadcast
         .subscribe_track(&hang::Catalog::default_track())
@@ -50,41 +61,8 @@ async fn read_hang_catalog(
 
     debug!(?catalog, "Received MoQ Hang catalog");
 
-    let video = match catalog.video.renditions.first_key_value() {
-        Some((name, config)) => match (&config.container, &config.codec) {
-            (CatalogContainer::Cmaf { init, .. }, VideoCodec::H264(_)) => {
-                let wire = fmp4::Wire::from_init(init)?;
-                Some(DiscoveredVideo {
-                    name: name.clone(),
-                    container: Container::Cmaf(wire),
-                    description: config.description.clone(),
-                })
-            }
-            _ => {
-                warn!("Only CMAF container with H264 encoded video is supported.");
-                None
-            }
-        },
-        None => None,
-    };
-
-    let audio = match catalog.audio.renditions.first_key_value() {
-        Some((name, config)) => match (&config.container, &config.codec) {
-            (CatalogContainer::Cmaf { init, .. }, AudioCodec::AAC(_)) => {
-                let wire = fmp4::Wire::from_init(init)?;
-                Some(DiscoveredAudio {
-                    name: name.clone(),
-                    container: Container::Cmaf(wire),
-                    description: config.description.clone(),
-                })
-            }
-            _ => {
-                warn!("Only CMAF container with AAC encoded audio is supported.");
-                None
-            }
-        },
-        None => None,
-    };
+    let video = discover_video(&catalog.video)?;
+    let audio = discover_audio(&catalog.audio)?;
 
     if video.is_none() && audio.is_none() {
         return Err(MoqCatalogError::CatalogNoTracks);
@@ -96,7 +74,7 @@ async fn read_hang_catalog(
 async fn read_msf_catalog(
     broadcast: &BroadcastConsumer,
 ) -> Result<DiscoveredTracks, MoqCatalogError> {
-    use moq_mux::catalog::{hang::Container, msf::Consumer};
+    use moq_mux::catalog::msf::Consumer;
 
     let catalog_track = broadcast
         .subscribe_track(&Track::new(moq_msf::DEFAULT_NAME))
@@ -109,66 +87,101 @@ async fn read_msf_catalog(
         .ok_or(MoqCatalogError::CatalogEmpty)?;
     debug!(?catalog, "Received MoQ MSF catalog");
 
-    let video = match catalog.video.renditions.first_key_value() {
-        Some((name, config)) => match (&config.container, &config.codec) {
-            (CatalogContainer::Cmaf { init, .. }, VideoCodec::H264(_)) => {
-                let wire = fmp4::Wire::from_init(init)?;
-                let description = match extract_codec_description(&wire) {
-                    Ok(config) => Some(config),
-                    Err(error) => {
-                        warn!(%error, "Failed to extract video config from CMAF container.");
-                        None
-                    }
-                };
-
-                Some(DiscoveredVideo {
-                    name: name.clone(),
-                    container: Container::Cmaf(wire),
-                    description,
-                })
-            }
-            _ => {
-                warn!("Only CMAF container with H264 encoded video is supported.");
-                None
-            }
-        },
-        None => None,
-    };
-
-    let audio = match catalog.audio.renditions.first_key_value() {
-        Some((name, config)) => match (&config.container, &config.codec) {
-            // TODO: (@jbrs): It needs to be reconsidered how decoder config should be handled,
-            // where should it be extracted from the container, here or in the decoder.
-            // Return to that when adding additional containers.
-            (CatalogContainer::Cmaf { init, .. }, AudioCodec::AAC(_)) => {
-                let wire = fmp4::Wire::from_init(init)?;
-                let description = match extract_codec_description(&wire) {
-                    Ok(config) => Some(config),
-                    Err(error) => {
-                        warn!(%error, "Failed to extract audio config from CMAF container.");
-                        None
-                    }
-                };
-
-                Some(DiscoveredAudio {
-                    name: name.clone(),
-                    container: Container::Cmaf(wire),
-                    description,
-                })
-            }
-            _ => {
-                warn!("Only CMAF container with AAC encoded audio is supported.");
-                None
-            }
-        },
-        None => None,
-    };
+    let video = discover_video(&catalog.video)?;
+    let audio = discover_audio(&catalog.audio)?;
 
     if video.is_none() && audio.is_none() {
         return Err(MoqCatalogError::CatalogNoTracks);
     }
 
     Ok(DiscoveredTracks { video, audio })
+}
+
+fn discover_video(
+    video: &hang::catalog::Video,
+) -> Result<Option<DiscoveredVideo>, MoqCatalogError> {
+    let Some((name, config)) = video.renditions.first_key_value() else {
+        return Ok(None);
+    };
+
+    let codec = match &config.codec {
+        MoqVideoCodec::H264(_) => VideoCodec::H264,
+        _ => {
+            warn!("Unsupported video codec. Use H264.");
+            return Ok(None);
+        }
+    };
+    let container = match &config.container {
+        CatalogContainer::Cmaf { init, .. } => Container::Cmaf(fmp4::Wire::from_init(init)?),
+        _ => {
+            warn!("Unsupported video container. Only CMAF is supported.");
+            return Ok(None);
+        }
+    };
+
+    let description = match (&config.description, &container) {
+        (Some(desc), _) => Some(desc.clone()),
+        (None, Container::Cmaf(wire)) => match extract_codec_description(wire) {
+            Ok(desc) => Some(desc),
+            Err(error) => {
+                warn!(%error, "Failed to extract video decoder config from container; skipping audio track.");
+                return Ok(None);
+            }
+        },
+        (None, _) => config.description.clone(),
+    };
+
+    Ok(Some(DiscoveredVideo {
+        name: name.clone(),
+        container,
+        codec,
+        description,
+    }))
+}
+
+fn discover_audio(
+    audio: &hang::catalog::Audio,
+) -> Result<Option<DiscoveredAudio>, MoqCatalogError> {
+    let Some((name, config)) = audio.renditions.first_key_value() else {
+        return Ok(None);
+    };
+
+    let codec = match &config.codec {
+        MoqAudioCodec::Opus => AudioCodec::Opus,
+        MoqAudioCodec::AAC(_) => AudioCodec::Aac,
+        _ => {
+            warn!("Unsupported audio codec. Use AAC or Opus.");
+            return Ok(None);
+        }
+    };
+    let container = match &config.container {
+        CatalogContainer::Cmaf { init, .. } => Container::Cmaf(fmp4::Wire::from_init(init)?),
+        _ => {
+            warn!("Unsupported audio container. Only CMAF is supported.");
+            return Ok(None);
+        }
+    };
+
+    // Decoder config extraction is necessary only for AAC. Opus is self-contained and does not need
+    // description
+    let description = match (&config.description, &container) {
+        (Some(desc), _) => Some(desc.clone()),
+        (None, Container::Cmaf(wire)) => match extract_codec_description(wire) {
+            Ok(desc) => Some(desc),
+            Err(error) => {
+                warn!(%error, "Failed to extract video decoder config from container; skipping video track.");
+                return Ok(None);
+            }
+        },
+        (None, _) => config.description.clone(),
+    };
+
+    Ok(Some(DiscoveredAudio {
+        name: name.clone(),
+        container,
+        codec,
+        description,
+    }))
 }
 
 fn extract_codec_description(cmaf: &fmp4::Wire) -> Result<Bytes, MoqCatalogError> {


### PR DESCRIPTION
- #2009

---

This one is important. Streaming from browser with our MoQ streamer tool does not work with AAC on Linux, as there are no supported encoders.