### PR TITLE
Added authentication via `auth_token` to MoQ server input

### DIFF
--- a/integration-tests/examples/demo/inputs/moq.rs
+++ b/integration-tests/examples/demo/inputs/moq.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MoqInput {
     pub name: String,
+    pub auth_token: String,
 }
 
 impl MoqInput {
@@ -19,7 +20,8 @@ impl MoqInput {
             "type": "moq_server",
             "decoder_map": {
                 "h264": "ffmpeg_h264",
-            }
+            },
+            "auth_token": self.auth_token,
         })
     }
 
@@ -32,12 +34,14 @@ impl MoqInput {
 
 pub struct MoqInputBuilder {
     name: String,
+    auth_token: String,
 }
 
 impl MoqInputBuilder {
     pub fn new() -> Self {
         let name = Self::generate_name();
-        Self { name }
+        let auth_token = "example".to_string();
+        Self { name, auth_token }
     }
 
     fn generate_name() -> String {
@@ -48,7 +52,7 @@ impl MoqInputBuilder {
     }
 
     pub fn prompt(self) -> Result<Self> {
-        self.prompt_name()
+        self.prompt_name()?.prompt_token()
     }
 
     fn prompt_name(self) -> Result<Self> {
@@ -60,12 +64,29 @@ impl MoqInputBuilder {
         }
     }
 
+    fn prompt_token(self) -> Result<Self> {
+        let token_input = Text::new("Auth token (ESC for \"example\"):").prompt_skippable()?;
+
+        match token_input {
+            Some(token) if !token.trim().is_empty() => Ok(self.with_token(token)),
+            None | Some(_) => Ok(self),
+        }
+    }
+
     pub fn with_name(mut self, name: String) -> Self {
         self.name = name;
         self
     }
 
+    pub fn with_token(mut self, auth_token: String) -> Self {
+        self.auth_token = auth_token;
+        self
+    }
+
     pub fn build(self) -> MoqInput {
-        MoqInput { name: self.name }
+        MoqInput {
+            name: self.name,
+            auth_token: self.auth_token,
+        }
     }
 }

--- a/smelter-api/src/input/moq_server.rs
+++ b/smelter-api/src/input/moq_server.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,9 @@ use super::SideChannel;
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct MoqInputServer {
+    /// Token used for authentication in MoQ server input. The broadcaster must provide
+    /// it as a `token` query parameter when connecting
+    pub auth_token: Arc<str>,
     /// (**default=`false`**) If input is required and the stream is not delivered
     /// on time, then Smelter will delay producing output frames.
     pub required: Option<bool>,

--- a/smelter-api/src/input/moq_server_into.rs
+++ b/smelter-api/src/input/moq_server_into.rs
@@ -6,6 +6,7 @@ impl TryFrom<MoqInputServer> for core::RegisterInputOptions {
 
     fn try_from(value: MoqInputServer) -> Result<Self, Self::Error> {
         let MoqInputServer {
+            auth_token,
             required,
             decoder_map,
             side_channel,
@@ -24,6 +25,7 @@ impl TryFrom<MoqInputServer> for core::RegisterInputOptions {
             .transpose()?;
 
         let input_options = core::MoqServerInputOptions {
+            auth_token,
             decoders: core::MoqServerInputDecoders { h264 },
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),

--- a/smelter-core/src/pipeline/moq/server.rs
+++ b/smelter-core/src/pipeline/moq/server.rs
@@ -151,7 +151,8 @@ async fn handle_incoming_connection(
     ctx: &Arc<PipelineCtx>,
 ) -> Result<(MoqSession, OriginConsumer, Ref<InputId>), MoqServerError> {
     let Some(url) = request.url() else {
-        reject_request(request, 400).await;
+        // This error is safe to ignore as it comes only if the connection is already dead.
+        _ = request.close(400).await;
         return Err(MoqServerError::UrlNotFound);
     };
 
@@ -159,7 +160,7 @@ async fn handle_incoming_connection(
     let input_name = match urlencoding::decode(input_name_encoded) {
         Ok(decoded) => decoded.into_owned(),
         Err(error) => {
-            reject_request(request, 400).await;
+            _ = request.close(400).await;
             return Err(MoqServerError::UrlDecodeFailed(error));
         }
     };
@@ -167,7 +168,7 @@ async fn handle_incoming_connection(
     let input_ref = match moq_inputs.find_by_url(&input_name) {
         Ok(input_ref) => input_ref,
         Err(error) => {
-            reject_request(request, 404).await;
+            _ = request.close(404).await;
             return Err(error);
         }
     };
@@ -178,7 +179,7 @@ async fn handle_incoming_connection(
         .map(|(_key, value)| value);
 
     let Some(auth_token) = auth_token else {
-        reject_request(request, 401).await;
+        _ = request.close(401).await;
         return Err(MoqServerError::MissingToken(input_ref.id().clone()));
     };
 
@@ -189,7 +190,7 @@ async fn handle_incoming_connection(
             // Should never happen
             _ => 400,
         };
-        reject_request(request, reject_code).await;
+        _ = request.close(reject_code).await;
         return Err(auth_error);
     }
 
@@ -203,12 +204,6 @@ async fn handle_incoming_connection(
     };
 
     Ok((session, consumer, input_ref))
-}
-
-async fn reject_request(request: Request, code: u16) {
-    if let Err(error) = request.close(code).await {
-        warn!(%error, "Error while rejecting MoQ connection.");
-    }
 }
 
 async fn handle_session(

--- a/smelter-core/src/pipeline/moq/server.rs
+++ b/smelter-core/src/pipeline/moq/server.rs
@@ -88,7 +88,7 @@ pub async fn spawn_moq_server(
 
     let server = match try_start_server(config).await {
         Ok(server) => server,
-        Err(error) => return Err(InitPipelineError::MoqServerInitError(error)),
+        Err(err) => return Err(InitPipelineError::MoqServerInitError(err)),
     };
 
     let accept_task = tokio::spawn(run_accept_loop(server, state.server_state.clone(), ctx));
@@ -121,12 +121,12 @@ async fn run_accept_loop(
     while let Some(request) = server.accept().await {
         let (origin, input_ref) = match handle_incoming_connection(&request, &moq_inputs).await {
             Ok(sci) => sci,
-            Err(error) => {
+            Err(err) => {
                 warn!(
                     "MoQ connection rejected: {}",
-                    ErrorStack::new(&error).into_string()
+                    ErrorStack::new(&err).into_string()
                 );
-                let rejection_code = match error {
+                let rejection_code = match err {
                     MoqServerError::UrlNotFound | MoqServerError::UrlDecodeFailed(_) => 400,
                     MoqServerError::PathNotFound(_) | MoqServerError::InputNotFound(_) => 404,
                     MoqServerError::MissingToken(_) | MoqServerError::InvalidToken(_) => 401,
@@ -171,17 +171,10 @@ async fn handle_incoming_connection(
     let input_name_encoded = url.path().trim_start_matches('/');
     let input_name = match urlencoding::decode(input_name_encoded) {
         Ok(decoded) => decoded.into_owned(),
-        Err(error) => {
-            return Err(MoqServerError::UrlDecodeFailed(error));
-        }
+        Err(err) => return Err(MoqServerError::UrlDecodeFailed(err)),
     };
 
-    let input_ref = match moq_inputs.find_by_url(&input_name) {
-        Ok(input_ref) => input_ref,
-        Err(error) => {
-            return Err(error);
-        }
-    };
+    let input_ref = moq_inputs.find_by_url(&input_name)?;
 
     let auth_token = url
         .query_pairs()

--- a/smelter-core/src/pipeline/moq/server.rs
+++ b/smelter-core/src/pipeline/moq/server.rs
@@ -126,13 +126,7 @@ async fn run_accept_loop(
                     "MoQ connection rejected: {}",
                     ErrorStack::new(&err).into_string()
                 );
-                let rejection_code = match err {
-                    MoqServerError::UrlNotFound | MoqServerError::UrlDecodeFailed(_) => 400,
-                    MoqServerError::PathNotFound(_) | MoqServerError::InputNotFound(_) => 404,
-                    MoqServerError::MissingToken(_) | MoqServerError::InvalidToken(_) => 401,
-                    _ => 400,
-                };
-                _ = request.close(rejection_code).await;
+                _ = request.close(err.http_status_code()).await;
                 continue;
             }
         };

--- a/smelter-core/src/pipeline/moq/server.rs
+++ b/smelter-core/src/pipeline/moq/server.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, sync::Arc, time::Duration};
 
-use hang::moq_net::OriginConsumer;
+use hang::moq_net::{OriginConsumer, OriginProducer};
 use moq_native::{
     Request, ServerConfig, ServerTlsConfig,
     moq_net::{Origin, Session},
@@ -119,17 +119,32 @@ async fn run_accept_loop(
     ctx: Arc<PipelineCtx>,
 ) {
     while let Some(request) = server.accept().await {
-        let (session, consumer, input_ref) =
-            match handle_incoming_connection(request, &moq_inputs, &ctx).await {
-                Ok(sci) => sci,
-                Err(error) => {
-                    warn!(
-                        "MoQ connection rejected: {}",
-                        ErrorStack::new(&error).into_string()
-                    );
-                    continue;
-                }
-            };
+        let (origin, input_ref) = match handle_incoming_connection(&request, &moq_inputs).await {
+            Ok(sci) => sci,
+            Err(error) => {
+                warn!(
+                    "MoQ connection rejected: {}",
+                    ErrorStack::new(&error).into_string()
+                );
+                let rejection_code = match error {
+                    MoqServerError::UrlNotFound | MoqServerError::UrlDecodeFailed(_) => 400,
+                    MoqServerError::PathNotFound(_) | MoqServerError::InputNotFound(_) => 404,
+                    MoqServerError::MissingToken(_) | MoqServerError::InvalidToken(_) => 401,
+                    _ => 400,
+                };
+                _ = request.close(rejection_code).await;
+                continue;
+            }
+        };
+        let consumer = origin.consume();
+        let session = match request.with_consume(origin).ok().await {
+            Ok(session) => MoqSession::new(session, ctx.tokio_rt.clone()),
+            Err(error) => {
+                warn!(%error, "MoQ handshake failed.");
+                continue;
+            }
+        };
+
         let moq_inputs = moq_inputs.clone();
         let ctx = ctx.clone();
 
@@ -146,13 +161,10 @@ async fn run_accept_loop(
 }
 
 async fn handle_incoming_connection(
-    request: Request,
+    request: &Request,
     moq_inputs: &MoqServerState,
-    ctx: &Arc<PipelineCtx>,
-) -> Result<(MoqSession, OriginConsumer, Ref<InputId>), MoqServerError> {
+) -> Result<(OriginProducer, Ref<InputId>), MoqServerError> {
     let Some(url) = request.url() else {
-        // This error is safe to ignore as it comes only if the connection is already dead.
-        _ = request.close(400).await;
         return Err(MoqServerError::UrlNotFound);
     };
 
@@ -160,7 +172,6 @@ async fn handle_incoming_connection(
     let input_name = match urlencoding::decode(input_name_encoded) {
         Ok(decoded) => decoded.into_owned(),
         Err(error) => {
-            _ = request.close(400).await;
             return Err(MoqServerError::UrlDecodeFailed(error));
         }
     };
@@ -168,7 +179,6 @@ async fn handle_incoming_connection(
     let input_ref = match moq_inputs.find_by_url(&input_name) {
         Ok(input_ref) => input_ref,
         Err(error) => {
-            _ = request.close(404).await;
             return Err(error);
         }
     };
@@ -179,31 +189,12 @@ async fn handle_incoming_connection(
         .map(|(_key, value)| value);
 
     let Some(auth_token) = auth_token else {
-        _ = request.close(401).await;
         return Err(MoqServerError::MissingToken(input_ref.id().clone()));
     };
-
-    if let Err(auth_error) = moq_inputs.validate_auth_token(&input_ref, &auth_token) {
-        let reject_code = match auth_error {
-            MoqServerError::InvalidToken(_) => 401,
-            MoqServerError::InputNotFound(_) => 404,
-            // Should never happen
-            _ => 400,
-        };
-        _ = request.close(reject_code).await;
-        return Err(auth_error);
-    }
+    moq_inputs.validate_auth_token(&input_ref, &auth_token)?;
 
     let origin = Origin::random().produce();
-    let consumer = origin.consume();
-    let session = match request.with_consume(origin).ok().await {
-        Ok(session) => MoqSession::new(session, ctx.tokio_rt.clone()),
-        Err(error) => {
-            return Err(MoqServerError::MoqHandshakeFailed(error));
-        }
-    };
-
-    Ok((session, consumer, input_ref))
+    Ok((origin, input_ref))
 }
 
 async fn handle_session(

--- a/smelter-core/src/pipeline/moq/server.rs
+++ b/smelter-core/src/pipeline/moq/server.rs
@@ -151,9 +151,7 @@ async fn handle_incoming_connection(
     ctx: &Arc<PipelineCtx>,
 ) -> Result<(MoqSession, OriginConsumer, Ref<InputId>), MoqServerError> {
     let Some(url) = request.url() else {
-        if let Err(error) = request.close(400).await {
-            warn!(%error, "Error while rejecting MoQ connection.");
-        }
+        reject_request(request, 400).await;
         return Err(MoqServerError::UrlNotFound);
     };
 
@@ -161,9 +159,7 @@ async fn handle_incoming_connection(
     let input_name = match urlencoding::decode(input_name_encoded) {
         Ok(decoded) => decoded.into_owned(),
         Err(error) => {
-            if let Err(error) = request.close(400).await {
-                warn!(%error, "Error while rejecting MoQ connection.");
-            }
+            reject_request(request, 400).await;
             return Err(MoqServerError::UrlDecodeFailed(error));
         }
     };
@@ -171,12 +167,31 @@ async fn handle_incoming_connection(
     let input_ref = match moq_inputs.find_by_url(&input_name) {
         Ok(input_ref) => input_ref,
         Err(error) => {
-            if let Err(error) = request.close(404).await {
-                warn!(%error, "Error while rejecting MoQ connection.");
-            }
+            reject_request(request, 404).await;
             return Err(error);
         }
     };
+
+    let auth_token = url
+        .query_pairs()
+        .find(|(key, _value)| key == "token")
+        .map(|(_key, value)| value);
+
+    let Some(auth_token) = auth_token else {
+        reject_request(request, 401).await;
+        return Err(MoqServerError::MissingToken(input_ref.id().clone()));
+    };
+
+    if let Err(auth_error) = moq_inputs.validate_auth_token(&input_ref, &auth_token) {
+        let reject_code = match auth_error {
+            MoqServerError::InvalidToken(_) => 401,
+            MoqServerError::InputNotFound(_) => 404,
+            // Should never happen
+            _ => 400,
+        };
+        reject_request(request, reject_code).await;
+        return Err(auth_error);
+    }
 
     let origin = Origin::random().produce();
     let consumer = origin.consume();
@@ -188,6 +203,12 @@ async fn handle_incoming_connection(
     };
 
     Ok((session, consumer, input_ref))
+}
+
+async fn reject_request(request: Request, code: u16) {
+    if let Err(error) = request.close(code).await {
+        warn!(%error, "Error while rejecting MoQ connection.");
+    }
 }
 
 async fn handle_session(

--- a/smelter-core/src/pipeline/moq/server.rs
+++ b/smelter-core/src/pipeline/moq/server.rs
@@ -120,7 +120,7 @@ async fn run_accept_loop(
 ) {
     while let Some(request) = server.accept().await {
         let (origin, input_ref) = match handle_incoming_connection(&request, &moq_inputs).await {
-            Ok(sci) => sci,
+            Ok(oi) => oi,
             Err(err) => {
                 warn!(
                     "MoQ connection rejected: {}",

--- a/smelter-core/src/pipeline/moq/server_input.rs
+++ b/smelter-core/src/pipeline/moq/server_input.rs
@@ -36,6 +36,7 @@ impl MoqServerInput {
             &input_ref,
             MoqInputStateOptions {
                 queue_input: queue_input.downgrade(),
+                auth_token: options.auth_token,
                 decoders: options.decoders,
             },
         )?;

--- a/smelter-core/src/pipeline/moq/state.rs
+++ b/smelter-core/src/pipeline/moq/state.rs
@@ -3,12 +3,11 @@ use std::{
     sync::{Arc, Mutex, atomic::AtomicBool},
 };
 
+use sha3::{Digest, Sha3_512};
 use tokio::task::JoinHandle;
 use tracing::error;
 
-use crate::{
-    pipeline::moq::server::MoqSession, queue::WeakQueueInput, utils::authentication::validate_token,
-};
+use crate::{pipeline::moq::server::MoqSession, queue::WeakQueueInput};
 
 use crate::prelude::*;
 
@@ -107,7 +106,9 @@ impl MoqServerState {
             input.auth_token.clone()
         };
 
-        match validate_token(&expected_token, provided_token) {
+        let expected_token_hash = Sha3_512::digest(expected_token.as_bytes());
+        let provided_token_hash = Sha3_512::digest(provided_token.as_bytes());
+        match expected_token_hash == provided_token_hash {
             true => Ok(()),
             false => Err(MoqServerError::InvalidToken(input_ref.id().clone())),
         }

--- a/smelter-core/src/pipeline/moq/state.rs
+++ b/smelter-core/src/pipeline/moq/state.rs
@@ -6,7 +6,9 @@ use std::{
 use tokio::task::JoinHandle;
 use tracing::error;
 
-use crate::{pipeline::moq::server::MoqSession, queue::WeakQueueInput};
+use crate::{
+    pipeline::moq::server::MoqSession, queue::WeakQueueInput, utils::authentication::validate_token,
+};
 
 use crate::prelude::*;
 
@@ -15,6 +17,7 @@ pub(crate) struct MoqServerState(Arc<Mutex<HashMap<Ref<InputId>, MoqInputState>>
 
 pub(crate) struct MoqInputState {
     pub queue_input: WeakQueueInput,
+    pub auth_token: Arc<str>,
     pub decoders: MoqServerInputDecoders,
     pub should_close: Arc<AtomicBool>,
     pub connection_task_handle: Option<JoinHandle<()>>,
@@ -23,6 +26,7 @@ pub(crate) struct MoqInputState {
 
 pub(crate) struct MoqInputStateOptions {
     pub queue_input: WeakQueueInput,
+    pub auth_token: Arc<str>,
     pub decoders: MoqServerInputDecoders,
 }
 
@@ -30,6 +34,7 @@ impl MoqInputState {
     fn new(options: MoqInputStateOptions) -> Self {
         Self {
             queue_input: options.queue_input,
+            auth_token: options.auth_token,
             decoders: options.decoders,
             should_close: Arc::new(false.into()),
             connection_task_handle: None,
@@ -87,6 +92,25 @@ impl MoqServerState {
             .find(|input_ref| input_ref.id().0.as_ref() == path)
             .cloned()
             .ok_or_else(|| MoqServerError::PathNotFound(Arc::from(path)))
+    }
+
+    pub(super) fn validate_auth_token(
+        &self,
+        input_ref: &Ref<InputId>,
+        provided_token: &str,
+    ) -> Result<(), MoqServerError> {
+        let expected_token = {
+            let guard = self.0.lock().unwrap();
+            let input = guard
+                .get(input_ref)
+                .ok_or(MoqServerError::InputNotFound(input_ref.id().clone()))?;
+            input.auth_token.clone()
+        };
+
+        match validate_token(&expected_token, provided_token) {
+            true => Ok(()),
+            false => Err(MoqServerError::InvalidToken(input_ref.id().clone())),
+        }
     }
 }
 

--- a/smelter-core/src/protocols/moq.rs
+++ b/smelter-core/src/protocols/moq.rs
@@ -53,3 +53,14 @@ pub enum MoqServerError {
     #[error("MoQ handshake failed: {0}")]
     MoqHandshakeFailed(#[source] anyhow::Error),
 }
+
+impl MoqServerError {
+    pub fn http_status_code(&self) -> u16 {
+        match self {
+            Self::UrlNotFound | Self::UrlDecodeFailed(_) => 400,
+            Self::PathNotFound(_) | Self::InputNotFound(_) => 404,
+            Self::MissingToken(_) | Self::InvalidToken(_) => 401,
+            _ => 400,
+        }
+    }
+}

--- a/smelter-core/src/protocols/moq.rs
+++ b/smelter-core/src/protocols/moq.rs
@@ -9,6 +9,7 @@ use crate::queue::QueueInputOptions;
 #[derive(Debug, Clone, PartialEq)]
 pub struct MoqServerInputOptions {
     pub decoders: MoqServerInputDecoders,
+    pub auth_token: Arc<str>,
     pub queue_options: QueueInputOptions,
 }
 
@@ -27,6 +28,12 @@ pub enum MoqServerError {
 
     #[error("URL path \"{0}\" not found among registered inputs.")]
     PathNotFound(Arc<str>),
+
+    #[error("Invalid authentication token for input \"{0}\"")]
+    InvalidToken(InputId),
+
+    #[error("Missing authentication token for input \"{0}\"")]
+    MissingToken(InputId),
 
     #[error("Input {0} is already registered.")]
     InputAlreadyRegistered(InputId),

--- a/tools/schemas/openapi_specification.json
+++ b/tools/schemas/openapi_specification.json
@@ -2452,7 +2452,14 @@
       },
       "MoqInputServer": {
         "type": "object",
+        "required": [
+          "auth_token"
+        ],
         "properties": {
+          "auth_token": {
+            "type": "string",
+            "description": "Token used for authentication in MoQ server input. The broadcaster must provide\nit as a `token` query parameter when connecting"
+          },
           "required": {
             "type": [
               "boolean",


### PR DESCRIPTION
- #2009

---

The user MUST provide the `auth_token` during input registration.

When connecting to the MoQ server via token must be provided as query param e.g. `https://example.com/input_name?token=<THE_PROVIDED_TOKEN>`