### PR TITLE
[gpu-video] Fix decoding video with a dynamic resolution

### DIFF
--- a/gpu-video/CHANGELOG.md
+++ b/gpu-video/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix artifacts in h264 decoder caused by unnecessary short reference deletion ([#1991](https://github.com/software-mansion/smelter/pull/1991) by @noituri)
 - `bytemuck` is now only required if compiling with the `transcoder` feature ([#1986](https://github.com/software-mansion/smelter/pull/1986) by @jerzywilczek)
 - Fix "green bar" artifact in H.264 decoder which appeared on Mesa drivers ([#2071](https://github.com/software-mansion/smelter/pull/2071) by @noituri)
+- Fix decoding video with a dynamic resolution ([#2080](https://github.com/software-mansion/smelter/pull/2080) by @noituri)
 
 ## [v0.4.0](https://github.com/software-mansion/smelter/releases/tag/gpu-video%2Fv0.4.0)
 

--- a/gpu-video/src/codec/h264/parameters.rs
+++ b/gpu-video/src/codec/h264/parameters.rs
@@ -13,20 +13,20 @@ const LOG2_MAX_FRAME_NUM: u8 = 7;
 
 pub(crate) trait SeqParameterSetExt {
     /// Macroblock-aligned frame size
-    fn coded_size(&self) -> Result<vk::Extent2D, VulkanDecoderError>;
+    fn coded_size(&self) -> vk::Extent2D;
 
     /// Frame size with frame-cropping taken into account
     fn size(&self) -> Result<vk::Extent2D, VulkanDecoderError>;
 }
 
 impl SeqParameterSetExt for SeqParameterSet {
-    fn coded_size(&self) -> Result<vk::Extent2D, VulkanDecoderError> {
+    fn coded_size(&self) -> vk::Extent2D {
         let width = (self.pic_width_in_mbs_minus1 + 1) * MACROBLOCK_SIZE;
         let height = (self.pic_height_in_map_units_minus1 + 1)
             * (2 - (self.frame_mbs_flags == FrameMbsFlags::Frames) as u32)
             * MACROBLOCK_SIZE;
 
-        Ok(vk::Extent2D { width, height })
+        vk::Extent2D { width, height }
     }
 
     #[allow(non_snake_case)]

--- a/gpu-video/src/vulkan_decoder.rs
+++ b/gpu-video/src/vulkan_decoder.rs
@@ -350,7 +350,6 @@ impl<'a> VulkanDecoder<'a> {
             )))?;
 
         let cropped_extent = sps.size()?;
-        let coded_extent = sps.coded_size()?;
         let color_space = ColorSpace::from(sps);
         let color_range = ColorRange::from(sps);
 
@@ -359,11 +358,8 @@ impl<'a> VulkanDecoder<'a> {
                 &self.decoding_device,
                 self.tracker.command_buffer_pools.decode.begin_buffer()?,
                 &mut self.tracker,
+                sps.coded_size(),
             )?;
-            // TODO: Will this be safe if we start decoding without CPU wait?
-            video_session_resources
-                .decoding_images
-                .update_coded_extent(coded_extent)?;
         }
 
         // upload data to a buffer

--- a/gpu-video/src/vulkan_decoder.rs
+++ b/gpu-video/src/vulkan_decoder.rs
@@ -350,6 +350,7 @@ impl<'a> VulkanDecoder<'a> {
             )))?;
 
         let cropped_extent = sps.size()?;
+        let coded_extent = sps.coded_size()?;
         let color_space = ColorSpace::from(sps);
         let color_range = ColorRange::from(sps);
 
@@ -359,6 +360,10 @@ impl<'a> VulkanDecoder<'a> {
                 self.tracker.command_buffer_pools.decode.begin_buffer()?,
                 &mut self.tracker,
             )?;
+            // TODO: Will this be safe if we start decoding without CPU wait?
+            video_session_resources
+                .decoding_images
+                .update_coded_extent(coded_extent)?;
         }
 
         // upload data to a buffer

--- a/gpu-video/src/vulkan_decoder/session_resources.rs
+++ b/gpu-video/src/vulkan_decoder/session_resources.rs
@@ -86,7 +86,7 @@ impl<'a> VideoSessionResources<'a> {
             )));
         }
 
-        let max_coded_extent = sps.coded_size()?;
+        let max_coded_extent = sps.coded_size();
         // +1 for current frame
         let max_dpb_slots = sps.max_num_ref_frames + 1;
         let max_active_references = sps.max_num_ref_frames;
@@ -166,7 +166,7 @@ impl<'a> VideoSessionResources<'a> {
         usage_info: vk::VideoDecodeUsageInfoKHR<'a>,
     ) -> Result<(), VulkanDecoderError> {
         let new_session_params = SessionParams {
-            max_coded_extent: sps.coded_size()?,
+            max_coded_extent: sps.coded_size(),
             max_dpb_slots: sps.max_num_ref_frames + 1, // +1 for current frame
             max_active_references: sps.max_num_ref_frames,
             max_num_reorder_frames: calculate_max_num_reorder_frames(&sps)?,
@@ -203,17 +203,31 @@ impl<'a> VideoSessionResources<'a> {
         decoding_device: &DecodingDevice,
         decode_buffer: OpenCommandBuffer,
         tracker: &mut DecoderTracker,
+        picture_coded_extent: vk::Extent2D,
     ) -> Result<(), VulkanDecoderError> {
-        let Some(new_params) = self.parameters_scheduled_for_reset.take() else {
-            return Ok(());
+        if let Some(new_params) = self.parameters_scheduled_for_reset.take() {
+            if self.parameters.is_valid(&new_params) {
+                // no need to change the session
+                self.parameters.max_num_reorder_frames = new_params.max_num_reorder_frames;
+            } else {
+                self.recreate_session(new_params, decoding_device, decode_buffer, tracker)?;
+            }
         };
 
-        if self.parameters.is_valid(&new_params) {
-            // no need to change the session
-            self.parameters.max_num_reorder_frames = new_params.max_num_reorder_frames;
-            return Ok(());
-        }
+        // The active SPS can have coded_extent smaller than max_coded_extent
+        self.decoding_images
+            .update_coded_extent(picture_coded_extent)?;
 
+        Ok(())
+    }
+
+    fn recreate_session(
+        &mut self,
+        params: SessionParams<'a>,
+        decoding_device: &DecodingDevice,
+        decode_buffer: OpenCommandBuffer,
+        tracker: &mut DecoderTracker,
+    ) -> Result<(), VulkanDecoderError> {
         let max_level_idc = vk_to_h264_level_idc(
             decoding_device
                 .profile_capabilities
@@ -221,37 +235,37 @@ impl<'a> VideoSessionResources<'a> {
                 .max_level_idc,
         )?;
 
-        if new_params.level_idc > max_level_idc {
+        if params.level_idc > max_level_idc {
             return Err(VulkanDecoderError::InvalidInputData(format!(
                 "stream has level_idc = {}, while the GPU can decode at most {}",
-                new_params.level_idc, max_level_idc
+                params.level_idc, max_level_idc
             )));
         }
 
-        if self.parameters.profile_info != new_params.profile_info {
+        if self.parameters.profile_info != params.profile_info {
             self.decode_query_pool = match decoding_device
                 .h264_decode_queues
                 .supports_result_status_queries()
             {
                 true => Some(Arc::new(DecodingQueryPool::new(
                     decoding_device.vulkan_device.device.clone(),
-                    new_params.profile_info.profile_info.profile_info,
+                    params.profile_info.profile_info.profile_info,
                 )?)),
                 false => None,
             };
             self.decode_buffer_pool = DecodeInputBufferPool::new(
                 decoding_device.allocator.clone(),
-                new_params.profile_info.clone(),
+                params.profile_info.clone(),
             );
         }
 
         self.video_session = Arc::new(VideoSession::new(
             &decoding_device.vulkan_device,
             &decoding_device.h264_decode_queues,
-            &new_params.profile_info.profile_info.profile_info,
-            new_params.max_coded_extent,
-            new_params.max_dpb_slots,
-            new_params.max_active_references,
+            &params.profile_info.profile_info.profile_info,
+            params.max_coded_extent,
+            params.max_dpb_slots,
+            params.max_active_references,
             vk::VideoSessionCreateFlagsKHR::empty(),
             &decoding_device
                 .profile_capabilities
@@ -264,7 +278,7 @@ impl<'a> VideoSessionResources<'a> {
 
         self.decoding_images = Self::new_decoding_images(
             decoding_device,
-            &new_params.profile_info,
+            &params.profile_info,
             self.video_session.max_coded_extent,
             self.video_session.max_dpb_slots,
             decode_buffer,
@@ -272,7 +286,7 @@ impl<'a> VideoSessionResources<'a> {
             self.image_modifiers,
         )?;
 
-        self.parameters = new_params;
+        self.parameters = params;
 
         Ok(())
     }

--- a/gpu-video/src/vulkan_decoder/session_resources/images.rs
+++ b/gpu-video/src/vulkan_decoder/session_resources/images.rs
@@ -50,7 +50,7 @@ impl<'a> DecodingImages<'a> {
         profile: &H264DecodeProfileInfo,
         dpb_format: &vk::VideoFormatPropertiesKHR<'a>,
         dst_format: &Option<vk::VideoFormatPropertiesKHR<'a>>,
-        dimensions: vk::Extent2D,
+        max_coded_extent: vk::Extent2D,
         max_dpb_slots: u32,
         additional_queue_index: u32,
     ) -> Result<Self, VulkanDecoderError> {
@@ -77,7 +77,7 @@ impl<'a> DecodingImages<'a> {
             &profile.profile_info.profile_info,
             dpb_image_usage,
             dpb_format,
-            dimensions,
+            max_coded_extent,
             max_dpb_slots,
             if dst_format.is_some() {
                 None
@@ -98,7 +98,7 @@ impl<'a> DecodingImages<'a> {
                     command_buffer,
                     image_tracker,
                     &dst_format,
-                    dimensions,
+                    max_coded_extent,
                     dst_image_usage,
                     false,
                     &profile.profile_info.profile_info,

--- a/gpu-video/src/vulkan_decoder/session_resources/images.rs
+++ b/gpu-video/src/vulkan_decoder/session_resources/images.rs
@@ -137,6 +137,18 @@ impl<'a> DecodingImages<'a> {
         self.dpb.video_resource_info(i)
     }
 
+    pub(crate) fn update_coded_extent(
+        &mut self,
+        coded_extent: vk::Extent2D,
+    ) -> Result<(), VulkanDecoderError> {
+        self.dpb.update_coded_extent(coded_extent)?;
+        if let Some(dst) = &mut self.dst_image {
+            dst.update_coded_extent(coded_extent)?;
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn free_reference_picture(&mut self, i: usize) {
         self.dpb.free_reference_picture(i);
     }

--- a/gpu-video/src/vulkan_video.rs
+++ b/gpu-video/src/vulkan_video.rs
@@ -205,6 +205,14 @@ pub enum VulkanCommonError {
 
     #[error("Unsupported image aspect: {0:?}")]
     UnsupportedImageAspect(vk::ImageAspectFlags),
+
+    #[error(
+        "The reference image is smaller than the requested extent. Requested: {requested:?}, max allowed: {max_extent:?}"
+    )]
+    ReferenceImageTooSmall {
+        requested: vk::Extent2D,
+        max_extent: vk::Extent2D,
+    },
 }
 
 /// Open connection to a coding-capable device

--- a/gpu-video/src/wrappers/video.rs
+++ b/gpu-video/src/wrappers/video.rs
@@ -513,6 +513,28 @@ impl<'a> CodingImageBundle<'a> {
     pub(crate) fn extent(&self) -> vk::Extent3D {
         self.image_with_view.extent()
     }
+
+    pub(crate) fn update_coded_extent(
+        &mut self,
+        coded_extent: vk::Extent2D,
+    ) -> Result<(), VulkanCommonError> {
+        let max_extent = self.extent();
+        if coded_extent.width > max_extent.width || coded_extent.height > max_extent.height {
+            return Err(VulkanCommonError::ReferenceImageTooSmall {
+                requested: coded_extent,
+                max_extent: vk::Extent2D {
+                    width: max_extent.width,
+                    height: max_extent.height,
+                },
+            });
+        }
+
+        for info in &mut self.video_resource_info {
+            info.coded_extent = coded_extent;
+        }
+
+        Ok(())
+    }
 }
 
 pub(crate) struct DecodedPicturesBuffer<'a> {
@@ -591,6 +613,13 @@ impl<'a> DecodedPicturesBuffer<'a> {
         i: usize,
     ) -> Option<&vk::VideoPictureResourceInfoKHR<'_>> {
         self.image.video_resource_info.get(i)
+    }
+
+    pub(crate) fn update_coded_extent(
+        &mut self,
+        coded_extent: vk::Extent2D,
+    ) -> Result<(), VulkanCommonError> {
+        self.image.update_coded_extent(coded_extent)
     }
 
     #[inline(always)]

--- a/gpu-video/src/wrappers/video.rs
+++ b/gpu-video/src/wrappers/video.rs
@@ -340,7 +340,7 @@ impl<'a> CodingImageBundle<'a> {
         command_buffer: &mut OpenCommandBuffer,
         image_tracker: Arc<Mutex<ImageLayoutTracker>>,
         format: &vk::VideoFormatPropertiesKHR<'a>,
-        dimensions: vk::Extent2D,
+        max_coded_extent: vk::Extent2D,
         image_usage: vk::ImageUsageFlags,
         use_separate_images: bool,
         profile_info: &vk::VideoProfileInfoKHR,
@@ -356,8 +356,8 @@ impl<'a> CodingImageBundle<'a> {
             .image_type(format.image_type)
             .format(format.format)
             .extent(vk::Extent3D {
-                width: dimensions.width,
-                height: dimensions.height,
+                width: max_coded_extent.width,
+                height: max_coded_extent.height,
                 depth: 1,
             })
             .mip_levels(1)
@@ -498,7 +498,7 @@ impl<'a> CodingImageBundle<'a> {
             .map(|i| {
                 vk::VideoPictureResourceInfoKHR::default()
                     .coded_offset(vk::Offset2D { x: 0, y: 0 })
-                    .coded_extent(dimensions)
+                    .coded_extent(max_coded_extent)
                     .base_array_layer(image_with_view.base_array_layer(i))
                     .image_view_binding(image_with_view.image_view(i).view)
             })


### PR DESCRIPTION
This was only an issue on my integrated AMD GPU, discrete AMD GPU had no problems with decoding this.

If new SPS changes resolution to a smaller one, we don't recreate DPB which causes the video resource info to contain larger `coded_extent`. So now when an IDR frame is decoded, the correct `coded_extent` is set for the current SPS.