### PR TITLE
[gpu-video] Make `VideoInstance` and `VideoAdapter` backend agnostic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ smelter-api = { path = "smelter-api" }
 smelter-core = { path = "smelter-core" }
 smelter-render = { path = "smelter-render" }
 libcef = { path = "libcef" }
-gpu-video = { path = "gpu-video", features = ["expose-parsers"] }
+gpu-video = { path = "gpu-video", features = ["expose-parsers", "expose-backends"] }
 rtmp = { path = "rtmp" }
 bytes = "1.11.1"
 serde_json = { version = "1.0.99", features = ["preserve_order"] }

--- a/gpu-video/Cargo.toml
+++ b/gpu-video/Cargo.toml
@@ -21,6 +21,7 @@ keywords = ["vulkan", "video", "wgpu", "decoding", "encoding"]
 
 [features]
 expose-parsers = []
+expose-backends = []
 wgpu = ["dep:wgpu"]
 transcoder = ["dep:naga", "dep:bytemuck"]
 default = ["wgpu"]

--- a/gpu-video/src/adapter.rs
+++ b/gpu-video/src/adapter.rs
@@ -1,19 +1,9 @@
-use ash::vk;
-use std::{
-    ffi::CStr,
-    fmt::{self, Debug},
-};
-use tracing::{debug, debug_span, warn};
+use std::fmt::{self, Debug};
 
 use crate::{
-    VideoInitError, VideoInstance,
+    VideoDeviceInitError,
     capabilities::EncodeCapabilities,
-    device::{
-        DECODE_CODEC_EXTENSIONS, DECODE_EXTENSIONS, ENCODE_CODEC_EXTENSIONS, ENCODE_EXTENSIONS,
-        REQUIRED_EXTENSIONS, VideoDevice, VideoDeviceDescriptor,
-        caps::{DecodeCapabilities, NativeDecodeCapabilities, NativeEncodeCapabilities},
-        queues::{QueueIndex, QueueIndices},
-    },
+    device::{VideoDeviceDescriptor, caps::DecodeCapabilities},
 };
 
 #[cfg(feature = "wgpu")]
@@ -21,299 +11,54 @@ mod wgpu_api;
 #[cfg(feature = "wgpu")]
 pub use wgpu_api::*;
 
+pub(crate) trait VideoAdapterBackend {
+    fn build_info(&self) -> VideoAdapterInfo;
+
+    fn create_device(
+        self: Box<Self>,
+        desc: &VideoDeviceDescriptor,
+    ) -> Result<crate::VideoDevice, VideoDeviceInitError>;
+}
+
 /// Represents a handle to a physical device.
 /// Can be used to create [`VideoDevice`](crate::VideoDevice).
 pub struct VideoAdapter<'a> {
-    pub(crate) instance: &'a VideoInstance,
-    pub(crate) physical_device: vk::PhysicalDevice,
-    pub(crate) queue_indices: QueueIndices<'static>,
-    pub(crate) decode_capabilities: Option<NativeDecodeCapabilities>,
-    pub(crate) encode_capabilities: Option<NativeEncodeCapabilities>,
-    pub(crate) info: VideoAdapterInfo,
+    adapter: Box<dyn VideoAdapterBackend + 'a>,
+    adapter_info: VideoAdapterInfo,
 }
 
 impl<'a> VideoAdapter<'a> {
-    fn new(vulkan_instance: &'a VideoInstance, device: vk::PhysicalDevice) -> Option<Self> {
-        let instance = &vulkan_instance.instance;
-        let properties = unsafe { instance.get_physical_device_properties(device) };
-        let device_name = properties
-            .device_name_as_c_str()
-            .map(CStr::to_string_lossy)
-            .unwrap_or("unknown".into());
-
-        let _span = debug_span!("creating adapter", device_name = %device_name).entered();
-
-        let mut vk_13_features = vk::PhysicalDeviceVulkan13Features::default();
-        let mut features = vk::PhysicalDeviceFeatures2::default().push_next(&mut vk_13_features);
-
-        unsafe { instance.get_physical_device_features2(device, &mut features) };
-        let extensions = match unsafe { instance.enumerate_device_extension_properties(device) } {
-            Ok(ext) => ext,
-            Err(err) => {
-                warn!("Couldn't enumerate device extension properties: {err}");
-                return None;
-            }
-        };
-
-        if vk_13_features.synchronization2 == vk::FALSE {
-            debug!("device does not support the required synchronization2 feature");
-            return None;
+    pub(crate) fn from_backend(backend: impl VideoAdapterBackend + 'a) -> Self {
+        let adapter_info = backend.build_info();
+        Self {
+            adapter: Box::new(backend),
+            adapter_info,
         }
+    }
 
-        if let Err(missing) = check_extensions(REQUIRED_EXTENSIONS, &extensions) {
-            debug!(missing_extensions = ?missing, "device is missing some required extensions",);
-            return None;
-        }
-
-        let has_decode_extensions = check_extensions(DECODE_EXTENSIONS, &extensions).is_ok();
-        let supported_decode_codec_extensions =
-            supported_extensions(DECODE_CODEC_EXTENSIONS, &extensions);
-        let supports_any_decoding =
-            has_decode_extensions && !supported_decode_codec_extensions.is_empty();
-        let supported_decode_operations =
-            extensions_to_codec_operations(&supported_decode_codec_extensions);
-
-        let has_encode_extensions = check_extensions(ENCODE_EXTENSIONS, &extensions).is_ok();
-        let supported_encode_codec_extensions =
-            supported_extensions(ENCODE_CODEC_EXTENSIONS, &extensions);
-        let supports_any_encoding =
-            has_encode_extensions && !supported_encode_codec_extensions.is_empty();
-        let supported_encode_operations =
-            extensions_to_codec_operations(&supported_encode_codec_extensions);
-
-        if !supports_any_decoding && !supports_any_encoding {
-            debug!("device does not support encoding or decoding extensions");
-            return None;
-        }
-
-        let queues_len =
-            unsafe { instance.get_physical_device_queue_family_properties2_len(device) };
-        let mut queues = vec![vk::QueueFamilyProperties2::default(); queues_len];
-        let mut video_properties = vec![vk::QueueFamilyVideoPropertiesKHR::default(); queues_len];
-        let mut query_result_status_properties =
-            vec![vk::QueueFamilyQueryResultStatusPropertiesKHR::default(); queues_len];
-
-        for ((queue, video_properties), query_result_properties) in queues
-            .iter_mut()
-            .zip(video_properties.iter_mut())
-            .zip(query_result_status_properties.iter_mut())
-        {
-            *queue = queue
-                .push_next(query_result_properties)
-                .push_next(video_properties);
-        }
-
-        unsafe { instance.get_physical_device_queue_family_properties2(device, &mut queues) };
-
-        let decode_capabilities =
-            NativeDecodeCapabilities::query(instance, device, supported_decode_operations);
-        let encode_capabilities =
-            NativeEncodeCapabilities::query(instance, device, supported_encode_operations);
-
-        let queue_counts = queues
-            .iter()
-            .map(|q| q.queue_family_properties.queue_count)
-            .collect::<Vec<_>>();
-
-        let transfer_queue_idx = queues
-            .iter()
-            .enumerate()
-            .find(|(_, q)| {
-                q.queue_family_properties
-                    .queue_flags
-                    .contains(vk::QueueFlags::TRANSFER)
-                    && !q
-                        .queue_family_properties
-                        .queue_flags
-                        .intersects(vk::QueueFlags::GRAPHICS)
-            })
-            .map(|(i, _)| i)?;
-
-        let compute_queue_idx = queues
-            .iter()
-            .enumerate()
-            .find(|(_, q)| {
-                q.queue_family_properties
-                    .queue_flags
-                    .contains(vk::QueueFlags::COMPUTE)
-                    && !q
-                        .queue_family_properties
-                        .queue_flags
-                        .intersects(vk::QueueFlags::GRAPHICS)
-            })
-            .map(|(i, _)| i)?;
-
-        let graphics_transfer_compute_queue_idx = queues
-            .iter()
-            .enumerate()
-            .find(|(_, q)| {
-                q.queue_family_properties.queue_flags.contains(
-                    vk::QueueFlags::GRAPHICS | vk::QueueFlags::TRANSFER | vk::QueueFlags::COMPUTE,
-                )
-            })
-            .map(|(i, _)| i)?;
-
-        let decode_queue_idx = match supports_any_decoding {
-            true => find_video_queue_idx(
-                &queues,
-                vk::QueueFlags::VIDEO_DECODE_KHR,
-                // TODO: for now, we only look for a single queue that supports all decoding
-                supported_decode_operations,
-            ),
-            false => None,
-        };
-        let encode_queue_idx = match supports_any_encoding {
-            true => find_video_queue_idx(
-                &queues,
-                vk::QueueFlags::VIDEO_ENCODE_KHR,
-                // TODO: for now, we only look for a single queue that supports all encoding
-                supported_encode_operations,
-            ),
-            false => None,
-        };
-
-        if decode_queue_idx.is_none() && encode_queue_idx.is_none() {
-            debug!("device does not have any queues that support video operations");
-            return None;
-        }
-
-        debug!("decode capabilities: {decode_capabilities:#?}");
-        debug!("encode capabilities: {encode_capabilities:#?}");
-
-        let (driver_name, driver_info) = match properties.api_version >= vk::API_VERSION_1_2 {
-            true => {
-                let mut driver_properties = vk::PhysicalDeviceDriverProperties::default();
-                let mut properties2 =
-                    vk::PhysicalDeviceProperties2::default().push_next(&mut driver_properties);
-                unsafe {
-                    instance.get_physical_device_properties2(device, &mut properties2);
-                }
-
-                let driver_name = driver_properties
-                    .driver_name_as_c_str()
-                    .map(CStr::to_string_lossy)
-                    .unwrap_or("unknown".into())
-                    .into_owned();
-                let driver_info = driver_properties
-                    .driver_info_as_c_str()
-                    .map(CStr::to_string_lossy)
-                    .unwrap_or_default()
-                    .into_owned();
-                (driver_name, driver_info)
-            }
-            false => ("unknown".to_owned(), "".to_owned()),
-        };
-
-        let info = VideoAdapterInfo {
-            name: device_name.into_owned(),
-            driver_name,
-            driver_info,
-            device_type: properties.device_type,
-            device_properties: properties,
-            supports_decoding: decode_queue_idx.is_some(),
-            supports_encoding: encode_queue_idx.is_some(),
-            decode_capabilities: decode_capabilities.user_facing(),
-            encode_capabilities: encode_capabilities.user_facing(),
-        };
-
-        Some(Self {
-            instance: vulkan_instance,
-            physical_device: device,
-            queue_indices: QueueIndices {
-                transfer: QueueIndex {
-                    family_index: transfer_queue_idx,
-                    queue_count: queue_counts[transfer_queue_idx] as usize,
-                    video_properties: video_properties[transfer_queue_idx],
-                    query_result_status_properties: query_result_status_properties
-                        [transfer_queue_idx],
-                },
-                compute: QueueIndex {
-                    family_index: compute_queue_idx,
-                    queue_count: queue_counts[compute_queue_idx] as usize,
-                    video_properties: video_properties[compute_queue_idx],
-                    query_result_status_properties: query_result_status_properties
-                        [compute_queue_idx],
-                },
-                h264_decode: decode_queue_idx.map(|idx| QueueIndex {
-                    family_index: idx,
-                    queue_count: queue_counts[idx] as usize,
-                    video_properties: video_properties[idx],
-                    query_result_status_properties: query_result_status_properties[idx],
-                }),
-                encode: encode_queue_idx.map(|idx| QueueIndex {
-                    family_index: idx,
-                    queue_count: queue_counts[idx] as usize,
-                    video_properties: video_properties[idx],
-                    query_result_status_properties: query_result_status_properties[idx],
-                }),
-                graphics_transfer_compute: QueueIndex {
-                    family_index: graphics_transfer_compute_queue_idx,
-                    queue_count: 1, // Currently we can only handle 1 queue
-                    video_properties: video_properties[graphics_transfer_compute_queue_idx],
-                    query_result_status_properties: query_result_status_properties
-                        [graphics_transfer_compute_queue_idx],
-                },
-            },
-            decode_capabilities: if supports_any_decoding {
-                Some(decode_capabilities)
-            } else {
-                None
-            },
-            encode_capabilities: if supports_any_encoding {
-                Some(encode_capabilities)
-            } else {
-                None
-            },
-            info,
-        })
+    pub fn info(&self) -> &VideoAdapterInfo {
+        &self.adapter_info
     }
 
     pub fn supports_decoding(&self) -> bool {
-        self.info.supports_decoding
+        self.adapter_info.supports_decoding
     }
 
     pub fn supports_encoding(&self) -> bool {
-        self.info.supports_encoding
+        self.adapter_info.supports_encoding
     }
 
     pub fn create_device(
         self,
         desc: &VideoDeviceDescriptor,
-    ) -> Result<crate::VideoDevice, VideoInitError> {
-        VideoDevice::create_and_register(self, desc.clone())
-    }
-
-    pub fn info(&self) -> &VideoAdapterInfo {
-        &self.info
-    }
-
-    pub(crate) fn required_extensions(&self) -> Vec<&'static CStr> {
-        REQUIRED_EXTENSIONS
-            .iter()
-            .copied()
-            .chain(match self.supports_decoding() {
-                true => DECODE_EXTENSIONS.iter().copied(),
-                false => [].iter().copied(),
-            })
-            .chain(match self.supports_decoding() {
-                true => DECODE_CODEC_EXTENSIONS.iter().copied(),
-                false => [].iter().copied(),
-            })
-            .chain(match self.supports_encoding() {
-                true => ENCODE_EXTENSIONS.iter().copied(),
-                false => [].iter().copied(),
-            })
-            .chain(match self.supports_encoding() {
-                true => ENCODE_CODEC_EXTENSIONS.iter().copied(),
-                false => [].iter().copied(),
-            })
-            .collect::<Vec<_>>()
+    ) -> Result<crate::VideoDevice, VideoDeviceInitError> {
+        self.adapter.create_device(desc)
     }
 }
 
 // TODO: maybe there should be a way of specifying power preference / device preference (like wgpu)
 /// Describes a [`VideoAdapter`].
-/// Used by [`VideoInstance::create_adapter`]
+/// Used by [`VideoInstance::create_adapter`](crate::VideoInstance::create_adapter)
 pub struct VideoAdapterDescriptor {
     pub supports_decoding: bool,
     pub supports_encoding: bool,
@@ -328,173 +73,42 @@ impl Default for VideoAdapterDescriptor {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DeviceType {
+    Other,
+    IntegratedGpu,
+    DiscreteGpu,
+    VirtualGpu,
+    Cpu,
+}
+
 #[derive(Clone)]
 pub struct VideoAdapterInfo {
     pub name: String,
     pub driver_name: String,
     pub driver_info: String,
-    pub device_type: vk::PhysicalDeviceType,
+    pub device: String,
+    pub device_type: DeviceType,
+    pub vendor: String,
+    pub api_version: String,
     pub supports_decoding: bool,
     pub supports_encoding: bool,
-    pub device_properties: vk::PhysicalDeviceProperties,
     pub decode_capabilities: DecodeCapabilities,
     pub encode_capabilities: EncodeCapabilities,
 }
 
 impl Debug for VideoAdapterInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        let version = {
-            let version = self.device_properties.api_version;
-            let major = vk::api_version_major(version);
-            let minor = vk::api_version_minor(version);
-            let patch = vk::api_version_patch(version);
-
-            format!("{major}.{minor}.{patch}")
-        };
         f.debug_struct("AdapterInfo")
             .field("name", &self.name)
             .field("device_type", &self.device_type)
-            .field("api_version", &version)
+            .field("api_version", &self.api_version)
             .field("driver", &self.driver_name)
             .field("driver_info", &self.driver_info)
-            .field("vendor", &self.device_properties.vendor_id)
-            .field("device", &self.device_properties.device_id)
+            .field("vendor", &self.vendor)
+            .field("device", &self.device)
             .field("supports_decoding", &self.supports_decoding)
             .field("supports_encoding", &self.supports_encoding)
             .finish()
     }
-}
-
-/// This macro will iterate over the `p_next` chain of the base struct until it finds a struct,
-/// which matches the given type. After that it will execute the given action on the found struct.
-///
-/// # Example
-/// ```ignore
-/// unsafe {
-///     find_ext!(queue_family_properties, found_extension @ ash::vk::QueueFamilyVideoPropertiesKHR => {
-///         dbg!(found_extension)
-///     });
-/// }
-/// ```
-#[cfg_attr(doctest, macro_export)]
-macro_rules! find_ext {
-    ($base:expr, $var:ident @ $ext:ty => $action:stmt) => {
-        let mut next = $base.p_next.cast::<ash::vk::BaseOutStructure>();
-        while !next.is_null() {
-            ash::match_out_struct!(match next {
-                $var @ $ext => {
-                    $action
-                    break;
-                }
-            });
-
-            next = (*next).p_next;
-        }
-    };
-}
-
-pub(crate) fn iter_adapters<'a>(
-    vulkan_instance: &'a VideoInstance,
-) -> Result<impl Iterator<Item = VideoAdapter<'a>> + 'a, VideoInitError> {
-    let physical_devices = unsafe { vulkan_instance.instance.enumerate_physical_devices()? };
-    Ok(physical_devices
-        .into_iter()
-        .filter_map(move |device| VideoAdapter::new(vulkan_instance, device)))
-}
-
-/// Returns the list of missing extensions
-fn check_extensions<'a>(
-    required_extensions: &'a [&'a CStr],
-    available_extensions: &'a [vk::ExtensionProperties],
-) -> Result<(), Vec<&'a CStr>> {
-    let missing = required_extensions
-        .iter()
-        .copied()
-        .filter(|&required_name| {
-            !available_extensions.iter().any(|ext| {
-                let Ok(name) = ext.extension_name_as_c_str() else {
-                    return false;
-                };
-
-                name == required_name
-            })
-        })
-        .collect::<Vec<_>>();
-
-    if !missing.is_empty() {
-        return Err(missing);
-    }
-
-    Ok(())
-}
-
-fn supported_extensions<'a>(
-    required_extensions: &'a [&'a CStr],
-    available_extensions: &'a [vk::ExtensionProperties],
-) -> Vec<&'a CStr> {
-    required_extensions
-        .iter()
-        .copied()
-        .filter(|&required_name| {
-            available_extensions.iter().any(|ext| {
-                let Ok(name) = ext.extension_name_as_c_str() else {
-                    return false;
-                };
-
-                name == required_name
-            })
-        })
-        .collect()
-}
-
-fn extensions_to_codec_operations(extensions: &[&CStr]) -> vk::VideoCodecOperationFlagsKHR {
-    extensions
-        .iter()
-        .copied()
-        .fold(vk::VideoCodecOperationFlagsKHR::empty(), |acc, ext| {
-            acc | match ext {
-                name if name == vk::KHR_VIDEO_ENCODE_H264_NAME => {
-                    vk::VideoCodecOperationFlagsKHR::ENCODE_H264
-                }
-                name if name == vk::KHR_VIDEO_ENCODE_H265_NAME => {
-                    vk::VideoCodecOperationFlagsKHR::ENCODE_H265
-                }
-                name if name == vk::KHR_VIDEO_DECODE_H264_NAME => {
-                    vk::VideoCodecOperationFlagsKHR::DECODE_H264
-                }
-                name if name == vk::KHR_VIDEO_DECODE_H265_NAME => {
-                    vk::VideoCodecOperationFlagsKHR::DECODE_H265
-                }
-                _ => vk::VideoCodecOperationFlagsKHR::empty(),
-            }
-        })
-}
-
-fn find_video_queue_idx(
-    queues: &[vk::QueueFamilyProperties2<'_>],
-    queue_flag: vk::QueueFlags,
-    video_codec_operation: vk::VideoCodecOperationFlagsKHR,
-) -> Option<usize> {
-    for (i, queue) in queues.iter().enumerate() {
-        if !queue
-            .queue_family_properties
-            .queue_flags
-            .contains(queue_flag)
-        {
-            continue;
-        }
-
-        unsafe {
-            find_ext!(queue, video_properties @ vk::QueueFamilyVideoPropertiesKHR =>
-                if video_properties
-                    .video_codec_operations
-                    .contains(video_codec_operation)
-                {
-                    return Some(i);
-                }
-            );
-        }
-    }
-
-    None
 }

--- a/gpu-video/src/adapter/wgpu_api.rs
+++ b/gpu-video/src/adapter/wgpu_api.rs
@@ -1,8 +1,11 @@
 use crate::{
-    VideoAdapter, VideoInitError, VideoInstance,
-    adapter::VideoAdapterInfo,
+    VideoDeviceInitError,
+    adapter::{VideoAdapterBackend, VideoAdapterInfo},
     device::{VideoDevice, VideoDeviceDescriptor},
 };
+
+#[cfg(vulkan)]
+use crate::backends::vulkan::vulkan_adapter::with_video_adapter_from_wgpu;
 
 /// [`wgpu::Adapter`] extension that exposes video capabilities of an adapter.
 pub trait VideoAdapterExt {
@@ -15,45 +18,21 @@ pub trait VideoAdapterExt {
     fn request_device_with_video_support(
         &self,
         desc: &VideoDeviceDescriptor,
-    ) -> Result<(wgpu::Device, wgpu::Queue), VideoInitError>;
+    ) -> Result<(wgpu::Device, wgpu::Queue), VideoDeviceInitError>;
 }
 
 impl VideoAdapterExt for wgpu::Adapter {
     fn video_adapter_info(&self) -> Option<VideoAdapterInfo> {
-        with_video_adapter_from_wgpu(self, |adapter| adapter.info)
+        with_video_adapter_from_wgpu(self, |adapter| adapter.build_info())
     }
 
     fn request_device_with_video_support(
         &self,
         desc: &VideoDeviceDescriptor,
-    ) -> Result<(wgpu::Device, wgpu::Queue), VideoInitError> {
+    ) -> Result<(wgpu::Device, wgpu::Queue), VideoDeviceInitError> {
         with_video_adapter_from_wgpu(self, |adapter| {
-            VideoDevice::create_and_register_wgpu(self, adapter, desc.clone())
+            VideoDevice::create_and_register_wgpu(self, adapter, desc.clone()).map_err(Into::into)
         })
-        .ok_or(VideoInitError::NoDevice)?
+        .ok_or(VideoDeviceInitError::NotSuitableAdapter)?
     }
-}
-
-#[cfg(vulkan)]
-fn with_video_adapter_from_wgpu<F, R>(wgpu_adapter: &wgpu::Adapter, use_adapter: F) -> Option<R>
-where
-    F: Fn(VideoAdapter<'_>) -> R,
-{
-    use crate::instance::VideoInstanceDescriptor;
-    use ash::vk;
-    use wgpu::hal::vulkan::Api as VkApi;
-
-    let hal_adapter = unsafe { wgpu_adapter.as_hal::<VkApi>()? };
-    let physical_device = hal_adapter.raw_physical_device();
-    let instance = hal_adapter.shared_instance();
-    let instance = VideoInstance::new_unowned(
-        instance.raw_instance().clone(),
-        instance.entry().clone(),
-        &VideoInstanceDescriptor {
-            enable_validations: instance.extensions().contains(&vk::EXT_DEBUG_UTILS_NAME),
-            ..Default::default()
-        },
-    );
-
-    VideoAdapter::new(&instance, physical_device).map(use_adapter)
 }

--- a/gpu-video/src/backends.rs
+++ b/gpu-video/src/backends.rs
@@ -1,0 +1,2 @@
+#[cfg(vulkan)]
+pub mod vulkan;

--- a/gpu-video/src/backends/vulkan.rs
+++ b/gpu-video/src/backends/vulkan.rs
@@ -1,0 +1,5 @@
+pub(crate) mod vulkan_adapter;
+pub(crate) mod vulkan_instance;
+
+pub use vulkan_adapter::{VulkanAdapter, VulkanAdapterInfo, VulkanAdapterInitError};
+pub use vulkan_instance::{VulkanInstance, VulkanInstanceInitError};

--- a/gpu-video/src/backends/vulkan/vulkan_adapter.rs
+++ b/gpu-video/src/backends/vulkan/vulkan_adapter.rs
@@ -1,0 +1,509 @@
+use ash::vk;
+use std::ffi::CStr;
+use tracing::{debug, debug_span, warn};
+
+use crate::{
+    VideoDeviceInitError,
+    adapter::{DeviceType, VideoAdapterBackend, VideoAdapterInfo},
+    backends::vulkan::vulkan_instance::VulkanInstance,
+    capabilities::{DecodeCapabilities, EncodeCapabilities},
+    device::{
+        DECODE_CODEC_EXTENSIONS, DECODE_EXTENSIONS, ENCODE_CODEC_EXTENSIONS, ENCODE_EXTENSIONS,
+        REQUIRED_EXTENSIONS, VideoDevice, VideoDeviceDescriptor,
+        caps::{NativeDecodeCapabilities, NativeEncodeCapabilities},
+        queues::{QueueIndex, QueueIndices},
+    },
+};
+
+#[cfg(feature = "wgpu")]
+mod wgpu_api;
+#[cfg(feature = "wgpu")]
+pub(crate) use wgpu_api::*;
+
+/// Represents a handle to a physical device.
+/// Can be used to create [`VideoDevice`](crate::VideoDevice).
+pub struct VulkanAdapter<'a> {
+    pub(crate) instance: &'a VulkanInstance,
+    pub(crate) physical_device: vk::PhysicalDevice,
+    pub(crate) queue_indices: QueueIndices<'static>,
+    pub(crate) decode_capabilities: Option<NativeDecodeCapabilities>,
+    pub(crate) encode_capabilities: Option<NativeEncodeCapabilities>,
+    pub(crate) info: VulkanAdapterInfo,
+}
+
+impl<'a> VulkanAdapter<'a> {
+    pub(crate) fn new(
+        vulkan_instance: &'a VulkanInstance,
+        device: vk::PhysicalDevice,
+    ) -> Option<Self> {
+        let instance = &vulkan_instance.instance;
+        let properties = unsafe { instance.get_physical_device_properties(device) };
+        let device_name = properties
+            .device_name_as_c_str()
+            .map(CStr::to_string_lossy)
+            .unwrap_or("unknown".into());
+
+        let _span = debug_span!("creating adapter", device_name = %device_name).entered();
+
+        let mut vk_13_features = vk::PhysicalDeviceVulkan13Features::default();
+        let mut features = vk::PhysicalDeviceFeatures2::default().push_next(&mut vk_13_features);
+
+        unsafe { instance.get_physical_device_features2(device, &mut features) };
+        let extensions = match unsafe { instance.enumerate_device_extension_properties(device) } {
+            Ok(ext) => ext,
+            Err(err) => {
+                warn!("Couldn't enumerate device extension properties: {err}");
+                return None;
+            }
+        };
+
+        if vk_13_features.synchronization2 == vk::FALSE {
+            debug!("device does not support the required synchronization2 feature");
+            return None;
+        }
+
+        if let Err(missing) = check_extensions(REQUIRED_EXTENSIONS, &extensions) {
+            debug!(missing_extensions = ?missing, "device is missing some required extensions",);
+            return None;
+        }
+
+        let has_decode_extensions = check_extensions(DECODE_EXTENSIONS, &extensions).is_ok();
+        let supported_decode_codec_extensions =
+            supported_extensions(DECODE_CODEC_EXTENSIONS, &extensions);
+        let supports_any_decoding =
+            has_decode_extensions && !supported_decode_codec_extensions.is_empty();
+        let supported_decode_operations =
+            extensions_to_codec_operations(&supported_decode_codec_extensions);
+
+        let has_encode_extensions = check_extensions(ENCODE_EXTENSIONS, &extensions).is_ok();
+        let supported_encode_codec_extensions =
+            supported_extensions(ENCODE_CODEC_EXTENSIONS, &extensions);
+        let supports_any_encoding =
+            has_encode_extensions && !supported_encode_codec_extensions.is_empty();
+        let supported_encode_operations =
+            extensions_to_codec_operations(&supported_encode_codec_extensions);
+
+        if !supports_any_decoding && !supports_any_encoding {
+            debug!("device does not support encoding or decoding extensions");
+            return None;
+        }
+
+        let queues_len =
+            unsafe { instance.get_physical_device_queue_family_properties2_len(device) };
+        let mut queues = vec![vk::QueueFamilyProperties2::default(); queues_len];
+        let mut video_properties = vec![vk::QueueFamilyVideoPropertiesKHR::default(); queues_len];
+        let mut query_result_status_properties =
+            vec![vk::QueueFamilyQueryResultStatusPropertiesKHR::default(); queues_len];
+
+        for ((queue, video_properties), query_result_properties) in queues
+            .iter_mut()
+            .zip(video_properties.iter_mut())
+            .zip(query_result_status_properties.iter_mut())
+        {
+            *queue = queue
+                .push_next(query_result_properties)
+                .push_next(video_properties);
+        }
+
+        unsafe { instance.get_physical_device_queue_family_properties2(device, &mut queues) };
+
+        let decode_capabilities =
+            NativeDecodeCapabilities::query(instance, device, supported_decode_operations);
+        let encode_capabilities =
+            NativeEncodeCapabilities::query(instance, device, supported_encode_operations);
+
+        let queue_counts = queues
+            .iter()
+            .map(|q| q.queue_family_properties.queue_count)
+            .collect::<Vec<_>>();
+
+        let transfer_queue_idx = queues
+            .iter()
+            .enumerate()
+            .find(|(_, q)| {
+                q.queue_family_properties
+                    .queue_flags
+                    .contains(vk::QueueFlags::TRANSFER)
+                    && !q
+                        .queue_family_properties
+                        .queue_flags
+                        .intersects(vk::QueueFlags::GRAPHICS)
+            })
+            .map(|(i, _)| i)?;
+
+        let compute_queue_idx = queues
+            .iter()
+            .enumerate()
+            .find(|(_, q)| {
+                q.queue_family_properties
+                    .queue_flags
+                    .contains(vk::QueueFlags::COMPUTE)
+                    && !q
+                        .queue_family_properties
+                        .queue_flags
+                        .intersects(vk::QueueFlags::GRAPHICS)
+            })
+            .map(|(i, _)| i)?;
+
+        let graphics_transfer_compute_queue_idx = queues
+            .iter()
+            .enumerate()
+            .find(|(_, q)| {
+                q.queue_family_properties.queue_flags.contains(
+                    vk::QueueFlags::GRAPHICS | vk::QueueFlags::TRANSFER | vk::QueueFlags::COMPUTE,
+                )
+            })
+            .map(|(i, _)| i)?;
+
+        let decode_queue_idx = match supports_any_decoding {
+            true => find_video_queue_idx(
+                &queues,
+                vk::QueueFlags::VIDEO_DECODE_KHR,
+                // TODO: for now, we only look for a single queue that supports all decoding
+                supported_decode_operations,
+            ),
+            false => None,
+        };
+        let encode_queue_idx = match supports_any_encoding {
+            true => find_video_queue_idx(
+                &queues,
+                vk::QueueFlags::VIDEO_ENCODE_KHR,
+                // TODO: for now, we only look for a single queue that supports all encoding
+                supported_encode_operations,
+            ),
+            false => None,
+        };
+
+        if decode_queue_idx.is_none() && encode_queue_idx.is_none() {
+            debug!("device does not have any queues that support video operations");
+            return None;
+        }
+
+        debug!("decode capabilities: {decode_capabilities:#?}");
+        debug!("encode capabilities: {encode_capabilities:#?}");
+
+        let (driver_name, driver_info) = match properties.api_version >= vk::API_VERSION_1_2 {
+            true => {
+                let mut driver_properties = vk::PhysicalDeviceDriverProperties::default();
+                let mut properties2 =
+                    vk::PhysicalDeviceProperties2::default().push_next(&mut driver_properties);
+                unsafe {
+                    instance.get_physical_device_properties2(device, &mut properties2);
+                }
+
+                let driver_name = driver_properties
+                    .driver_name_as_c_str()
+                    .map(CStr::to_string_lossy)
+                    .unwrap_or("unknown".into())
+                    .into_owned();
+                let driver_info = driver_properties
+                    .driver_info_as_c_str()
+                    .map(CStr::to_string_lossy)
+                    .unwrap_or_default()
+                    .into_owned();
+                (driver_name, driver_info)
+            }
+            false => ("unknown".to_owned(), "".to_owned()),
+        };
+
+        let info = VulkanAdapterInfo {
+            name: device_name.into_owned(),
+            driver_name,
+            driver_info,
+            device_type: properties.device_type,
+            device_properties: properties,
+            supports_decoding: decode_queue_idx.is_some(),
+            supports_encoding: encode_queue_idx.is_some(),
+            decode_capabilities: decode_capabilities.user_facing(),
+            encode_capabilities: encode_capabilities.user_facing(),
+        };
+
+        Some(Self {
+            instance: vulkan_instance,
+            physical_device: device,
+            queue_indices: QueueIndices {
+                transfer: QueueIndex {
+                    family_index: transfer_queue_idx,
+                    queue_count: queue_counts[transfer_queue_idx] as usize,
+                    video_properties: video_properties[transfer_queue_idx],
+                    query_result_status_properties: query_result_status_properties
+                        [transfer_queue_idx],
+                },
+                compute: QueueIndex {
+                    family_index: compute_queue_idx,
+                    queue_count: queue_counts[compute_queue_idx] as usize,
+                    video_properties: video_properties[compute_queue_idx],
+                    query_result_status_properties: query_result_status_properties
+                        [compute_queue_idx],
+                },
+                h264_decode: decode_queue_idx.map(|idx| QueueIndex {
+                    family_index: idx,
+                    queue_count: queue_counts[idx] as usize,
+                    video_properties: video_properties[idx],
+                    query_result_status_properties: query_result_status_properties[idx],
+                }),
+                encode: encode_queue_idx.map(|idx| QueueIndex {
+                    family_index: idx,
+                    queue_count: queue_counts[idx] as usize,
+                    video_properties: video_properties[idx],
+                    query_result_status_properties: query_result_status_properties[idx],
+                }),
+                graphics_transfer_compute: QueueIndex {
+                    family_index: graphics_transfer_compute_queue_idx,
+                    queue_count: 1, // Currently we can only handle 1 queue
+                    video_properties: video_properties[graphics_transfer_compute_queue_idx],
+                    query_result_status_properties: query_result_status_properties
+                        [graphics_transfer_compute_queue_idx],
+                },
+            },
+            decode_capabilities: if supports_any_decoding {
+                Some(decode_capabilities)
+            } else {
+                None
+            },
+            encode_capabilities: if supports_any_encoding {
+                Some(encode_capabilities)
+            } else {
+                None
+            },
+            info,
+        })
+    }
+
+    pub fn supports_decoding(&self) -> bool {
+        self.info.supports_decoding
+    }
+
+    pub fn supports_encoding(&self) -> bool {
+        self.info.supports_encoding
+    }
+
+    pub fn info(&self) -> &VulkanAdapterInfo {
+        &self.info
+    }
+
+    pub(crate) fn required_extensions(&self) -> Vec<&'static CStr> {
+        REQUIRED_EXTENSIONS
+            .iter()
+            .copied()
+            .chain(match self.supports_decoding() {
+                true => DECODE_EXTENSIONS.iter().copied(),
+                false => [].iter().copied(),
+            })
+            .chain(match self.supports_decoding() {
+                true => DECODE_CODEC_EXTENSIONS.iter().copied(),
+                false => [].iter().copied(),
+            })
+            .chain(match self.supports_encoding() {
+                true => ENCODE_EXTENSIONS.iter().copied(),
+                false => [].iter().copied(),
+            })
+            .chain(match self.supports_encoding() {
+                true => ENCODE_CODEC_EXTENSIONS.iter().copied(),
+                false => [].iter().copied(),
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+impl VideoAdapterBackend for VulkanAdapter<'_> {
+    fn build_info(&self) -> VideoAdapterInfo {
+        let VulkanAdapterInfo {
+            name,
+            driver_name,
+            driver_info,
+            device_type,
+            supports_decoding,
+            supports_encoding,
+            device_properties,
+            decode_capabilities,
+            encode_capabilities,
+        } = self.info().clone();
+
+        let api_version = {
+            let version = self.info.device_properties.api_version;
+            let major = vk::api_version_major(version);
+            let minor = vk::api_version_minor(version);
+            let patch = vk::api_version_patch(version);
+
+            format!("{major}.{minor}.{patch}")
+        };
+
+        let device_type = match device_type {
+            vk::PhysicalDeviceType::OTHER => DeviceType::Other,
+            vk::PhysicalDeviceType::INTEGRATED_GPU => DeviceType::IntegratedGpu,
+            vk::PhysicalDeviceType::DISCRETE_GPU => DeviceType::DiscreteGpu,
+            vk::PhysicalDeviceType::VIRTUAL_GPU => DeviceType::VirtualGpu,
+            vk::PhysicalDeviceType::CPU => DeviceType::Cpu,
+            _ => DeviceType::Other,
+        };
+
+        VideoAdapterInfo {
+            name,
+            driver_name,
+            driver_info,
+            device: device_properties.device_id.to_string(),
+            vendor: device_properties.vendor_id.to_string(),
+            device_type,
+            api_version,
+            supports_decoding,
+            supports_encoding,
+            decode_capabilities,
+            encode_capabilities,
+        }
+    }
+
+    fn create_device(
+        self: Box<Self>,
+        desc: &VideoDeviceDescriptor,
+    ) -> Result<crate::VideoDevice, VideoDeviceInitError> {
+        VideoDevice::create_and_register(*self, desc.clone()).map_err(Into::into)
+    }
+}
+
+/// This macro will iterate over the `p_next` chain of the base struct until it finds a struct,
+/// which matches the given type. After that it will execute the given action on the found struct.
+///
+/// # Example
+/// ```ignore
+/// unsafe {
+///     find_ext!(queue_family_properties, found_extension @ ash::vk::QueueFamilyVideoPropertiesKHR => {
+///         dbg!(found_extension)
+///     });
+/// }
+/// ```
+#[cfg_attr(doctest, macro_export)]
+macro_rules! find_ext {
+    ($base:expr, $var:ident @ $ext:ty => $action:stmt) => {
+        let mut next = $base.p_next.cast::<ash::vk::BaseOutStructure>();
+        while !next.is_null() {
+            ash::match_out_struct!(match next {
+                $var @ $ext => {
+                    $action
+                    break;
+                }
+            });
+
+            next = (*next).p_next;
+        }
+    };
+}
+
+/// Returns the list of missing extensions
+fn check_extensions<'a>(
+    required_extensions: &'a [&'a CStr],
+    available_extensions: &'a [vk::ExtensionProperties],
+) -> Result<(), Vec<&'a CStr>> {
+    let missing = required_extensions
+        .iter()
+        .copied()
+        .filter(|&required_name| {
+            !available_extensions.iter().any(|ext| {
+                let Ok(name) = ext.extension_name_as_c_str() else {
+                    return false;
+                };
+
+                name == required_name
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if !missing.is_empty() {
+        return Err(missing);
+    }
+
+    Ok(())
+}
+
+fn supported_extensions<'a>(
+    required_extensions: &'a [&'a CStr],
+    available_extensions: &'a [vk::ExtensionProperties],
+) -> Vec<&'a CStr> {
+    required_extensions
+        .iter()
+        .copied()
+        .filter(|&required_name| {
+            available_extensions.iter().any(|ext| {
+                let Ok(name) = ext.extension_name_as_c_str() else {
+                    return false;
+                };
+
+                name == required_name
+            })
+        })
+        .collect()
+}
+
+fn extensions_to_codec_operations(extensions: &[&CStr]) -> vk::VideoCodecOperationFlagsKHR {
+    extensions
+        .iter()
+        .copied()
+        .fold(vk::VideoCodecOperationFlagsKHR::empty(), |acc, ext| {
+            acc | match ext {
+                name if name == vk::KHR_VIDEO_ENCODE_H264_NAME => {
+                    vk::VideoCodecOperationFlagsKHR::ENCODE_H264
+                }
+                name if name == vk::KHR_VIDEO_ENCODE_H265_NAME => {
+                    vk::VideoCodecOperationFlagsKHR::ENCODE_H265
+                }
+                name if name == vk::KHR_VIDEO_DECODE_H264_NAME => {
+                    vk::VideoCodecOperationFlagsKHR::DECODE_H264
+                }
+                name if name == vk::KHR_VIDEO_DECODE_H265_NAME => {
+                    vk::VideoCodecOperationFlagsKHR::DECODE_H265
+                }
+                _ => vk::VideoCodecOperationFlagsKHR::empty(),
+            }
+        })
+}
+
+fn find_video_queue_idx(
+    queues: &[vk::QueueFamilyProperties2<'_>],
+    queue_flag: vk::QueueFlags,
+    video_codec_operation: vk::VideoCodecOperationFlagsKHR,
+) -> Option<usize> {
+    for (i, queue) in queues.iter().enumerate() {
+        if !queue
+            .queue_family_properties
+            .queue_flags
+            .contains(queue_flag)
+        {
+            continue;
+        }
+
+        unsafe {
+            find_ext!(queue, video_properties @ vk::QueueFamilyVideoPropertiesKHR =>
+                if video_properties
+                    .video_codec_operations
+                    .contains(video_codec_operation)
+                {
+                    return Some(i);
+                }
+            );
+        }
+    }
+
+    None
+}
+
+#[derive(Clone)]
+pub struct VulkanAdapterInfo {
+    pub name: String,
+    pub driver_name: String,
+    pub driver_info: String,
+    pub device_type: vk::PhysicalDeviceType,
+    pub supports_decoding: bool,
+    pub supports_encoding: bool,
+    pub device_properties: vk::PhysicalDeviceProperties,
+    pub decode_capabilities: DecodeCapabilities,
+    pub encode_capabilities: EncodeCapabilities,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum VulkanAdapterInitError {
+    #[error("Vulkan error: {0}")]
+    VkError(#[from] vk::Result),
+
+    #[error("Profile does not support NV12 texture format")]
+    NoNV12ProfileSupport,
+}

--- a/gpu-video/src/backends/vulkan/vulkan_adapter/wgpu_api.rs
+++ b/gpu-video/src/backends/vulkan/vulkan_adapter/wgpu_api.rs
@@ -1,0 +1,28 @@
+use ash::vk;
+use wgpu::hal::vulkan::Api as VkApi;
+
+use crate::{backends::vulkan::VulkanInstance, instance::VideoInstanceDescriptor};
+
+use super::VulkanAdapter;
+
+pub(crate) fn with_video_adapter_from_wgpu<F, R>(
+    wgpu_adapter: &wgpu::Adapter,
+    use_adapter: F,
+) -> Option<R>
+where
+    F: Fn(VulkanAdapter<'_>) -> R,
+{
+    let hal_adapter = unsafe { wgpu_adapter.as_hal::<VkApi>()? };
+    let physical_device = hal_adapter.raw_physical_device();
+    let instance = hal_adapter.shared_instance();
+    let instance = VulkanInstance::new_unowned(
+        instance.raw_instance().clone(),
+        instance.entry().clone(),
+        &VideoInstanceDescriptor {
+            enable_validations: instance.extensions().contains(&vk::EXT_DEBUG_UTILS_NAME),
+            ..Default::default()
+        },
+    );
+
+    VulkanAdapter::new(&instance, physical_device).map(use_adapter)
+}

--- a/gpu-video/src/backends/vulkan/vulkan_instance.rs
+++ b/gpu-video/src/backends/vulkan/vulkan_instance.rs
@@ -154,9 +154,16 @@ pub enum VulkanInstanceInitError {
 
 impl From<VulkanInstanceInitError> for VideoInstanceInitError {
     fn from(err: VulkanInstanceInitError) -> Self {
-        Self::BackendError(VideoBackendError {
-            message: err.to_string(),
-            source: Box::new(err),
-        })
+        match err {
+            VulkanInstanceInitError::LoadingError(_)
+            | VulkanInstanceInitError::VkError(_)
+            | VulkanInstanceInitError::MissingExtension(_)
+            | VulkanInstanceInitError::InvalidLayerName(_) => {
+                Self::BackendError(VideoBackendError {
+                    message: err.to_string(),
+                    source: Box::new(err),
+                })
+            }
+        }
     }
 }

--- a/gpu-video/src/backends/vulkan/vulkan_instance.rs
+++ b/gpu-video/src/backends/vulkan/vulkan_instance.rs
@@ -1,0 +1,162 @@
+use std::{ffi::CStr, sync::Arc};
+
+use ash::{Entry, vk};
+
+use crate::{
+    VideoBackendError, VideoInstanceInitError,
+    adapter::VideoAdapter,
+    backends::vulkan::vulkan_adapter::VulkanAdapter,
+    instance::{VideoInstanceBackend, VideoInstanceDescriptor},
+    wrappers::*,
+};
+
+pub struct VulkanInstance {
+    _entry: Entry,
+    pub(crate) instance: Arc<Instance>,
+    _debug_messenger: Option<DebugMessenger>,
+}
+
+impl VideoInstanceBackend for VulkanInstance {
+    fn iter_adapters<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = VideoAdapter<'a>> + 'a>, VideoInstanceInitError> {
+        VulkanInstance::iter_adapters(self)
+    }
+}
+
+impl VulkanInstance {
+    pub(crate) fn new(desc: &VideoInstanceDescriptor) -> Result<Self, VulkanInstanceInitError> {
+        let entry = unsafe { Entry::load()? };
+        Self::new_from_entry(entry, &mut Vec::new(), desc)
+    }
+
+    pub fn new_from_entry(
+        entry: Entry,
+        extensions: &mut Vec<&'static CStr>,
+        desc: &VideoInstanceDescriptor,
+    ) -> Result<Self, VulkanInstanceInitError> {
+        let api_version = vk::make_api_version(0, 1, 3, 0);
+        let app_info = vk::ApplicationInfo {
+            api_version,
+            ..Default::default()
+        };
+
+        let mut requested_layers = Vec::new();
+        if desc.enable_validations {
+            requested_layers.push(c"VK_LAYER_KHRONOS_validation");
+        }
+        if desc.enable_api_dump {
+            requested_layers.push(c"VK_LAYER_LUNARG_api_dump");
+        }
+
+        let instance_layer_properties = unsafe { entry.enumerate_instance_layer_properties()? };
+        let instance_layer_names = instance_layer_properties
+            .iter()
+            .map(|layer| layer.layer_name_as_c_str())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(VulkanInstanceInitError::InvalidLayerName)?;
+
+        let layers = requested_layers
+            .into_iter()
+            .filter(|requested_layer_name| {
+                instance_layer_names
+                    .iter()
+                    .any(|instance_layer_name| instance_layer_name == requested_layer_name)
+            })
+            .map(|layer| layer.as_ptr())
+            .collect::<Vec<_>>();
+
+        if !extensions.contains(&vk::EXT_DEBUG_UTILS_NAME) {
+            extensions.push(vk::EXT_DEBUG_UTILS_NAME);
+        }
+
+        let extension_ptrs = extensions.iter().map(|e| e.as_ptr()).collect::<Vec<_>>();
+
+        let create_info = vk::InstanceCreateInfo::default()
+            .application_info(&app_info)
+            .enabled_layer_names(&layers)
+            .enabled_extension_names(&extension_ptrs);
+
+        let instance = unsafe { entry.create_instance(&create_info, None) }?;
+        let instance = Arc::new(Instance::new(
+            instance.clone(),
+            entry.clone(),
+            desc.enable_validations,
+            true,
+        ));
+
+        let debug_messenger = if desc.enable_validations {
+            Some(DebugMessenger::new(instance.clone())?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            _entry: entry,
+            instance,
+            _debug_messenger: debug_messenger,
+        })
+    }
+
+    /// Creates an instance that does not own `ash::Instance`. The instance is not destroyed on drop.
+    #[cfg_attr(not(feature = "wgpu"), allow(dead_code))]
+    pub(crate) fn new_unowned(
+        instance: ash::Instance,
+        entry: Entry,
+        desc: &VideoInstanceDescriptor,
+    ) -> Self {
+        let instance = Arc::new(Instance::new(
+            instance.clone(),
+            entry.clone(),
+            desc.enable_validations,
+            false,
+        ));
+        Self {
+            _entry: entry,
+            instance,
+            _debug_messenger: None,
+        }
+    }
+
+    #[cfg_attr(not(feature = "expose-backends"), allow(dead_code))]
+    pub fn raw_instance(&self) -> ash::Instance {
+        self.instance.instance.clone()
+    }
+
+    pub fn iter_adapters<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = VideoAdapter<'a>> + 'a>, VideoInstanceInitError> {
+        let physical_devices = unsafe {
+            self.instance
+                .enumerate_physical_devices()
+                .map_err(VulkanInstanceInitError::VkError)?
+        };
+        Ok(Box::new(physical_devices.into_iter().filter_map(
+            move |device| VulkanAdapter::new(self, device).map(VideoAdapter::from_backend),
+        )))
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum VulkanInstanceInitError {
+    #[error("Error loading vulkan: {0}")]
+    LoadingError(#[from] ash::LoadingError),
+
+    #[error("Vulkan error: {0}")]
+    VkError(#[from] vk::Result),
+
+    #[error("Missing required extension: {0}")]
+    MissingExtension(String),
+
+    #[error("Invalid layer name: {0}")]
+    InvalidLayerName(#[source] std::ffi::FromBytesUntilNulError),
+}
+
+impl From<VulkanInstanceInitError> for VideoInstanceInitError {
+    fn from(err: VulkanInstanceInitError) -> Self {
+        Self::BackendError(VideoBackendError {
+            message: err.to_string(),
+            source: Box::new(err),
+        })
+    }
+}

--- a/gpu-video/src/device.rs
+++ b/gpu-video/src/device.rs
@@ -756,10 +756,17 @@ pub enum VulkanDeviceInitError {
 
 impl From<VulkanDeviceInitError> for VideoDeviceInitError {
     fn from(err: VulkanDeviceInitError) -> Self {
-        Self::BackendError(crate::VideoBackendError {
-            message: err.to_string(),
-            source: Box::new(err),
-        })
+        match err {
+            VulkanDeviceInitError::VkError(_) => Self::BackendError(crate::VideoBackendError {
+                message: err.to_string(),
+                source: Box::new(err),
+            }),
+            #[cfg(feature = "wgpu")]
+            VulkanDeviceInitError::WgpuError(_) => Self::BackendError(crate::VideoBackendError {
+                message: err.to_string(),
+                source: Box::new(err),
+            }),
+        }
     }
 }
 

--- a/gpu-video/src/device.rs
+++ b/gpu-video/src/device.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 
 use ash::vk;
 
-use crate::adapter::VideoAdapter;
-use crate::capabilities::VideoAdapterInfo;
+use crate::backends::vulkan::{VulkanAdapter, VulkanAdapterInfo};
 use crate::codec::EncodeCodec;
 use crate::codec::h264::H264Codec;
 use crate::device::caps::{
@@ -19,7 +18,7 @@ use crate::parameters::{
 };
 use crate::vulkan_encoder::FullEncoderParameters;
 
-use crate::{VideoEncoderError, VideoInitError, VulkanDecoderError, wrappers::*};
+use crate::{VideoDeviceInitError, VideoEncoderError, VulkanDecoderError, wrappers::*};
 
 pub(crate) mod caps;
 pub(crate) mod queues;
@@ -264,15 +263,15 @@ pub(crate) struct VideoDevice {
     pub(crate) queues: Queues,
     pub(crate) native_decode_capabilities: Option<NativeDecodeCapabilities>,
     pub(crate) native_encode_capabilities: Option<NativeEncodeCapabilities>,
-    pub(crate) adapter_info: Arc<VideoAdapterInfo>,
+    pub(crate) adapter_info: Arc<VulkanAdapterInfo>,
     pub(crate) device: Arc<Device>,
 }
 
 impl VideoDevice {
     pub(crate) fn create_and_register(
-        video_adapter: VideoAdapter<'_>,
+        video_adapter: VulkanAdapter<'_>,
         _desc: VideoDeviceDescriptor,
-    ) -> Result<crate::VideoDevice, VideoInitError> {
+    ) -> Result<crate::VideoDevice, VulkanDeviceInitError> {
         let mut required_extensions = video_adapter.required_extensions();
         required_extensions.push(ash::khr::timeline_semaphore::NAME);
 
@@ -295,9 +294,9 @@ impl VideoDevice {
     #[cfg(feature = "wgpu")]
     pub(crate) fn create_and_register_wgpu(
         wgpu_adapter: &wgpu::Adapter,
-        video_adapter: VideoAdapter<'_>,
+        video_adapter: VulkanAdapter<'_>,
         desc: VideoDeviceDescriptor,
-    ) -> Result<(wgpu::Device, wgpu::Queue), VideoInitError> {
+    ) -> Result<(wgpu::Device, wgpu::Queue), VulkanDeviceInitError> {
         use std::sync::OnceLock;
 
         use crate::{
@@ -393,11 +392,11 @@ impl VideoDevice {
     }
 
     fn new_from_create_info(
-        adapter: VideoAdapter<'_>,
+        adapter: VulkanAdapter<'_>,
         required_extensions: &[&'static CStr],
         device_create_info: vk::DeviceCreateInfo<'_>,
-    ) -> Result<Arc<Self>, VideoInitError> {
-        let VideoAdapter {
+    ) -> Result<Arc<Self>, VulkanDeviceInitError> {
+        let VulkanAdapter {
             instance,
             physical_device,
             queue_indices,
@@ -742,6 +741,25 @@ impl Deref for EncodingDevice {
 
     fn deref(&self) -> &Self::Target {
         &self.vulkan_device
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum VulkanDeviceInitError {
+    #[error("Vulkan error: {0}")]
+    VkError(#[from] vk::Result),
+
+    #[cfg(feature = "wgpu")]
+    #[error(transparent)]
+    WgpuError(#[from] crate::WgpuInitError),
+}
+
+impl From<VulkanDeviceInitError> for VideoDeviceInitError {
+    fn from(err: VulkanDeviceInitError) -> Self {
+        Self::BackendError(crate::VideoBackendError {
+            message: err.to_string(),
+            source: Box::new(err),
+        })
     }
 }
 

--- a/gpu-video/src/device/caps.rs
+++ b/gpu-video/src/device/caps.rs
@@ -2,8 +2,8 @@ use std::ptr::null_mut;
 
 use ash::vk;
 
-use crate::VideoInitError;
 use crate::VulkanDecoderError;
+use crate::backends::vulkan::VulkanAdapterInitError;
 use crate::codec::CodecCapabilities;
 use crate::codec::CodecSpecificEncoderQualityLevelProperties as _;
 use crate::codec::h264::H264Codec;
@@ -19,7 +19,7 @@ pub(crate) fn query_video_format_properties<'a>(
     video_queue_instance_ext: &ash::khr::video_queue::Instance,
     profile_info: &vk::VideoProfileInfoKHR<'_>,
     image_usage: vk::ImageUsageFlags,
-) -> Result<Vec<vk::VideoFormatPropertiesKHR<'a>>, VideoInitError> {
+) -> Result<Vec<vk::VideoFormatPropertiesKHR<'a>>, VulkanAdapterInitError> {
     let mut profile_list_info =
         vk::VideoProfileListInfoKHR::default().profiles(std::slice::from_ref(profile_info));
 
@@ -287,7 +287,7 @@ impl<C: CodecCapabilities> NativeEncodeProfileCapabilities<C> {
         instance: &Instance,
         device: vk::PhysicalDevice,
         profile: &vk::VideoProfileInfoKHR,
-    ) -> Result<Self, VideoInitError> {
+    ) -> Result<Self, VulkanAdapterInitError> {
         let encode_dpb_properties = query_video_format_properties(
             device,
             &instance.video_queue_instance_ext,
@@ -396,7 +396,7 @@ impl<C: CodecCapabilities> NativeEncodeQualityLevelProperties<C> {
         device: vk::PhysicalDevice,
         profile_info: &vk::VideoProfileInfoKHR<'_>,
         quality_level: u32,
-    ) -> Result<Self, VideoInitError> {
+    ) -> Result<Self, VulkanAdapterInitError> {
         let quality_level_info = vk::PhysicalDeviceVideoEncodeQualityLevelInfoKHR::default()
             .video_profile(profile_info)
             .quality_level(quality_level);
@@ -666,7 +666,7 @@ impl<C: CodecCapabilities> NativeDecodeProfileCapabilities<C> {
         instance: &Instance,
         device: vk::PhysicalDevice,
         profile: &vk::VideoProfileInfoKHR,
-    ) -> Result<Self, VideoInitError> {
+    ) -> Result<Self, VulkanAdapterInitError> {
         let mut codec_decode_caps = C::CodecSpecificDecodeCapabilities::default();
         let mut decode_caps = vk::VideoDecodeCapabilitiesKHR::default();
         let mut caps = vk::VideoCapabilitiesKHR::default()
@@ -733,7 +733,7 @@ impl<C: CodecCapabilities> NativeDecodeProfileCapabilities<C> {
             .find(|f| f.format == vk::Format::G8_B8R8_2PLANE_420_UNORM)
         {
             Some(f) => f,
-            None => return Err(VideoInitError::NoNV12ProfileSupport),
+            None => return Err(VulkanAdapterInitError::NoNV12ProfileSupport),
         };
 
         let dst_format_properties = match dst_format_properties {
@@ -742,7 +742,7 @@ impl<C: CodecCapabilities> NativeDecodeProfileCapabilities<C> {
                 .find(|f| f.format == vk::Format::G8_B8R8_2PLANE_420_UNORM)
             {
                 Some(f) => Some(f),
-                None => return Err(VideoInitError::NoNV12ProfileSupport),
+                None => return Err(VulkanAdapterInitError::NoNV12ProfileSupport),
             },
             None => None,
         };

--- a/gpu-video/src/instance.rs
+++ b/gpu-video/src/instance.rs
@@ -1,11 +1,9 @@
-use std::{ffi::CStr, sync::Arc};
-
-use ash::{Entry, vk};
+use std::sync::Arc;
 
 use crate::{
-    VideoInitError,
+    VideoInstanceInitError,
     adapter::{VideoAdapter, VideoAdapterDescriptor},
-    wrappers::*,
+    backends,
 };
 
 /// Describes a [`VideoInstance`].
@@ -18,135 +16,51 @@ pub struct VideoInstanceDescriptor {
     pub enable_api_dump: bool,
 }
 
+pub(crate) trait VideoInstanceBackend {
+    fn iter_adapters<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = VideoAdapter<'a>> + 'a>, VideoInstanceInitError>;
+}
+
 /// Context for all encoders and decoders.
+#[derive(Clone)]
 pub struct VideoInstance {
-    _entry: Entry,
-    pub(crate) instance: Arc<Instance>,
-    _debug_messenger: Option<DebugMessenger>,
+    instance: Arc<dyn VideoInstanceBackend>,
 }
 
 impl VideoInstance {
-    pub fn new(desc: &VideoInstanceDescriptor) -> Result<Arc<Self>, VideoInitError> {
-        let entry = unsafe { Entry::load()? };
-        Self::new_from_entry(entry, &mut Vec::new(), desc)
-    }
-
-    #[cfg(vulkan)]
-    pub fn new_from_entry(
-        entry: Entry,
-        extensions: &mut Vec<&'static CStr>,
-        desc: &VideoInstanceDescriptor,
-    ) -> Result<Arc<Self>, VideoInitError> {
-        let api_version = vk::make_api_version(0, 1, 3, 0);
-        let app_info = vk::ApplicationInfo {
-            api_version,
-            ..Default::default()
-        };
-
-        let mut requested_layers = Vec::new();
-        if desc.enable_validations {
-            requested_layers.push(c"VK_LAYER_KHRONOS_validation");
-        }
-        if desc.enable_api_dump {
-            requested_layers.push(c"VK_LAYER_LUNARG_api_dump");
-        }
-
-        let instance_layer_properties = unsafe { entry.enumerate_instance_layer_properties()? };
-        let instance_layer_names = instance_layer_properties
-            .iter()
-            .map(|layer| layer.layer_name_as_c_str())
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let layers = requested_layers
-            .into_iter()
-            .filter(|requested_layer_name| {
-                instance_layer_names
-                    .iter()
-                    .any(|instance_layer_name| instance_layer_name == requested_layer_name)
-            })
-            .map(|layer| layer.as_ptr())
-            .collect::<Vec<_>>();
-
-        if !extensions.contains(&vk::EXT_DEBUG_UTILS_NAME) {
-            extensions.push(vk::EXT_DEBUG_UTILS_NAME);
-        }
-
-        let extension_ptrs = extensions.iter().map(|e| e.as_ptr()).collect::<Vec<_>>();
-
-        let create_info = vk::InstanceCreateInfo::default()
-            .application_info(&app_info)
-            .enabled_layer_names(&layers)
-            .enabled_extension_names(&extension_ptrs);
-
-        let instance = unsafe { entry.create_instance(&create_info, None) }?;
-        let instance = Arc::new(Instance::new(
-            instance.clone(),
-            entry.clone(),
-            desc.enable_validations,
-            true,
-        ));
-
-        let debug_messenger = if desc.enable_validations {
-            Some(DebugMessenger::new(instance.clone())?)
-        } else {
-            None
-        };
+    pub fn new(desc: &VideoInstanceDescriptor) -> Result<Self, VideoInstanceInitError> {
+        #[cfg(vulkan)]
+        let instance = backends::vulkan::VulkanInstance::new(desc)?;
 
         Ok(Self {
-            _entry: entry,
-            instance,
-            _debug_messenger: debug_messenger,
-        }
-        .into())
-    }
-
-    /// Creates an instance that does not own `ash::Instance`. The instance is not destroyed on drop.
-    #[cfg_attr(not(feature = "wgpu"), allow(dead_code))]
-    pub(crate) fn new_unowned(
-        instance: ash::Instance,
-        entry: Entry,
-        desc: &VideoInstanceDescriptor,
-    ) -> Self {
-        let instance = Arc::new(Instance::new(
-            instance.clone(),
-            entry.clone(),
-            desc.enable_validations,
-            false,
-        ));
-        Self {
-            _entry: entry,
-            instance,
-            _debug_messenger: None,
-        }
+            instance: Arc::new(instance),
+        })
     }
 
     /// Creates an adapter that meets requirements specified in the descriptor.
     pub fn create_adapter<'a>(
         &'a self,
         descriptor: &VideoAdapterDescriptor,
-    ) -> Result<VideoAdapter<'a>, VideoInitError> {
+    ) -> Result<VideoAdapter<'a>, VideoInstanceInitError> {
         self.iter_adapters()?
             .find(|adapter| {
                 (!descriptor.supports_decoding || adapter.supports_decoding())
                     && (!descriptor.supports_encoding || adapter.supports_encoding())
             })
-            .ok_or(VideoInitError::NoDevice)
+            .ok_or(VideoInstanceInitError::NoAdapterFound)
     }
 
     /// Iterator over all available [`VideoAdapter`]s that support at least decoding or encoding.
     pub fn iter_adapters<'a>(
         &'a self,
-    ) -> Result<impl Iterator<Item = VideoAdapter<'a>> + 'a, VideoInitError> {
-        crate::adapter::iter_adapters(self)
-    }
-
-    pub fn raw_instance(&self) -> ash::Instance {
-        self.instance.instance.clone()
+    ) -> Result<impl Iterator<Item = VideoAdapter<'a>>, VideoInstanceInitError> {
+        self.instance.iter_adapters()
     }
 }
 
 impl std::fmt::Debug for VideoInstance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VulkanInstance").finish()
+        f.debug_struct("VideoInstance").finish()
     }
 }

--- a/gpu-video/src/lib.rs
+++ b/gpu-video/src/lib.rs
@@ -1,7 +1,16 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "expose-backends")]
+pub mod backends;
+#[cfg(all(vulkan, not(feature = "expose-backends")))]
+pub(crate) mod backends;
+
+// TODO: After caps refactor cfg for instance and adapter won't be needed
 #[cfg(vulkan)]
 mod adapter;
+#[cfg(vulkan)]
+mod instance;
+
 #[cfg(vulkan)]
 pub(crate) mod codec;
 #[cfg(vulkan)]
@@ -9,8 +18,6 @@ mod device;
 // TODO: cfg(vulkan) will not be needed once we add proper metal support
 #[cfg(all(vulkan, feature = "wgpu"))]
 mod global_registry;
-#[cfg(vulkan)]
-mod instance;
 #[cfg(vulkan)]
 mod vulkan_decoder;
 #[cfg(vulkan)]
@@ -22,6 +29,7 @@ pub(crate) mod wgpu_helpers;
 #[cfg(vulkan)]
 pub(crate) mod wrappers;
 
+// TODO: This could be inlined with lib.rs when metal support is added
 #[cfg(vulkan)]
 mod vulkan_video;
 #[cfg(vulkan)]

--- a/gpu-video/src/vulkan_video.rs
+++ b/gpu-video/src/vulkan_video.rs
@@ -1,12 +1,10 @@
 pub mod capabilities {
-    pub use crate::adapter::VideoAdapterInfo;
+    pub use crate::adapter::{DeviceType, VideoAdapterInfo};
     pub use crate::device::caps::{
         DecodeCapabilities, DecodeH264Capabilities, DecodeH264ProfileCapabilities,
         DecodeH265Capabilities, DecodeH265ProfileCapabilities, EncodeCapabilities,
         EncodeH264Capabilities, EncodeH265Capabilities, EncodeProfileCapabilities,
     };
-
-    pub use ash::vk::PhysicalDeviceType as VulkanDeviceType;
 }
 
 pub mod parameters {
@@ -150,28 +148,29 @@ pub enum VideoDecoderError {
 }
 
 #[derive(thiserror::Error, Debug)]
-pub enum VideoInitError {
-    #[error("Error loading vulkan: {0}")]
-    LoadingError(#[from] ash::LoadingError),
+#[error("{message}")]
+pub struct VideoBackendError {
+    pub message: String,
+    #[source]
+    pub source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
 
-    #[error("Vulkan error: {0}")]
-    VkError(#[from] vk::Result),
+#[derive(thiserror::Error, Debug)]
+pub enum VideoInstanceInitError {
+    #[error("Cannot find a suitable adapters for a video device")]
+    NoAdapterFound,
 
-    #[error("Cannot find a suitable physical device")]
-    NoDevice,
+    #[error("Instance error: {0}")]
+    BackendError(VideoBackendError),
+}
 
-    #[error("Missing required extension: {0}")]
-    MissingExtension(String),
+#[derive(thiserror::Error, Debug)]
+pub enum VideoDeviceInitError {
+    #[error("The chosen adapter is not suitable for a video device")]
+    NotSuitableAdapter,
 
-    #[error("String conversion error: {0}")]
-    StringConversionError(#[from] std::ffi::FromBytesUntilNulError),
-
-    #[error("Profile does not support NV12 texture format")]
-    NoNV12ProfileSupport,
-
-    #[cfg(feature = "wgpu")]
-    #[error(transparent)]
-    WgpuError(#[from] WgpuInitError),
+    #[error("Device error: {0}")]
+    BackendError(VideoBackendError),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/gpu-video/src/wrappers/debug.rs
+++ b/gpu-video/src/wrappers/debug.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, sync::Arc};
 use ash::vk::{self, QueryType};
 use tracing::{error, info, trace, warn};
 
-use crate::{VideoInitError, VulkanCommonError, VulkanDecoderError};
+use crate::{VulkanCommonError, VulkanDecoderError, backends::vulkan::VulkanInstanceInitError};
 
 use super::{Device, Instance};
 
@@ -13,9 +13,9 @@ pub(crate) struct DebugMessenger {
 }
 
 impl DebugMessenger {
-    pub(crate) fn new(instance: Arc<Instance>) -> Result<Self, VideoInitError> {
+    pub(crate) fn new(instance: Arc<Instance>) -> Result<Self, VulkanInstanceInitError> {
         let Some(debug_utils) = &instance.debug_utils_instance_ext else {
-            return Err(VideoInitError::MissingExtension(
+            return Err(VulkanInstanceInitError::MissingExtension(
                 vk::EXT_DEBUG_UTILS_NAME.to_string_lossy().to_string(),
             ));
         };

--- a/gpu-video/src/wrappers/mem.rs
+++ b/gpu-video/src/wrappers/mem.rs
@@ -4,9 +4,9 @@ use ash::vk::{self, Handle};
 use vk_mem::Alloc;
 
 use crate::{
-    VideoInitError, VulkanCommonError, VulkanDecoderError,
+    VulkanCommonError, VulkanDecoderError,
     codec::h264::parameters::H264DecodeProfileInfo,
-    device::EncodingDevice,
+    device::{EncodingDevice, VulkanDeviceInitError},
     wrappers::{ImageLayoutTracker, OpenCommandBuffer, ProfileInfo},
 };
 
@@ -23,7 +23,7 @@ impl Allocator {
         instance: Arc<Instance>,
         physical_device: vk::PhysicalDevice,
         device: Arc<Device>,
-    ) -> Result<Self, VideoInitError> {
+    ) -> Result<Self, VulkanDeviceInitError> {
         let mut allocator_create_info =
             vk_mem::AllocatorCreateInfo::new(&instance, &device, physical_device);
         allocator_create_info.vulkan_api_version = vk::API_VERSION_1_3;

--- a/smelter-core/src/graphics_context.rs
+++ b/smelter-core/src/graphics_context.rs
@@ -129,7 +129,11 @@ pub enum CreateGraphicsContextError {
 
     #[cfg(feature = "gpu-video")]
     #[error(transparent)]
-    VulkanInitError(#[from] gpu_video::VideoInitError),
+    VideoInstanceInitError(#[from] gpu_video::backends::vulkan::VulkanInstanceInitError),
+
+    #[cfg(feature = "gpu-video")]
+    #[error(transparent)]
+    VideoDeviceInitError(#[from] gpu_video::VideoDeviceInitError),
 
     #[cfg(feature = "gpu-video")]
     #[error(transparent)]

--- a/smelter-core/src/graphics_context/vulkan_context.rs
+++ b/smelter-core/src/graphics_context/vulkan_context.rs
@@ -1,7 +1,8 @@
 use ash::{Entry, vk};
 use gpu_video::{
-    VideoAdapterExt, VideoInstance,
-    capabilities::VulkanDeviceType,
+    VideoAdapterExt,
+    backends::vulkan::VulkanInstance,
+    capabilities::DeviceType,
     parameters::{VideoDeviceDescriptor, VideoInstanceDescriptor},
 };
 use itertools::Itertools;
@@ -38,7 +39,7 @@ pub fn create_vulkan_graphics_ctx(
     let mut extensions =
         wgpu::hal::vulkan::Instance::desired_extensions(&entry, api_version, instance_flags)?;
 
-    let video_instance = VideoInstance::new_from_entry(
+    let video_instance = VulkanInstance::new_from_entry(
         entry.clone(),
         &mut extensions,
         &VideoInstanceDescriptor {
@@ -97,8 +98,8 @@ pub fn create_vulkan_graphics_ctx(
                     (false, false) => 2,
                 };
                 let performance_based_priority = match info.device_type {
-                    VulkanDeviceType::DISCRETE_GPU => 0,
-                    VulkanDeviceType::INTEGRATED_GPU => 1,
+                    DeviceType::DiscreteGpu => 0,
+                    DeviceType::IntegratedGpu => 1,
                     _ => 3,
                 };
 


### PR DESCRIPTION
The plan is to have each backend specific object wrapped in `Video*Backend` trait.
In this PR I only did instance and adapter.

Errors are split into backend specific and backend agnostic (user-facing) errors. If some error can't be converted to backend agnostic error, it's converted to string and put into `VideoBackendError`