### PR TITLE
Added `vp8` and `vp9` to MoQ server input.

### DIFF
--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -380,17 +380,31 @@ fn spawn_video_decoder(
     video: &VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    let transformer = match (&video.description, &video.codec, &video.container) {
-        (None, VideoCodec::H264, Container::Cmaf(_)) => {
-            return Err(MoqConnectionError::MissingAvcc);
-        }
-        (Some(desc), VideoCodec::H264, _) => {
-            let h264_config = H264AvcDecoderConfig::parse(desc.clone())
-                .map_err(|_| MoqConnectionError::InvalidAvcc)?;
+    let (decoder_opt, transformer) = match &video.codec {
+        VideoCodec::H264 => {
+            let transformer = match (&video.description, &video.container) {
+                (None, Container::Cmaf(_)) => {
+                    return Err(MoqConnectionError::MissingAvcc);
+                }
+                (Some(desc), _) => {
+                    let h264_config = H264AvcDecoderConfig::parse(desc.clone())
+                        .map_err(|_| MoqConnectionError::InvalidAvcc)?;
+                    Some(H264AvccToAnnexB::new(h264_config))
+                }
+                (None, _) => None,
+            };
 
-            Some(H264AvccToAnnexB::new(h264_config))
+            let decoder_opt = decoders.h264.unwrap_or_else(|| {
+                match ctx.graphics_context.has_vulkan_decoder_support() {
+                    true => VideoDecoderOptions::VulkanH264,
+                    false => VideoDecoderOptions::FfmpegH264,
+                }
+            });
+
+            (decoder_opt, transformer)
         }
-        _ => None,
+        VideoCodec::Vp8 => (VideoDecoderOptions::FfmpegVp8, None),
+        VideoCodec::Vp9 => (VideoDecoderOptions::FfmpegVp9, None),
     };
 
     let options = VideoDecoderThreadOptions {
@@ -400,39 +414,31 @@ fn spawn_video_decoder(
         input_buffer_size: MOQ_MAX_BUFFER,
     };
 
-    let decoder_opt = match &video.codec {
-        VideoCodec::H264 => decoders.h264.unwrap_or_else(|| {
-            match ctx.graphics_context.has_vulkan_decoder_support() {
-                true => VideoDecoderOptions::VulkanH264,
-                false => VideoDecoderOptions::FfmpegH264,
+    let handle =
+        match decoder_opt {
+            VideoDecoderOptions::FfmpegH264 => VideoDecoderThread::<
+                ffmpeg_h264::FfmpegH264Decoder,
+                _,
+            >::spawn(input_ref.clone(), options)?,
+            VideoDecoderOptions::VulkanH264 => VideoDecoderThread::<
+                vulkan_h264::VulkanH264Decoder,
+                _,
+            >::spawn(input_ref.clone(), options)?,
+            VideoDecoderOptions::FfmpegVp8 => {
+                VideoDecoderThread::<ffmpeg_vp8::FfmpegVp8Decoder, _>::spawn(
+                    input_ref.clone(),
+                    options,
+                )?
             }
-        }),
-        VideoCodec::Vp8 => VideoDecoderOptions::FfmpegVp8,
-        VideoCodec::Vp9 => VideoDecoderOptions::FfmpegVp9,
-    };
+            VideoDecoderOptions::FfmpegVp9 => {
+                VideoDecoderThread::<ffmpeg_vp9::FfmpegVp9Decoder, _>::spawn(
+                    input_ref.clone(),
+                    options,
+                )?
+            }
+        };
 
-    match decoder_opt {
-        VideoDecoderOptions::FfmpegH264 => Ok(VideoDecoderThread::<
-            ffmpeg_h264::FfmpegH264Decoder,
-            _,
-        >::spawn(input_ref.clone(), options)?),
-        VideoDecoderOptions::VulkanH264 => Ok(VideoDecoderThread::<
-            vulkan_h264::VulkanH264Decoder,
-            _,
-        >::spawn(input_ref.clone(), options)?),
-        VideoDecoderOptions::FfmpegVp8 => Ok(
-            VideoDecoderThread::<ffmpeg_vp8::FfmpegVp8Decoder, _>::spawn(
-                input_ref.clone(),
-                options,
-            )?,
-        ),
-        VideoDecoderOptions::FfmpegVp9 => Ok(
-            VideoDecoderThread::<ffmpeg_vp9::FfmpegVp9Decoder, _>::spawn(
-                input_ref.clone(),
-                options,
-            )?,
-        ),
-    }
+    Ok(handle)
 }
 
 fn spawn_audio_decoder(

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -16,7 +16,7 @@ use crate::{
             decoder_thread_audio::{AudioDecoderThread, AudioDecoderThreadOptions},
             decoder_thread_video::{VideoDecoderThread, VideoDecoderThreadOptions},
             fdk_aac::FdkAacDecoder,
-            ffmpeg_h264, ffmpeg_vp8,
+            ffmpeg_h264, ffmpeg_vp8, ffmpeg_vp9,
             libopus::OpusDecoder,
             vulkan_h264,
         },
@@ -411,7 +411,7 @@ fn spawn_video_decoder(
             }
         }),
         VideoCodec::Vp8 => VideoDecoderOptions::FfmpegVp8,
-        VideoCodec::Vp9 => todo!(),
+        VideoCodec::Vp9 => VideoDecoderOptions::FfmpegVp9,
     };
 
     match decoder_opt {
@@ -429,7 +429,12 @@ fn spawn_video_decoder(
                 options,
             )?,
         ),
-        VideoDecoderOptions::FfmpegVp9 => todo!(),
+        VideoDecoderOptions::FfmpegVp9 => Ok(
+            VideoDecoderThread::<ffmpeg_vp9::FfmpegVp9Decoder, _>::spawn(
+                input_ref.clone(),
+                options,
+            )?,
+        ),
     }
 }
 

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -16,7 +16,7 @@ use crate::{
             decoder_thread_audio::{AudioDecoderThread, AudioDecoderThreadOptions},
             decoder_thread_video::{VideoDecoderThread, VideoDecoderThreadOptions},
             fdk_aac::FdkAacDecoder,
-            ffmpeg_h264,
+            ffmpeg_h264, ffmpeg_vp8,
             libopus::OpusDecoder,
             vulkan_h264,
         },
@@ -380,18 +380,17 @@ fn spawn_video_decoder(
     video: &VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    let transformer = {
-        match &video.description {
-            Some(desc) => {
-                let h264_config = H264AvcDecoderConfig::parse(desc.clone())
-                    .map_err(|_| MoqConnectionError::InvalidAvcc)?;
+    let transformer = match (&video.codec, &video.description) {
+        (VideoCodec::H264, Some(desc)) => {
+            let h264_config = H264AvcDecoderConfig::parse(desc.clone())
+                .map_err(|_| MoqConnectionError::InvalidAvcc)?;
 
-                Some(H264AvccToAnnexB::new(h264_config))
-            }
-            None => None,
+            Some(H264AvccToAnnexB::new(h264_config))
         }
+        _ => None,
     };
     if let Container::Cmaf(_) = video.container
+        && video.codec == VideoCodec::H264
         && transformer.is_none()
     {
         return Err(MoqConnectionError::MissingAvcc);
@@ -404,15 +403,18 @@ fn spawn_video_decoder(
         input_buffer_size: MOQ_MAX_BUFFER,
     };
 
-    let h264_decoder = match decoders.h264 {
-        Some(decoder) => decoder,
-        None => match ctx.graphics_context.has_vulkan_decoder_support() {
-            true => VideoDecoderOptions::VulkanH264,
-            false => VideoDecoderOptions::FfmpegH264,
-        },
+    let decoder_opt = match &video.codec {
+        VideoCodec::H264 => decoders.h264.unwrap_or_else(|| {
+            match ctx.graphics_context.has_vulkan_decoder_support() {
+                true => VideoDecoderOptions::VulkanH264,
+                false => VideoDecoderOptions::FfmpegH264,
+            }
+        }),
+        VideoCodec::Vp8 => VideoDecoderOptions::FfmpegVp8,
+        VideoCodec::Vp9 => todo!(),
     };
 
-    match h264_decoder {
+    match decoder_opt {
         VideoDecoderOptions::FfmpegH264 => Ok(VideoDecoderThread::<
             ffmpeg_h264::FfmpegH264Decoder,
             _,
@@ -421,7 +423,13 @@ fn spawn_video_decoder(
             vulkan_h264::VulkanH264Decoder,
             _,
         >::spawn(input_ref.clone(), options)?),
-        _ => Err(MoqConnectionError::UnsupportedVideoCodec),
+        VideoDecoderOptions::FfmpegVp8 => Ok(
+            VideoDecoderThread::<ffmpeg_vp8::FfmpegVp8Decoder, _>::spawn(
+                input_ref.clone(),
+                options,
+            )?,
+        ),
+        VideoDecoderOptions::FfmpegVp9 => todo!(),
     }
 }
 
@@ -476,9 +484,6 @@ enum MoqConnectionError {
 
     #[error("Failed to initialize decoder: {0}")]
     InitDecoder(#[from] DecoderInitError),
-
-    #[error("Unsupported video codec, H264 expected.")]
-    UnsupportedVideoCodec,
 
     #[error("Invalid H264 decoder config.")]
     InvalidAvcc,

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -380,15 +380,15 @@ fn spawn_video_decoder(
     video: &VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    let transformer = match (&video.codec, &video.container, &video.description) {
-        (VideoCodec::H264, Container::Cmaf(_), Some(desc)) => {
+    let transformer = match (&video.description, &video.codec, &video.container) {
+        (None, VideoCodec::H264, Container::Cmaf(_)) => {
+            return Err(MoqConnectionError::MissingAvcc);
+        }
+        (Some(desc), VideoCodec::H264, _) => {
             let h264_config = H264AvcDecoderConfig::parse(desc.clone())
                 .map_err(|_| MoqConnectionError::InvalidAvcc)?;
 
             Some(H264AvccToAnnexB::new(h264_config))
-        }
-        (VideoCodec::H264, Container::Cmaf(_), None) => {
-            return Err(MoqConnectionError::MissingAvcc);
         }
         _ => None,
     };

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -16,9 +16,11 @@ use crate::{
             decoder_thread_audio::{AudioDecoderThread, AudioDecoderThreadOptions},
             decoder_thread_video::{VideoDecoderThread, VideoDecoderThreadOptions},
             fdk_aac::FdkAacDecoder,
-            ffmpeg_h264, ffmpeg_vp8, ffmpeg_vp9,
+            ffmpeg_h264::FfmpegH264Decoder,
+            ffmpeg_vp8::FfmpegVp8Decoder,
+            ffmpeg_vp9::FfmpegVp9Decoder,
             libopus::OpusDecoder,
-            vulkan_h264,
+            vulkan_h264::VulkanH264Decoder,
         },
         moq::state::MoqInputState,
     },
@@ -380,64 +382,64 @@ fn spawn_video_decoder(
     video: &VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    let (decoder_opt, transformer) = match &video.codec {
+    let handle = match &video.codec {
         VideoCodec::H264 => {
-            let transformer = match (&video.description, &video.container) {
-                (None, Container::Cmaf(_)) => {
-                    return Err(MoqConnectionError::MissingAvcc);
-                }
-                (Some(desc), _) => {
-                    let h264_config = H264AvcDecoderConfig::parse(desc.clone())
-                        .map_err(|_| MoqConnectionError::InvalidAvcc)?;
-                    Some(H264AvccToAnnexB::new(h264_config))
-                }
-                (None, _) => None,
-            };
-
-            let decoder_opt = decoders.h264.unwrap_or_else(|| {
-                match ctx.graphics_context.has_vulkan_decoder_support() {
-                    true => VideoDecoderOptions::VulkanH264,
-                    false => VideoDecoderOptions::FfmpegH264,
-                }
-            });
-
-            (decoder_opt, transformer)
+            spawn_h264_video_decoder(ctx, input_ref, decoders, video, frame_sender)?
         }
-        VideoCodec::Vp8 => (VideoDecoderOptions::FfmpegVp8, None),
-        VideoCodec::Vp9 => (VideoDecoderOptions::FfmpegVp9, None),
+        VideoCodec::Vp8 => VideoDecoderThread::<FfmpegVp8Decoder, _>::spawn(
+            input_ref.clone(),
+            VideoDecoderThreadOptions::<H264AvccToAnnexB> {
+                ctx: ctx.clone(),
+                transformer: None,
+                frame_sender,
+                input_buffer_size: MOQ_MAX_BUFFER,
+            },
+        )?,
+        VideoCodec::Vp9 => VideoDecoderThread::<FfmpegVp9Decoder, _>::spawn(
+            input_ref.clone(),
+            VideoDecoderThreadOptions::<H264AvccToAnnexB> {
+                ctx: ctx.clone(),
+                transformer: None,
+                frame_sender,
+                input_buffer_size: MOQ_MAX_BUFFER,
+            },
+        )?,
+    };
+    Ok(handle)
+}
+
+fn spawn_h264_video_decoder(
+    ctx: &Arc<PipelineCtx>,
+    input_ref: &Ref<InputId>,
+    decoders: &MoqServerInputDecoders,
+    video: &VideoTrack,
+    frame_sender: QueueSender<Frame>,
+) -> Result<DecoderThreadHandle, MoqConnectionError> {
+    let config = match &video.description {
+        Some(desc) => Some(H264AvcDecoderConfig::parse(desc.clone())?),
+        None => match &video.container {
+            Container::Cmaf(_) => return Err(MoqConnectionError::MissingAvcc),
+            _ => None,
+        },
     };
 
     let options = VideoDecoderThreadOptions {
         ctx: ctx.clone(),
-        transformer,
+        transformer: config.map(H264AvccToAnnexB::new),
         frame_sender,
         input_buffer_size: MOQ_MAX_BUFFER,
     };
 
-    let handle =
-        match decoder_opt {
-            VideoDecoderOptions::FfmpegH264 => VideoDecoderThread::<
-                ffmpeg_h264::FfmpegH264Decoder,
-                _,
-            >::spawn(input_ref.clone(), options)?,
-            VideoDecoderOptions::VulkanH264 => VideoDecoderThread::<
-                vulkan_h264::VulkanH264Decoder,
-                _,
-            >::spawn(input_ref.clone(), options)?,
-            VideoDecoderOptions::FfmpegVp8 => {
-                VideoDecoderThread::<ffmpeg_vp8::FfmpegVp8Decoder, _>::spawn(
-                    input_ref.clone(),
-                    options,
-                )?
-            }
-            VideoDecoderOptions::FfmpegVp9 => {
-                VideoDecoderThread::<ffmpeg_vp9::FfmpegVp9Decoder, _>::spawn(
-                    input_ref.clone(),
-                    options,
-                )?
-            }
-        };
-
+    let default_decoder = match ctx.graphics_context.has_vulkan_decoder_support() {
+        true => VideoDecoderOptions::VulkanH264,
+        false => VideoDecoderOptions::FfmpegH264,
+    };
+    let handle = match decoders.h264.unwrap_or(default_decoder) {
+        VideoDecoderOptions::VulkanH264 => {
+            VideoDecoderThread::<VulkanH264Decoder, _>::spawn(input_ref.clone(), options)?
+        }
+        _ => VideoDecoderThread::<FfmpegH264Decoder, _>::spawn(input_ref.clone(), options)?,
+    };
     Ok(handle)
 }
 
@@ -494,7 +496,7 @@ enum MoqConnectionError {
     InitDecoder(#[from] DecoderInitError),
 
     #[error("Invalid H264 decoder config.")]
-    InvalidAvcc,
+    InvalidAvcc(#[from] H264AvcDecoderConfigError),
 
     #[error("Missing H264 decoder config.")]
     MissingAvcc,

--- a/smelter-core/src/pipeline/moq/connection.rs
+++ b/smelter-core/src/pipeline/moq/connection.rs
@@ -380,21 +380,18 @@ fn spawn_video_decoder(
     video: &VideoTrack,
     frame_sender: QueueSender<Frame>,
 ) -> Result<DecoderThreadHandle, MoqConnectionError> {
-    let transformer = match (&video.codec, &video.description) {
-        (VideoCodec::H264, Some(desc)) => {
+    let transformer = match (&video.codec, &video.container, &video.description) {
+        (VideoCodec::H264, Container::Cmaf(_), Some(desc)) => {
             let h264_config = H264AvcDecoderConfig::parse(desc.clone())
                 .map_err(|_| MoqConnectionError::InvalidAvcc)?;
 
             Some(H264AvccToAnnexB::new(h264_config))
         }
+        (VideoCodec::H264, Container::Cmaf(_), None) => {
+            return Err(MoqConnectionError::MissingAvcc);
+        }
         _ => None,
     };
-    if let Container::Cmaf(_) = video.container
-        && video.codec == VideoCodec::H264
-        && transformer.is_none()
-    {
-        return Err(MoqConnectionError::MissingAvcc);
-    }
 
     let options = VideoDecoderThreadOptions {
         ctx: ctx.clone(),

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -119,7 +119,13 @@ fn find_first_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, 
 
     let description = match &config.description {
         Some(desc) => Some(desc.clone()),
-        None => extract_codec_description(&container)?,
+        None => match extract_codec_description(&container) {
+            Ok(desc) => desc,
+            Err(error) => {
+                warn!(%error, "Failed to extract video decoder config from container; skipping video track.");
+                return Ok(None);
+            }
+        },
     };
 
     Ok(Some(VideoTrack {
@@ -151,7 +157,13 @@ fn find_first_audio(audio: &hang::catalog::Audio) -> Result<Option<AudioTrack>, 
 
     let description = match &config.description {
         Some(desc) => Some(desc.clone()),
-        None => extract_codec_description(&container)?,
+        None => match extract_codec_description(&container) {
+            Ok(desc) => desc,
+            Err(error) => {
+                warn!(%error, "Failed to extract audio decoder config from container; skipping audio track.");
+                return Ok(None);
+            }
+        },
     };
 
     Ok(Some(AudioTrack {

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -182,19 +182,17 @@ fn extract_codec_description(container: &Container) -> Result<Option<Bytes>, Moq
         return Ok(None);
     };
 
-    let codec = cmaf.trak().mdia.minf.stbl.stsd.codecs.first().ok_or(
-        MoqCatalogError::CodecConfigExtractionError("CMAF init segment contains no codec entries"),
-    )?;
+    let codec = cmaf.trak().mdia.minf.stbl.stsd.codecs.first();
 
     match codec {
-        mp4_atom::Codec::Avc1(avc1) => {
+        Some(mp4_atom::Codec::Avc1(avc1)) => {
             let mut buf = BytesMut::new();
             avc1.avcc.encode_body(&mut buf).map_err(|_| {
                 MoqCatalogError::CodecConfigExtractionError("failed to encode AVCDecoderConfig")
             })?;
             Ok(Some(buf.freeze()))
         }
-        mp4_atom::Codec::Mp4a(mp4a) => {
+        Some(mp4_atom::Codec::Mp4a(mp4a)) => {
             let mut buf = BytesMut::new();
             mp4a.esds
                 .es_desc

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -104,6 +104,7 @@ fn find_first_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, 
 
     let codec = match &config.codec {
         MoqVideoCodec::H264(_) => VideoCodec::H264,
+        MoqVideoCodec::VP8 => VideoCodec::Vp8,
         _ => {
             warn!("Unsupported video codec. Use H264.");
             return Ok(None);
@@ -115,8 +116,8 @@ fn find_first_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, 
         CatalogContainer::Loc => Container::Loc,
     };
 
-    let description = match (&config.description, &container) {
-        (None, Container::Cmaf(wire)) => match extract_codec_description(wire) {
+    let description = match (&config.description, &codec, &container) {
+        (None, VideoCodec::H264, Container::Cmaf(wire)) => match extract_codec_description(wire) {
             Ok(desc) => Some(desc),
             Err(error) => {
                 warn!(%error, "Failed to extract video decoder config from container; skipping video track.");

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -117,15 +117,9 @@ fn find_first_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, 
         CatalogContainer::Loc => Container::Loc,
     };
 
-    let description = match (&config.description, &codec, &container) {
-        (None, VideoCodec::H264, Container::Cmaf(wire)) => match extract_codec_description(wire) {
-            Ok(desc) => Some(desc),
-            Err(error) => {
-                warn!(%error, "Failed to extract video decoder config from container; skipping video track.");
-                return Ok(None);
-            }
-        },
-        _ => config.description.clone(),
+    let description = match &config.description {
+        Some(desc) => Some(desc.clone()),
+        None => extract_codec_description(&container)?,
     };
 
     Ok(Some(VideoTrack {
@@ -155,17 +149,9 @@ fn find_first_audio(audio: &hang::catalog::Audio) -> Result<Option<AudioTrack>, 
         CatalogContainer::Loc => Container::Loc,
     };
 
-    // Decoder config extraction is necessary only for AAC. Opus is self-contained and does not need
-    // description
-    let description = match (&config.description, &codec, &container) {
-        (None, AudioCodec::Aac, Container::Cmaf(wire)) => match extract_codec_description(wire) {
-            Ok(desc) => Some(desc),
-            Err(error) => {
-                warn!(%error, "Failed to extract audio decoder config from container; skipping audio track.");
-                return Ok(None);
-            }
-        },
-        _ => config.description.clone(),
+    let description = match &config.description {
+        Some(desc) => Some(desc.clone()),
+        None => extract_codec_description(&container)?,
     };
 
     Ok(Some(AudioTrack {
@@ -176,8 +162,13 @@ fn find_first_audio(audio: &hang::catalog::Audio) -> Result<Option<AudioTrack>, 
     }))
 }
 
-fn extract_codec_description(cmaf: &fmp4::Wire) -> Result<Bytes, MoqCatalogError> {
+fn extract_codec_description(container: &Container) -> Result<Option<Bytes>, MoqCatalogError> {
     use mp4_atom::{Atom, Encode};
+
+    // There is no data to extract from in other containers.
+    let Container::Cmaf(cmaf) = container else {
+        return Ok(None);
+    };
 
     let codec = cmaf.trak().mdia.minf.stbl.stsd.codecs.first().ok_or(
         MoqCatalogError::CodecConfigExtractionError("CMAF init segment contains no codec entries"),
@@ -189,7 +180,7 @@ fn extract_codec_description(cmaf: &fmp4::Wire) -> Result<Bytes, MoqCatalogError
             avc1.avcc.encode_body(&mut buf).map_err(|_| {
                 MoqCatalogError::CodecConfigExtractionError("failed to encode AVCDecoderConfig")
             })?;
-            Ok(buf.freeze())
+            Ok(Some(buf.freeze()))
         }
         mp4_atom::Codec::Mp4a(mp4a) => {
             let mut buf = BytesMut::new();
@@ -203,10 +194,8 @@ fn extract_codec_description(cmaf: &fmp4::Wire) -> Result<Bytes, MoqCatalogError
                         "failed to encode AudioSpecificConfig",
                     )
                 })?;
-            Ok(buf.freeze())
+            Ok(Some(buf.freeze()))
         }
-        _ => Err(MoqCatalogError::CodecConfigExtractionError(
-            "unsupported codec in CMAF init segment",
-        )),
+        _ => Ok(None),
     }
 }

--- a/smelter-core/src/pipeline/moq/connection/catalog.rs
+++ b/smelter-core/src/pipeline/moq/connection/catalog.rs
@@ -105,8 +105,9 @@ fn find_first_video(video: &hang::catalog::Video) -> Result<Option<VideoTrack>, 
     let codec = match &config.codec {
         MoqVideoCodec::H264(_) => VideoCodec::H264,
         MoqVideoCodec::VP8 => VideoCodec::Vp8,
+        MoqVideoCodec::VP9(_) => VideoCodec::Vp9,
         _ => {
-            warn!("Unsupported video codec. Use H264.");
+            warn!("Unsupported video codec. Use H264, VP8 or VP9.");
             return Ok(None);
         }
     };


### PR DESCRIPTION
- #2009 

---

One word about API for `decoder_map`. It mirrors the RTMP server input, i. e. Only one option for `h264` which chooses software vs hardware decoding. If this option is set and detected codec is vp8 or vp9 it will be ignored and take no effect.