### PR TITLE
Correct error codes for MoQ server input registration.

### DIFF
--- a/smelter-core/src/error.rs
+++ b/smelter-core/src/error.rs
@@ -330,6 +330,7 @@ const INVALID_MP4_SOURCE: &str = "INVALID_MP4_SOURCE";
 const WHEP_INVALID_SERVER_URL: &str = "WHEP_INVALID_SERVER_URL";
 const WHEP_REQUEST_FAILED: &str = "WHEP_REQUEST_FAILED";
 const WHEP_BAD_STATUS: &str = "WHEP_BAD_STATUS";
+const MOQ_SERVER_NOT_RUNNING: &str = "MOQ_SERVER_NOT_RUNNING";
 
 impl From<&RegisterInputError> for PipelineErrorInfo {
     fn from(err: &RegisterInputError) -> Self {
@@ -370,6 +371,12 @@ impl From<&RegisterInputError> for PipelineErrorInfo {
             RegisterInputError::InputError(_, InputInitError::Mp4(Mp4InputError::IoError(_))) => {
                 PipelineErrorInfo::new(INVALID_MP4_SOURCE, ErrorType::UserError)
             }
+
+            // MoQ Server
+            RegisterInputError::InputError(
+                _,
+                InputInitError::Moq(MoqServerError::ServerNotRunning),
+            ) => PipelineErrorInfo::new(MOQ_SERVER_NOT_RUNNING, ErrorType::UserError),
 
             // FFmpeg (used in HLS input)
             RegisterInputError::InputError(

--- a/smelter-core/src/pipeline/moq/state.rs
+++ b/smelter-core/src/pipeline/moq/state.rs
@@ -5,7 +5,7 @@ use std::{
 
 use sha3::{Digest, Sha3_512};
 use tokio::task::JoinHandle;
-use tracing::error;
+use tracing::warn;
 
 use crate::{pipeline::moq::server::MoqSession, queue::WeakQueueInput};
 
@@ -79,7 +79,7 @@ impl MoqServerState {
                     .store(true, std::sync::atomic::Ordering::Relaxed);
             }
             None => {
-                error!(?input_ref, "Failed to remove MoQ input, ID not found");
+                warn!(?input_ref, "Failed to remove MoQ input, ID not found");
             }
         }
     }

--- a/smelter-core/src/protocols/moq.rs
+++ b/smelter-core/src/protocols/moq.rs
@@ -49,9 +49,6 @@ pub enum MoqServerError {
 
     #[error("Unable to decode URL path: {0}")]
     UrlDecodeFailed(#[from] FromUtf8Error),
-
-    #[error("MoQ handshake failed: {0}")]
-    MoqHandshakeFailed(#[source] anyhow::Error),
 }
 
 impl MoqServerError {


### PR DESCRIPTION
I forgot to do that before. Plus some cleanup for correct log level in one place and removed unused error variant.