### PR TITLE
[ci] Do not abort early if some test failed

### DIFF
--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -144,10 +144,12 @@ jobs:
                   cargo nextest run --workspace --profile ci -E 'not test(/^pipeline_tests::/)'
 
             - name: 🧪 Run pipeline tests
+              if: ${{ !cancelled() }}
               run: |
                   cargo nextest run --workspace --profile ci -E 'test(/^pipeline_tests::/) and not test(/_flaky$/)'
 
             - name: 🧪 Run flaky pipeline tests
+              if: ${{ !cancelled() }}
               run: |
                   cargo nextest run --workspace --profile ci -E 'test(/^pipeline_tests::/) and test(/_flaky$/)'
 


### PR DESCRIPTION
Regenerating test via CI is annoying if different test groups are failing