### PR TITLE
Proposed change for build caches

### DIFF
--- a/.github/workflows/rust_check.yml
+++ b/.github/workflows/rust_check.yml
@@ -39,6 +39,7 @@ jobs:
               uses: Swatinem/rust-cache@v2
               with:
                   shared-key: "linux-build"
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: 🪢 Generate Chromium Embedded Framework bindings
               run: cargo build --package libcef
@@ -83,6 +84,7 @@ jobs:
               uses: Swatinem/rust-cache@v2
               with:
                   shared-key: "macos-build"
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: 🪢 Generate Chromium Embedded Framework bindings
               run: cargo build --package libcef
@@ -137,8 +139,9 @@ jobs:
             - name: 📁 Rust cache
               uses: Swatinem/rust-cache@v2
               with:
-                  shared-key: "linux-build"
-                  
+                  shared-key: "linux-test"
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
+
             - name: 🧪 Run non-pipeline tests
               run: |
                   cargo nextest run --workspace --profile ci -E 'not test(/^pipeline_tests::/)'


### PR DESCRIPTION
This patch does 2 things:
- Only save build cache on master runs, don't save on PR runs
- Give tests their own cache key

Why:

With PRs saving build caches, there are a lot of evictions due to overflowing the 10GB cache limit. This hurts the overall performance of all jobs significantly. If we only save cache from `master` runs, then we have two effects:
- if a PR does not change lockfiles, cache is restored hopefully every, or almost every time
- if a PR does change lockfiles, the rust cache never works (which is only a bit worse than the current situation)

I think this is a good tradeoff.

Also, lowering evictions and decreasing relevant cache size allows us to cache tests separately. This is meaningful, because if the tests use the same cache as the build job, they can never save (only the first job with a given key in a PR saves, from what I understand). Switching tests to their own cache allows caching them properly.

I'm not saying this is definitely a good change, I think it's more of a something that we can consider, but I'm for merging this. Also, feel free to merge/close this PR if the discussion resolves while I'm on holiday.

Also, sorry for this PR's job runs causing a lot of evictions 🤷