### PR TITLE
[gpu-video] Improve compile times a bit (on linux)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,17 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,13 +2329,12 @@ dependencies = [
  "bytes",
  "cfg_aliases",
  "clap",
- "derivative",
  "h264-reader",
  "memchr",
  "naga",
  "pollster",
  "rustc-hash 2.1.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",
  "vk-mem",
@@ -8222,7 +8210,6 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.17",
  "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
  "wgpu-core-deps-wasm",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
@@ -8235,15 +8222,6 @@ name = "wgpu-core-deps-apple"
 version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-emscripten"
-version = "30.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
 dependencies = [
  "wgpu-hal",
 ]

--- a/gpu-video/Cargo.toml
+++ b/gpu-video/Cargo.toml
@@ -29,13 +29,17 @@ default = ["wgpu"]
 [dependencies]
 bytemuck = { version = "1.19.0", features = ["derive"], optional = true }
 bytes = "1"
-derivative = "2.2.0"
 h264-reader = { workspace = true }
 memchr = "2.7.4"
 rustc-hash = "2.1.1"
-thiserror = "1.0.59"
+thiserror = "2"
 tracing = "0.1.40"
-wgpu = { version = "30.0.0", optional = true }
+wgpu = { version = "30.0.0", optional = true, default-features = false, features = [
+    "std",
+    "parking_lot",
+    "vulkan",
+    "wgsl",
+] }
 
 # Platforms that support vulkan are: windows and all non-apple unixes. emscripten is a web-based platform, where vulkan is not available either
 [target.'cfg(any(windows, all(unix, not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "macos"))))'.dependencies]
@@ -45,7 +49,13 @@ vk-mem = "0.4.0"
 [dev-dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 tracing-subscriber = "0.3.20"
-wgpu = { version = "30.0.0", features = ["noop"] }
+wgpu = { version = "30.0.0", default-features = false, features = [
+    "std",
+    "parking_lot",
+    "vulkan",
+    "wgsl",
+    "noop",
+] }
 winit = "0.30"
 bytemuck = { version = "1.19.0", features = ["derive"] }
 pollster = { workspace = true }

--- a/gpu-video/src/parser/nalu_parser.rs
+++ b/gpu-video/src/parser/nalu_parser.rs
@@ -156,16 +156,21 @@ pub struct Nalu {
     pub pts: Option<u64>,
 }
 
-#[derive(derivative::Derivative)]
-#[derivative(Debug)]
 pub struct Slice {
     pub nal_header: h264_reader::nal::NalHeader,
     pub pps_id: h264_reader::nal::pps::PicParamSetId,
     pub header: Arc<SliceHeader>,
-    #[derivative(Debug = "ignore")]
     pub rbsp_bytes: Vec<u8>,
-    #[derivative(Debug = "ignore")]
     pub sps: h264_reader::nal::sps::SeqParameterSet,
-    #[derivative(Debug = "ignore")]
     pub pps: h264_reader::nal::pps::PicParameterSet,
+}
+
+impl std::fmt::Debug for Slice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Slice")
+            .field("nal_header", &self.nal_header)
+            .field("pps_id", &self.pps_id)
+            .field("header", &self.header)
+            .finish_non_exhaustive()
+    }
 }

--- a/gpu-video/src/parser/reference_manager.rs
+++ b/gpu-video/src/parser/reference_manager.rs
@@ -1268,20 +1268,31 @@ impl SliceHeaderExt for SliceHeader {
     }
 }
 
-#[derive(Clone, derivative::Derivative)]
-#[derivative(Debug)]
+#[derive(Clone)]
 pub struct DecodeInformation {
     pub(crate) reference_list_l0: Option<Vec<ReferencePictureInfo>>,
     pub(crate) reference_list_l1: Option<Vec<ReferencePictureInfo>>,
-    #[derivative(Debug = "ignore")]
     pub(crate) rbsp_bytes: Vec<u8>,
     pub(crate) slice_indices: Vec<usize>,
-    #[derivative(Debug = "ignore")]
     pub(crate) header: Arc<SliceHeader>,
     pub(crate) sps_id: u8,
     pub(crate) pps_id: u8,
     pub(crate) picture_info: PictureInfo,
     pub(crate) pts: Option<u64>,
+}
+
+impl std::fmt::Debug for DecodeInformation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecodeInformation")
+            .field("reference_list_l0", &self.reference_list_l0)
+            .field("reference_list_l1", &self.reference_list_l1)
+            .field("slice_indices", &self.slice_indices)
+            .field("sps_id", &self.sps_id)
+            .field("pps_id", &self.pps_id)
+            .field("picture_info", &self.picture_info)
+            .field("pts", &self.pts)
+            .finish_non_exhaustive()
+    }
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
For a long time, I wanted to check how much compile time can we save by managing dependencies more carefully

Turns out a bit, but not a ton:

| change | build with wgpu | build with no default features | example decode | example decode_wgpu |
|--------|----------|---------|-----------|----------------|
| before | 14.6s | 6.3s | 15.4s | 16.7s |
| after | 12.5s | 6.3s | 13.8s | 15.0s |
| change | -14.4% | 0% | -10.4% | -10.2% | 