### PR TITLE
Add standalone media input and output handles

### DIFF
--- a/smelter-core/src/pipeline.rs
+++ b/smelter-core/src/pipeline.rs
@@ -46,6 +46,7 @@ mod runtime;
 
 pub(crate) mod utils;
 
+pub use input::{AudioDrainResult, InputDrain, InputHandle, TrackAdvance, VideoDrainResult};
 pub use instance::Pipeline;
 pub(crate) use moq::SelfSignedTlsError;
 pub use output::{AudioOutputEndpoint, OutputHandle, VideoOutputEndpoint};

--- a/smelter-core/src/pipeline.rs
+++ b/smelter-core/src/pipeline.rs
@@ -42,11 +42,14 @@ mod webrtc;
 mod input;
 mod instance;
 mod output;
+mod runtime;
 
 pub(crate) mod utils;
 
 pub use instance::Pipeline;
 pub(crate) use moq::SelfSignedTlsError;
+pub use output::{AudioOutputEndpoint, OutputHandle, VideoOutputEndpoint};
+pub use runtime::{MediaRuntime, MediaRuntimeOptions};
 
 #[cfg(target_os = "linux")]
 pub use v4l2::{V4l2DeviceInfo, V4l2FormatInfo, V4l2ResolutionInfo, list_v4l2_devices};

--- a/smelter-core/src/pipeline/input.rs
+++ b/smelter-core/src/pipeline/input.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     pipeline::{
+        MediaRuntime,
         hls::HlsInput,
         moq::{MoqClientInput, MoqServerInput},
         mp4::Mp4Input,
@@ -12,7 +13,7 @@ use crate::{
         rtp::RtpInput,
         webrtc::{WhepInput, WhipInput},
     },
-    queue::QueueInput,
+    queue::{QueueInput, QueueTrackAdvance},
 };
 
 use crate::prelude::*;
@@ -26,6 +27,37 @@ pub struct PipelineInput {
     /// Some(received) - Whether EOS was received from queue on video stream for that input.
     /// None - No video configured for that input.
     pub(super) video_eos_received: Option<bool>,
+}
+
+pub struct InputHandle {
+    _runtime: MediaRuntime,
+    input: Input,
+    info: InputInitInfo,
+    drain: InputDrain,
+}
+
+#[derive(Clone)]
+pub struct InputDrain {
+    queue_input: QueueInput,
+}
+
+#[derive(Debug, Clone)]
+pub struct VideoDrainResult {
+    pub frame: Option<Frame>,
+    pub end_of_stream: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioDrainResult {
+    pub samples: Vec<InputAudioSamples>,
+    pub end_of_stream: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackAdvance {
+    Advanced,
+    CurrentTrackNotDrained,
+    WaitingForTrack,
 }
 
 pub enum Input {
@@ -91,6 +123,77 @@ impl Input {
             }
             _ => Err(UpdateInputError::PausingNotSupported(self.kind())),
         }
+    }
+}
+
+impl InputHandle {
+    pub fn info(&self) -> &InputInitInfo {
+        &self.info
+    }
+
+    pub fn drain(&self) -> InputDrain {
+        self.drain.clone()
+    }
+
+    pub fn kind(&self) -> InputProtocolKind {
+        self.input.kind()
+    }
+
+    pub fn seek(&self, position: Duration) -> Result<(), UpdateInputError> {
+        self.input.seek(position)
+    }
+
+    pub fn pause(&self) -> Result<(), UpdateInputError> {
+        self.input.pause()
+    }
+
+    pub fn resume(&self) -> Result<(), UpdateInputError> {
+        self.input.resume()
+    }
+}
+
+impl InputDrain {
+    pub fn pull_video(&self, pts: Duration) -> Option<VideoDrainResult> {
+        self.queue_input
+            .pull_video(pts)
+            .map(|result| VideoDrainResult {
+                frame: result.frame,
+                end_of_stream: result.is_eos,
+            })
+    }
+
+    pub fn pull_audio(&self, start_pts: Duration, end_pts: Duration) -> Option<AudioDrainResult> {
+        self.queue_input
+            .pull_audio((start_pts, end_pts))
+            .map(|result| AudioDrainResult {
+                samples: result.samples,
+                end_of_stream: result.is_eos,
+            })
+    }
+
+    pub fn advance_track(&self) -> TrackAdvance {
+        match self.queue_input.advance_track() {
+            QueueTrackAdvance::Advanced => TrackAdvance::Advanced,
+            QueueTrackAdvance::CurrentTrackNotDrained => TrackAdvance::CurrentTrackNotDrained,
+            QueueTrackAdvance::WaitingForTrack => TrackAdvance::WaitingForTrack,
+        }
+    }
+}
+
+impl MediaRuntime {
+    pub fn create_input(
+        &self,
+        input_id: InputId,
+        options: RegisterInputOptions,
+    ) -> Result<InputHandle, InputInitError> {
+        let (input, info, queue_input) =
+            new_external_input(self.ctx.clone(), Ref::new(&input_id), options)?;
+        Ok(InputHandle {
+            _runtime: self.clone(),
+            input,
+            info,
+            drain: InputDrain { queue_input },
+        })
     }
 }
 

--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -662,7 +662,7 @@ fn create_pipeline(opts: PipelineOptions) -> Result<Pipeline, InitPipelineError>
     Ok(pipeline)
 }
 
-fn prepare_side_channel_socket_dir(dir: &Path) -> Result<(), InitPipelineError> {
+pub(super) fn prepare_side_channel_socket_dir(dir: &Path) -> Result<(), InitPipelineError> {
     if !dir.exists() {
         return std::fs::create_dir_all(dir).map_err(|e| {
             InitPipelineError::SideChannelSocketDir(format!(

--- a/smelter-core/src/pipeline/output.rs
+++ b/smelter-core/src/pipeline/output.rs
@@ -8,6 +8,8 @@ use smelter_render::OutputFrameFormat;
 use tracing::{info, warn};
 
 use crate::pipeline::{
+    MediaRuntime,
+    channel::EncodedDataOutput,
     hls::HlsOutput,
     input::PipelineInput,
     moq::MoqClientOutput,
@@ -22,6 +24,27 @@ pub(crate) struct PipelineOutput {
     pub output: Box<dyn Output>,
     pub video_end_condition: Option<PipelineOutputEndConditionState>,
     pub audio_end_condition: Option<PipelineOutputEndConditionState>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VideoOutputEndpoint {
+    pub resolution: Resolution,
+    pub frame_format: OutputFrameFormat,
+    pub frame_sender: Sender<PipelineEvent<Frame>>,
+    pub keyframe_request_sender: Sender<()>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioOutputEndpoint {
+    pub samples_batch_sender: Sender<PipelineEvent<OutputAudioSamples>>,
+}
+
+pub struct OutputHandle {
+    _runtime: MediaRuntime,
+    output: Box<dyn Output>,
+    video: Option<VideoOutputEndpoint>,
+    audio: Option<AudioOutputEndpoint>,
+    port: Option<Port>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -41,6 +64,67 @@ pub(crate) trait Output: Send {
     fn audio(&self) -> Option<OutputAudio<'_>>;
     fn video(&self) -> Option<OutputVideo<'_>>;
     fn kind(&self) -> OutputProtocolKind;
+}
+
+impl OutputHandle {
+    fn new(runtime: MediaRuntime, output: Box<dyn Output>, port: Option<Port>) -> OutputHandle {
+        let video = output.video().map(|video| VideoOutputEndpoint {
+            resolution: video.resolution,
+            frame_format: video.frame_format,
+            frame_sender: video.frame_sender.clone(),
+            keyframe_request_sender: video.keyframe_request_sender.clone(),
+        });
+        let audio = output.audio().map(|audio| AudioOutputEndpoint {
+            samples_batch_sender: audio.samples_batch_sender.clone(),
+        });
+        Self {
+            _runtime: runtime,
+            output,
+            video,
+            audio,
+            port,
+        }
+    }
+
+    pub fn video(&self) -> Option<&VideoOutputEndpoint> {
+        self.video.as_ref()
+    }
+
+    pub fn audio(&self) -> Option<&AudioOutputEndpoint> {
+        self.audio.as_ref()
+    }
+
+    pub fn port(&self) -> Option<Port> {
+        self.port
+    }
+
+    pub fn kind(&self) -> OutputProtocolKind {
+        self.output.kind()
+    }
+}
+
+impl MediaRuntime {
+    pub fn create_output(
+        &self,
+        output_id: OutputId,
+        options: ProtocolOutputOptions,
+    ) -> Result<OutputHandle, OutputInitError> {
+        let (output, port) = new_external_output(self.ctx.clone(), Ref::new(&output_id), options)?;
+        Ok(OutputHandle::new(self.clone(), output, port))
+    }
+
+    pub fn create_encoded_output(
+        &self,
+        output_id: OutputId,
+        options: EncodedDataOutputOptions,
+    ) -> Result<(OutputHandle, EncodedDataOutputHandle), OutputInitError> {
+        let (output, encoded) =
+            EncodedDataOutput::new(self.ctx.clone(), Ref::new(&output_id), options)?;
+        Ok((
+            OutputHandle::new(self.clone(), Box::new(output), None),
+            encoded,
+        ))
+    }
 }
 
 pub(super) fn new_external_output(

--- a/smelter-core/src/pipeline/runtime.rs
+++ b/smelter-core/src/pipeline/runtime.rs
@@ -1,0 +1,119 @@
+use std::{
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use crossbeam_channel::Receiver;
+use smelter_render::{Framerate, WgpuCtx};
+use tokio::runtime::Runtime;
+
+use crate::{
+    event::{Event, EventEmitter},
+    graphics_context::GraphicsContext,
+    pipeline::{
+        PipelineCtx, instance::prepare_side_channel_socket_dir, webrtc::WebrtcSettingEngineCtx,
+    },
+    queue::QueueContext,
+    stats::{StatsMonitor, StatsReport},
+};
+
+use crate::prelude::*;
+
+pub struct MediaRuntimeOptions {
+    pub sync_point: Instant,
+    pub default_buffer_duration: Duration,
+    pub side_channel_socket_dir: Option<Arc<Path>>,
+    pub output_framerate: Framerate,
+    pub mixing_sample_rate: u32,
+    pub download_root: Arc<Path>,
+    pub graphics_context: GraphicsContext,
+    pub wgpu_ctx: Arc<WgpuCtx>,
+    pub tokio_rt: Option<Arc<Runtime>>,
+    pub webrtc_stun_servers: Arc<Vec<String>>,
+    pub webrtc_udp_port_strategy: Option<WebrtcUdpPortStrategy>,
+    pub webrtc_nat_1to1_ips: Arc<Vec<String>>,
+    pub moq_disable_tls_verification: bool,
+}
+
+struct MediaRuntimeLifetime {
+    stats_monitor: StatsMonitor,
+    webrtc_setting_engine: WebrtcSettingEngineCtx,
+}
+
+impl Drop for MediaRuntimeLifetime {
+    fn drop(&mut self) {
+        self.webrtc_setting_engine.close();
+    }
+}
+
+#[derive(Clone)]
+pub struct MediaRuntime {
+    pub(super) ctx: Arc<PipelineCtx>,
+    lifetime: Arc<MediaRuntimeLifetime>,
+}
+
+impl MediaRuntime {
+    pub fn new(options: MediaRuntimeOptions) -> Result<Self, InitPipelineError> {
+        if let Some(dir) = options.side_channel_socket_dir.as_deref() {
+            prepare_side_channel_socket_dir(dir)?;
+        }
+        let download_dir: Arc<Path> = options
+            .download_root
+            .join(format!("smelter-{}", rand::random::<u64>()))
+            .into();
+        std::fs::create_dir_all(&download_dir).map_err(InitPipelineError::CreateDownloadDir)?;
+        let tokio_rt = match options.tokio_rt {
+            Some(tokio_rt) => tokio_rt,
+            None => Arc::new(Runtime::new().map_err(InitPipelineError::CreateTokioRuntime)?),
+        };
+        let (stats_monitor, stats_sender) = StatsMonitor::new();
+        let webrtc_setting_engine = WebrtcSettingEngineCtx::new(
+            options.webrtc_nat_1to1_ips,
+            options.webrtc_udp_port_strategy,
+            &tokio_rt,
+        )?;
+        let ctx = Arc::new(PipelineCtx {
+            queue_ctx: QueueContext::new(options.sync_point, options.side_channel_socket_dir),
+            default_buffer_duration: options.default_buffer_duration,
+            mixing_sample_rate: options.mixing_sample_rate,
+            output_framerate: options.output_framerate,
+            download_dir,
+            graphics_context: options.graphics_context,
+            wgpu_ctx: options.wgpu_ctx,
+            event_emitter: Arc::new(EventEmitter::new()),
+            stats_sender,
+            webrtc_stun_servers: options.webrtc_stun_servers,
+            webrtc_setting_engine: webrtc_setting_engine.clone(),
+            moq_disable_tls_verification: options.moq_disable_tls_verification,
+            tokio_rt,
+            whip_whep_state: None,
+            rtmp_state: None,
+            moq_state: None,
+        });
+        Ok(Self {
+            ctx,
+            lifetime: Arc::new(MediaRuntimeLifetime {
+                stats_monitor,
+                webrtc_setting_engine,
+            }),
+        })
+    }
+
+    pub fn stats(&self) -> StatsReport {
+        self.lifetime.stats_monitor.report()
+    }
+
+    pub fn subscribe_events(&self) -> Receiver<Event> {
+        self.ctx.event_emitter.subscribe()
+    }
+
+    pub fn with_output_framerate(&self, output_framerate: Framerate) -> Self {
+        let mut ctx = (*self.ctx).clone();
+        ctx.output_framerate = output_framerate;
+        Self {
+            ctx: Arc::new(ctx),
+            lifetime: self.lifetime.clone(),
+        }
+    }
+}

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -29,7 +29,7 @@ use crate::prelude::*;
 
 pub use self::queue_input::QueueInputOptions;
 pub(crate) use self::queue_input::{
-    QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, WeakQueueInput,
+    QueueInput, QueueSender, QueueTrackAdvance, QueueTrackOffset, QueueTrackOptions, WeakQueueInput,
 };
 
 use self::{
@@ -182,9 +182,9 @@ pub(super) struct QueueVideoOutput {
 
 #[derive(Debug, Clone)]
 pub(super) struct QueueVideoFrame {
-    pub frame: Option<Frame>,
+    pub(crate) frame: Option<Frame>,
     /// Track on this input ended.
-    pub is_eos: bool,
+    pub(crate) is_eos: bool,
 }
 
 impl QueueVideoFrame {
@@ -219,9 +219,9 @@ pub(super) struct QueueAudioOutput {
 
 #[derive(Debug, Clone)]
 pub(super) struct QueueAudioSamples {
-    pub samples: Vec<InputAudioSamples>,
+    pub(crate) samples: Vec<InputAudioSamples>,
     /// Track on this input ended.
-    pub is_eos: bool,
+    pub(crate) is_eos: bool,
 }
 
 impl QueueAudioSamples {

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -156,6 +156,15 @@ pub struct QueueContext {
 }
 
 impl QueueContext {
+    pub(crate) fn new(sync_point: Instant, side_channel_socket_dir: Option<Arc<Path>>) -> Self {
+        Self {
+            sync_point,
+            start_pts: Default::default(),
+            last_pts: Default::default(),
+            side_channel_socket_dir,
+        }
+    }
+
     pub(crate) fn effective_last_pts(&self) -> Duration {
         self.last_pts
             .value()
@@ -255,12 +264,7 @@ impl<T: Clone> Clone for PipelineEvent<T> {
 
 impl Queue {
     pub(crate) fn new(opts: QueueOptions) -> Arc<Self> {
-        let queue_ctx = QueueContext {
-            sync_point: Instant::now(),
-            start_pts: Default::default(),
-            last_pts: Default::default(),
-            side_channel_socket_dir: opts.side_channel_socket_dir,
-        };
+        let queue_ctx = QueueContext::new(Instant::now(), opts.side_channel_socket_dir);
         let (queue_start_sender, queue_start_receiver) = bounded(0);
         let (scheduled_event_sender, scheduled_event_receiver) = bounded(0);
         let queue = Arc::new(Queue {

--- a/smelter-core/src/queue/audio_input.rs
+++ b/smelter-core/src/queue/audio_input.rs
@@ -110,6 +110,23 @@ impl AudioQueueInput {
         pts_range: (Duration, Duration),
         queue_start_pts: Duration,
     ) -> QueueAudioSamples {
+        self.pop_samples_with_lookahead(pts_range, queue_start_pts, MIXER_STRETCH_BUFFER)
+    }
+
+    pub(super) fn pop_samples_before(
+        &mut self,
+        pts_range: (Duration, Duration),
+        queue_start_pts: Duration,
+    ) -> QueueAudioSamples {
+        self.pop_samples_with_lookahead(pts_range, queue_start_pts, Duration::ZERO)
+    }
+
+    fn pop_samples_with_lookahead(
+        &mut self,
+        pts_range: (Duration, Duration),
+        queue_start_pts: Duration,
+        lookahead: Duration,
+    ) -> QueueAudioSamples {
         if self.paused {
             return QueueAudioSamples::empty();
         }
@@ -130,7 +147,7 @@ impl AudioQueueInput {
             };
         }
 
-        let input_pts = (pts_range.1 + MIXER_STRETCH_BUFFER).saturating_sub(offset);
+        let input_pts = (pts_range.1 + lookahead).saturating_sub(offset);
         trace!(queue_pts=?pts_range, ?input_pts, "Try get samples batch");
 
         let mut samples = self.receiver.pop_before_pts(input_pts);

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use crate::{
     event::EventEmitter,
     queue::{
-        QueueContext,
+        QueueAudioSamples, QueueContext, QueueVideoFrame,
         audio_input::AudioQueueInput,
         side_channel::{AudioSideChannel, VideoSideChannel},
         utils::PauseState,
@@ -32,6 +32,13 @@ struct PendingTrack {
 }
 
 pub(crate) struct QueueSender<T>(crossbeam_channel::Sender<T>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QueueTrackAdvance {
+    Advanced,
+    CurrentTrackNotDrained,
+    WaitingForTrack,
+}
 
 impl<T> QueueSender<T> {
     pub(crate) fn new(sender: crossbeam_channel::Sender<T>) -> Self {
@@ -74,18 +81,30 @@ pub(super) struct InnerQueueInput {
 
 impl InnerQueueInput {
     fn maybe_start_next_track(&mut self) {
-        let video_eos_sent = self.video.as_ref().map(|v| v.eos_sent()).unwrap_or(true);
-        let audio_eos_sent = self.audio.as_ref().map(|a| a.eos_sent()).unwrap_or(true);
-        if video_eos_sent && audio_eos_sent {
-            self.replace_track()
-        }
+        let _ = self.advance_track();
     }
 
-    /// Replace current track with the next pending, do nothing if there is no pending
+    fn advance_track(&mut self) -> QueueTrackAdvance {
+        let video_eos_sent = self.video.as_ref().map(|v| v.eos_sent()).unwrap_or(true);
+        let audio_eos_sent = self.audio.as_ref().map(|a| a.eos_sent()).unwrap_or(true);
+        if !video_eos_sent || !audio_eos_sent {
+            return QueueTrackAdvance::CurrentTrackNotDrained;
+        }
+        let Ok(pending) = self.pending_receiver.try_recv() else {
+            return QueueTrackAdvance::WaitingForTrack;
+        };
+        self.install_track(pending);
+        QueueTrackAdvance::Advanced
+    }
+
     fn replace_track(&mut self) {
         let Ok(pending) = self.pending_receiver.try_recv() else {
             return;
         };
+        self.install_track(pending);
+    }
+
+    fn install_track(&mut self, pending: PendingTrack) {
         info!(input_id=%self.input_ref, "Push track to queue");
 
         self.video = pending.video;
@@ -335,6 +354,28 @@ impl QueueInput {
 
     pub(super) fn maybe_start_next_track(&self) {
         self.0.lock().unwrap().maybe_start_next_track();
+    }
+
+    pub(crate) fn pull_video(&self, pts: Duration) -> Option<QueueVideoFrame> {
+        self.0
+            .lock()
+            .unwrap()
+            .video
+            .as_mut()
+            .map(|video| video.get_frame(pts, Duration::ZERO))
+    }
+
+    pub(crate) fn pull_audio(&self, pts_range: (Duration, Duration)) -> Option<QueueAudioSamples> {
+        self.0
+            .lock()
+            .unwrap()
+            .audio
+            .as_mut()
+            .map(|audio| audio.pop_samples_before(pts_range, Duration::ZERO))
+    }
+
+    pub(crate) fn advance_track(&self) -> QueueTrackAdvance {
+        self.0.lock().unwrap().advance_track()
     }
 }
 

--- a/smelter-core/src/queue/tests/drain.rs
+++ b/smelter-core/src/queue/tests/drain.rs
@@ -1,0 +1,85 @@
+use std::{sync::Arc, time::Instant};
+
+use smelter_render::InputId;
+
+use crate::{
+    event::EventEmitter,
+    queue::{
+        QueueContext, QueueInput, QueueInputOptions, QueueTrackAdvance, QueueTrackOffset,
+        QueueTrackOptions,
+    },
+    types::Ref,
+};
+
+use super::harness::{ms, test_frame, test_samples};
+
+fn input() -> QueueInput {
+    let input_id = InputId("drain".into());
+    QueueInput::new_inner(
+        QueueContext::new(Instant::now(), None),
+        Arc::new(EventEmitter::new()),
+        &Ref::new(&input_id),
+        QueueInputOptions::default(),
+        None,
+        None,
+    )
+}
+
+fn media_track() -> QueueTrackOptions {
+    QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    }
+}
+
+#[test]
+fn advances_only_after_both_streams_are_drained() {
+    let input = input();
+    let (video, audio) = input.queue_new_track(media_track());
+    assert_eq!(input.advance_track(), QueueTrackAdvance::Advanced);
+    let (video, audio) = (video.unwrap(), audio.unwrap());
+    video.send(test_frame(0, ms(0))).unwrap();
+    audio.send(test_samples(ms(0), ms(20))).unwrap();
+
+    let (_next_video, _next_audio) = input.queue_new_track(media_track());
+    assert_eq!(
+        input.advance_track(),
+        QueueTrackAdvance::CurrentTrackNotDrained
+    );
+
+    drop(video);
+    assert!(input.pull_video(ms(20)).unwrap().is_eos);
+    assert_eq!(
+        input.advance_track(),
+        QueueTrackAdvance::CurrentTrackNotDrained
+    );
+
+    drop(audio);
+    assert!(input.pull_audio((ms(0), ms(40))).unwrap().is_eos);
+    assert_eq!(input.advance_track(), QueueTrackAdvance::Advanced);
+}
+
+#[test]
+fn exact_audio_pull_has_no_mixer_lookahead() {
+    let input = input();
+    let (_video, audio) = input.queue_new_track(QueueTrackOptions {
+        video: false,
+        audio: true,
+        offset: QueueTrackOffset::Pts(ms(0)),
+    });
+    assert_eq!(input.advance_track(), QueueTrackAdvance::Advanced);
+    audio.unwrap().send(test_samples(ms(100), ms(20))).unwrap();
+
+    assert!(
+        input
+            .pull_audio((ms(0), ms(50)))
+            .unwrap()
+            .samples
+            .is_empty()
+    );
+    assert_eq!(
+        input.pull_audio((ms(50), ms(120))).unwrap().samples.len(),
+        1
+    );
+}

--- a/smelter-core/src/queue/tests/mod.rs
+++ b/smelter-core/src/queue/tests/mod.rs
@@ -1,4 +1,5 @@
 mod audio;
+mod drain;
 mod events;
 mod harness;
 mod video;


### PR DESCRIPTION
Expose an opaque `MediaRuntime` for applications that reuse Smelter protocol inputs, decoders, encoders, and muxers without running Smelter's renderer, queue thread, or audio mixer.

- Add owned output handles with video/audio endpoints and encoded event receivers.
- Add owned input handles with exact audio/video draining and atomic track advancement.
- Keep `PipelineCtx`, protocol implementations, queue mailboxes, and output traits private.
- Leave the existing `Pipeline` registration and ownership paths unchanged.