### PR TITLE
Preserve DeckLink hardware A/V timing

### DIFF
--- a/smelter-core/src/pipeline/decklink/capture.rs
+++ b/smelter-core/src/pipeline/decklink/capture.rs
@@ -28,8 +28,12 @@ pub(super) struct ChannelCallbackAdapter {
     // dependency
     input: Weak<decklink::Input>,
     sync_point: Instant,
-    audio_offset: Mutex<Option<Duration>>,
-    video_offset: Mutex<Option<Duration>>,
+    /// One clock mapper for both media. Video `stream_time` and audio
+    /// `packet_time` are positions on the card's single stream clock, so a
+    /// shared offset carries the hardware's own A/V alignment into our
+    /// epoch. Per-medium offsets would overwrite that alignment with
+    /// whatever the callback arrival order happened to be.
+    stream_offset: Mutex<Option<Duration>>,
     last_format: Mutex<Format>,
 }
 
@@ -48,10 +52,24 @@ impl ChannelCallbackAdapter {
             span,
             input,
             sync_point: ctx.queue_ctx.sync_point,
-            audio_offset: Mutex::new(None),
-            video_offset: Mutex::new(None),
+            stream_offset: Mutex::new(None),
             last_format: Mutex::new(initial_format),
         }
+    }
+
+    /// Card stream time → elapsed since the sync point. The offset is
+    /// established once, by whichever medium arrives first, and reset on
+    /// format change.
+    ///
+    /// Stamps are capture-domain: they say when the card saw the content,
+    /// not when it should be presented. A consumer that needs media to be
+    /// available before its presentation time owns that lead — it is the
+    /// only side that knows how far ahead it reads.
+    fn map_stream_time(&self, stream_time: Duration) -> Duration {
+        let mut guard = self.stream_offset.lock().unwrap();
+        let offset =
+            *guard.get_or_insert_with(|| self.sync_point.elapsed().saturating_sub(stream_time));
+        stream_time + offset
     }
 
     fn handle_video_frame(
@@ -59,12 +77,7 @@ impl ChannelCallbackAdapter {
         video_frame: &mut VideoInputFrame,
         sender: &QueueSender<Frame>,
     ) -> Result<(), decklink::DeckLinkError> {
-        let stream_time = video_frame.stream_time()?;
-        let offset = {
-            let mut guard = self.video_offset.lock().unwrap();
-            *guard.get_or_insert_with(|| self.sync_point.elapsed().saturating_sub(stream_time))
-        };
-        let pts = stream_time + offset + Duration::from_millis(40);
+        let pts = self.map_stream_time(video_frame.stream_time()?);
 
         let width = video_frame.width();
         let height = video_frame.height();
@@ -183,12 +196,7 @@ impl ChannelCallbackAdapter {
         audio_packet: &mut AudioInputPacket,
         sender: &QueueSender<InputAudioSamples>,
     ) -> Result<(), decklink::DeckLinkError> {
-        let packet_time = audio_packet.packet_time()?;
-        let offset = {
-            let mut guard = self.audio_offset.lock().unwrap();
-            *guard.get_or_insert_with(|| self.sync_point.elapsed().saturating_sub(packet_time))
-        };
-        let pts = packet_time + offset + Duration::from_millis(40);
+        let pts = self.map_stream_time(audio_packet.packet_time()?);
 
         let samples = audio_packet.as_32_bit_stereo()?;
         let samples = InputAudioSamples {
@@ -274,8 +282,7 @@ impl ChannelCallbackAdapter {
         input.start_streams()?;
 
         // it will reset on the next packet
-        *self.video_offset.lock().unwrap() = None;
-        *self.audio_offset.lock().unwrap() = None;
+        *self.stream_offset.lock().unwrap() = None;
 
         Ok(())
     }

--- a/smelter-core/src/pipeline/decklink/mod.rs
+++ b/smelter-core/src/pipeline/decklink/mod.rs
@@ -25,17 +25,22 @@ const AUDIO_SAMPLE_RATE: u32 = 48_000;
 ///
 /// - Register track with `QueueTrackOffset::Pts(Duration::ZERO)` which means
 ///   that PTS should be relative to queue `sync_point`.
-/// - On first video/audio packet, compute offset as `sync_point.elapsed() - stream_time`.
-///   PTS of each subsequent packet is `stream_time + offset + 40ms`.
-/// - The 40ms buffer accounts for delivery latency, value could lower for video, but
-///   but for audio we need at least 40ms.
+/// - On the first packet of either medium, compute offset as
+///   `sync_point.elapsed() - stream_time`. PTS of each subsequent packet is
+///   `stream_time + offset`. Video `stream_time` and audio `packet_time` are
+///   positions on one card clock, so the shared offset preserves the
+///   hardware's own A/V alignment.
+/// - Stamps are capture-domain — when the card saw the content, not when it
+///   should be presented. A consumer that needs media in hand before its
+///   presentation time owns that lead; it is the only side that knows how
+///   far ahead it reads.
 /// - Never block on sending. Frames/samples are dropped if the channel is full.
 ///
 /// ### Format detection
 /// - Initial video mode is provisional (HD720p50). `enable_format_detection` is set,
 ///   so the SDK calls `video_input_format_changed` when the real format is detected.
 /// - On format change, streams are paused, video is re-enabled with the new mode,
-///   streams are flushed and restarted, and video/audio offsets are reset (recomputed
+///   streams are flushed and restarted, and the stream offset is reset (recomputed
 ///   on the next packet).
 ///
 /// ### Unsupported scenarios


### PR DESCRIPTION
Map DeckLink video and audio through one stream-time offset established by whichever medium arrives first. This preserves the card's hardware A/V relationship instead of replacing it with independent callback-arrival offsets, and reports capture-domain timestamps without a baked-in presentation lead.