### PR TITLE
Preserve DeckLink hardware A/V timing

### DIFF
--- a/smelter-core/src/pipeline/decklink/capture.rs
+++ b/smelter-core/src/pipeline/decklink/capture.rs
@@ -28,8 +28,7 @@ pub(super) struct ChannelCallbackAdapter {
     // dependency
     input: Weak<decklink::Input>,
     sync_point: Instant,
-    audio_offset: Mutex<Option<Duration>>,
-    video_offset: Mutex<Option<Duration>>,
+    stream_offset: Mutex<Option<Duration>>,
     last_format: Mutex<Format>,
 }
 
@@ -48,8 +47,7 @@ impl ChannelCallbackAdapter {
             span,
             input,
             sync_point: ctx.queue_ctx.sync_point,
-            audio_offset: Mutex::new(None),
-            video_offset: Mutex::new(None),
+            stream_offset: Mutex::new(None),
             last_format: Mutex::new(initial_format),
         }
     }
@@ -61,10 +59,12 @@ impl ChannelCallbackAdapter {
     ) -> Result<(), decklink::DeckLinkError> {
         let stream_time = video_frame.stream_time()?;
         let offset = {
-            let mut guard = self.video_offset.lock().unwrap();
+            let mut guard = self.stream_offset.lock().unwrap();
             *guard.get_or_insert_with(|| self.sync_point.elapsed().saturating_sub(stream_time))
         };
-        let pts = stream_time + offset + Duration::from_millis(40);
+        let presentation_delay =
+            Duration::from_millis(if self.audio_sender.is_some() { 40 } else { 0 });
+        let pts = stream_time + offset + presentation_delay;
 
         let width = video_frame.width();
         let height = video_frame.height();
@@ -185,7 +185,7 @@ impl ChannelCallbackAdapter {
     ) -> Result<(), decklink::DeckLinkError> {
         let packet_time = audio_packet.packet_time()?;
         let offset = {
-            let mut guard = self.audio_offset.lock().unwrap();
+            let mut guard = self.stream_offset.lock().unwrap();
             *guard.get_or_insert_with(|| self.sync_point.elapsed().saturating_sub(packet_time))
         };
         let pts = packet_time + offset + Duration::from_millis(40);
@@ -274,8 +274,7 @@ impl ChannelCallbackAdapter {
         input.start_streams()?;
 
         // it will reset on the next packet
-        *self.video_offset.lock().unwrap() = None;
-        *self.audio_offset.lock().unwrap() = None;
+        *self.stream_offset.lock().unwrap() = None;
 
         Ok(())
     }

--- a/smelter-core/src/pipeline/decklink/mod.rs
+++ b/smelter-core/src/pipeline/decklink/mod.rs
@@ -25,17 +25,16 @@ const AUDIO_SAMPLE_RATE: u32 = 48_000;
 ///
 /// - Register track with `QueueTrackOffset::Pts(Duration::ZERO)` which means
 ///   that PTS should be relative to queue `sync_point`.
-/// - On first video/audio packet, compute offset as `sync_point.elapsed() - stream_time`.
-///   PTS of each subsequent packet is `stream_time + offset + 40ms`.
-/// - The 40ms buffer accounts for delivery latency, value could lower for video, but
-///   but for audio we need at least 40ms.
+/// - Video and audio use one offset because their timestamps share the card clock.
+/// - Video-only capture has no presentation delay. Audio capture adds the same
+///   40ms delay to both media to preserve A/V alignment.
 /// - Never block on sending. Frames/samples are dropped if the channel is full.
 ///
 /// ### Format detection
 /// - Initial video mode is provisional (HD720p50). `enable_format_detection` is set,
 ///   so the SDK calls `video_input_format_changed` when the real format is detected.
 /// - On format change, streams are paused, video is re-enabled with the new mode,
-///   streams are flushed and restarted, and video/audio offsets are reset (recomputed
+///   streams are flushed and restarted, and the stream offset is reset (recomputed
 ///   on the next packet).
 ///
 /// ### Unsupported scenarios


### PR DESCRIPTION
Map DeckLink video and audio through one hardware stream clock. Video-only capture adds no fixed presentation lead; audio-enabled capture applies the same 40 ms lead to both tracks so audio reaches the queue without breaking A/V alignment.