### PR TITLE
Add standalone media input and output handles

### DIFF
--- a/smelter-core/src/pipeline.rs
+++ b/smelter-core/src/pipeline.rs
@@ -42,11 +42,14 @@ mod webrtc;
 mod input;
 mod instance;
 mod output;
+mod runtime;
 
 pub(crate) mod utils;
 
 pub use instance::Pipeline;
 pub(crate) use moq::SelfSignedTlsError;
+pub use output::{OutputAudio, OutputHandle, OutputVideo};
+pub use runtime::{MediaRuntime, MediaRuntimeOptions};
 
 #[cfg(target_os = "linux")]
 pub use v4l2::{V4l2DeviceInfo, V4l2FormatInfo, V4l2ResolutionInfo, list_v4l2_devices};

--- a/smelter-core/src/pipeline.rs
+++ b/smelter-core/src/pipeline.rs
@@ -46,6 +46,7 @@ mod runtime;
 
 pub(crate) mod utils;
 
+pub use input::{AudioDrainResult, InputHandle, TrackAdvance, VideoDrainResult};
 pub use instance::Pipeline;
 pub(crate) use moq::SelfSignedTlsError;
 pub use output::{OutputAudio, OutputHandle, OutputVideo};

--- a/smelter-core/src/pipeline/input.rs
+++ b/smelter-core/src/pipeline/input.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     pipeline::{
+        MediaRuntime,
         hls::HlsInput,
         moq::{MoqClientInput, MoqServerInput},
         mp4::Mp4Input,
@@ -12,7 +13,7 @@ use crate::{
         rtp::RtpInput,
         webrtc::{WhepInput, WhipInput},
     },
-    queue::QueueInput,
+    queue::{QueueInput, QueueTrackAdvance},
 };
 
 use crate::prelude::*;
@@ -26,6 +27,32 @@ pub struct PipelineInput {
     /// Some(received) - Whether EOS was received from queue on video stream for that input.
     /// None - No video configured for that input.
     pub(super) video_eos_received: Option<bool>,
+}
+
+pub struct InputHandle {
+    _runtime: MediaRuntime,
+    input: Input,
+    info: InputInitInfo,
+    queue_input: QueueInput,
+}
+
+#[derive(Debug, Clone)]
+pub struct VideoDrainResult {
+    pub frame: Option<Frame>,
+    pub end_of_stream: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioDrainResult {
+    pub samples: Vec<InputAudioSamples>,
+    pub end_of_stream: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackAdvance {
+    Advanced,
+    CurrentTrackNotDrained,
+    WaitingForTrack,
 }
 
 pub enum Input {
@@ -91,6 +118,71 @@ impl Input {
             }
             _ => Err(UpdateInputError::PausingNotSupported(self.kind())),
         }
+    }
+}
+
+impl InputHandle {
+    pub fn info(&self) -> &InputInitInfo {
+        &self.info
+    }
+
+    pub fn kind(&self) -> InputProtocolKind {
+        self.input.kind()
+    }
+
+    pub fn seek(&self, position: Duration) -> Result<(), UpdateInputError> {
+        self.input.seek(position)
+    }
+
+    pub fn pause(&self) -> Result<(), UpdateInputError> {
+        self.input.pause()
+    }
+
+    pub fn resume(&self) -> Result<(), UpdateInputError> {
+        self.input.resume()
+    }
+
+    pub fn pull_video(&self, pts: Duration) -> Option<VideoDrainResult> {
+        self.queue_input
+            .pull_video(pts)
+            .map(|result| VideoDrainResult {
+                frame: result.frame,
+                end_of_stream: result.is_eos,
+            })
+    }
+
+    pub fn pull_audio(&self, start_pts: Duration, end_pts: Duration) -> Option<AudioDrainResult> {
+        self.queue_input
+            .pull_audio((start_pts, end_pts))
+            .map(|result| AudioDrainResult {
+                samples: result.samples,
+                end_of_stream: result.is_eos,
+            })
+    }
+
+    pub fn advance_track(&self) -> TrackAdvance {
+        match self.queue_input.advance_track() {
+            QueueTrackAdvance::Advanced => TrackAdvance::Advanced,
+            QueueTrackAdvance::CurrentTrackNotDrained => TrackAdvance::CurrentTrackNotDrained,
+            QueueTrackAdvance::WaitingForTrack => TrackAdvance::WaitingForTrack,
+        }
+    }
+}
+
+impl MediaRuntime {
+    pub fn create_input(
+        &self,
+        input_id: InputId,
+        options: RegisterInputOptions,
+    ) -> Result<InputHandle, InputInitError> {
+        let (input, info, queue_input) =
+            new_external_input(self.ctx.clone(), Ref::new(&input_id), options)?;
+        Ok(InputHandle {
+            _runtime: self.clone(),
+            input,
+            info,
+            queue_input,
+        })
     }
 }
 

--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -662,7 +662,7 @@ fn create_pipeline(opts: PipelineOptions) -> Result<Pipeline, InitPipelineError>
     Ok(pipeline)
 }
 
-fn prepare_side_channel_socket_dir(dir: &Path) -> Result<(), InitPipelineError> {
+pub(super) fn prepare_side_channel_socket_dir(dir: &Path) -> Result<(), InitPipelineError> {
     if !dir.exists() {
         return std::fs::create_dir_all(dir).map_err(|e| {
             InitPipelineError::SideChannelSocketDir(format!(

--- a/smelter-core/src/pipeline/output.rs
+++ b/smelter-core/src/pipeline/output.rs
@@ -8,6 +8,8 @@ use smelter_render::OutputFrameFormat;
 use tracing::{info, warn};
 
 use crate::pipeline::{
+    MediaRuntime,
+    channel::EncodedDataOutput,
     hls::HlsOutput,
     input::PipelineInput,
     moq::MoqClientOutput,
@@ -24,8 +26,13 @@ pub(crate) struct PipelineOutput {
     pub audio_end_condition: Option<PipelineOutputEndConditionState>,
 }
 
+pub struct OutputHandle {
+    _runtime: MediaRuntime,
+    output: Box<dyn Output>,
+}
+
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct OutputVideo<'a> {
+pub struct OutputVideo<'a> {
     pub resolution: Resolution,
     pub frame_format: OutputFrameFormat,
     pub frame_sender: &'a Sender<PipelineEvent<Frame>>,
@@ -33,7 +40,7 @@ pub(crate) struct OutputVideo<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct OutputAudio<'a> {
+pub struct OutputAudio<'a> {
     pub samples_batch_sender: &'a Sender<PipelineEvent<OutputAudioSamples>>,
 }
 
@@ -41,6 +48,48 @@ pub(crate) trait Output: Send {
     fn audio(&self) -> Option<OutputAudio<'_>>;
     fn video(&self) -> Option<OutputVideo<'_>>;
     fn kind(&self) -> OutputProtocolKind;
+}
+
+impl OutputHandle {
+    fn new(runtime: MediaRuntime, output: Box<dyn Output>) -> OutputHandle {
+        Self {
+            _runtime: runtime,
+            output,
+        }
+    }
+
+    pub fn video(&self) -> Option<OutputVideo<'_>> {
+        self.output.video()
+    }
+
+    pub fn audio(&self) -> Option<OutputAudio<'_>> {
+        self.output.audio()
+    }
+
+    pub fn kind(&self) -> OutputProtocolKind {
+        self.output.kind()
+    }
+}
+
+impl MediaRuntime {
+    pub fn create_output(
+        &self,
+        output_id: OutputId,
+        options: ProtocolOutputOptions,
+    ) -> Result<(OutputHandle, Option<Port>), OutputInitError> {
+        let (output, port) = new_external_output(self.ctx.clone(), Ref::new(&output_id), options)?;
+        Ok((OutputHandle::new(self.clone(), output), port))
+    }
+
+    pub fn create_encoded_output(
+        &self,
+        output_id: OutputId,
+        options: EncodedDataOutputOptions,
+    ) -> Result<(OutputHandle, EncodedDataOutputHandle), OutputInitError> {
+        let (output, encoded) =
+            EncodedDataOutput::new(self.ctx.clone(), Ref::new(&output_id), options)?;
+        Ok((OutputHandle::new(self.clone(), Box::new(output)), encoded))
+    }
 }
 
 pub(super) fn new_external_output(

--- a/smelter-core/src/pipeline/runtime.rs
+++ b/smelter-core/src/pipeline/runtime.rs
@@ -1,0 +1,119 @@
+use std::{
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use crossbeam_channel::Receiver;
+use smelter_render::{Framerate, WgpuCtx};
+use tokio::runtime::Runtime;
+
+use crate::{
+    event::{Event, EventEmitter},
+    graphics_context::GraphicsContext,
+    pipeline::{
+        PipelineCtx, instance::prepare_side_channel_socket_dir, webrtc::WebrtcSettingEngineCtx,
+    },
+    queue::QueueContext,
+    stats::{StatsMonitor, StatsReport},
+};
+
+use crate::prelude::*;
+
+pub struct MediaRuntimeOptions {
+    pub sync_point: Instant,
+    pub default_buffer_duration: Duration,
+    pub side_channel_socket_dir: Option<Arc<Path>>,
+    pub output_framerate: Framerate,
+    pub mixing_sample_rate: u32,
+    pub download_root: Arc<Path>,
+    pub graphics_context: GraphicsContext,
+    pub wgpu_ctx: Arc<WgpuCtx>,
+    pub tokio_rt: Option<Arc<Runtime>>,
+    pub webrtc_stun_servers: Arc<Vec<String>>,
+    pub webrtc_udp_port_strategy: Option<WebrtcUdpPortStrategy>,
+    pub webrtc_nat_1to1_ips: Arc<Vec<String>>,
+    pub moq_disable_tls_verification: bool,
+}
+
+struct MediaRuntimeLifetime {
+    stats_monitor: StatsMonitor,
+    webrtc_setting_engine: WebrtcSettingEngineCtx,
+}
+
+impl Drop for MediaRuntimeLifetime {
+    fn drop(&mut self) {
+        self.webrtc_setting_engine.close();
+    }
+}
+
+#[derive(Clone)]
+pub struct MediaRuntime {
+    pub(super) ctx: Arc<PipelineCtx>,
+    lifetime: Arc<MediaRuntimeLifetime>,
+}
+
+impl MediaRuntime {
+    pub fn new(options: MediaRuntimeOptions) -> Result<Self, InitPipelineError> {
+        if let Some(dir) = options.side_channel_socket_dir.as_deref() {
+            prepare_side_channel_socket_dir(dir)?;
+        }
+        let download_dir: Arc<Path> = options
+            .download_root
+            .join(format!("smelter-{}", rand::random::<u64>()))
+            .into();
+        std::fs::create_dir_all(&download_dir).map_err(InitPipelineError::CreateDownloadDir)?;
+        let tokio_rt = match options.tokio_rt {
+            Some(tokio_rt) => tokio_rt,
+            None => Arc::new(Runtime::new().map_err(InitPipelineError::CreateTokioRuntime)?),
+        };
+        let (stats_monitor, stats_sender) = StatsMonitor::new();
+        let webrtc_setting_engine = WebrtcSettingEngineCtx::new(
+            options.webrtc_nat_1to1_ips,
+            options.webrtc_udp_port_strategy,
+            &tokio_rt,
+        )?;
+        let ctx = Arc::new(PipelineCtx {
+            queue_ctx: QueueContext::new(options.sync_point, options.side_channel_socket_dir),
+            default_buffer_duration: options.default_buffer_duration,
+            mixing_sample_rate: options.mixing_sample_rate,
+            output_framerate: options.output_framerate,
+            download_dir,
+            graphics_context: options.graphics_context,
+            wgpu_ctx: options.wgpu_ctx,
+            event_emitter: Arc::new(EventEmitter::new()),
+            stats_sender,
+            webrtc_stun_servers: options.webrtc_stun_servers,
+            webrtc_setting_engine: webrtc_setting_engine.clone(),
+            moq_disable_tls_verification: options.moq_disable_tls_verification,
+            tokio_rt,
+            whip_whep_state: None,
+            rtmp_state: None,
+            moq_state: None,
+        });
+        Ok(Self {
+            ctx,
+            lifetime: Arc::new(MediaRuntimeLifetime {
+                stats_monitor,
+                webrtc_setting_engine,
+            }),
+        })
+    }
+
+    pub fn stats(&self) -> StatsReport {
+        self.lifetime.stats_monitor.report()
+    }
+
+    pub fn subscribe_events(&self) -> Receiver<Event> {
+        self.ctx.event_emitter.subscribe()
+    }
+
+    pub fn with_output_framerate(&self, output_framerate: Framerate) -> Self {
+        let mut ctx = (*self.ctx).clone();
+        ctx.output_framerate = output_framerate;
+        Self {
+            ctx: Arc::new(ctx),
+            lifetime: self.lifetime.clone(),
+        }
+    }
+}

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -29,7 +29,7 @@ use crate::prelude::*;
 
 pub use self::queue_input::QueueInputOptions;
 pub(crate) use self::queue_input::{
-    QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, WeakQueueInput,
+    QueueInput, QueueSender, QueueTrackAdvance, QueueTrackOffset, QueueTrackOptions, WeakQueueInput,
 };
 
 use self::{
@@ -182,9 +182,9 @@ pub(super) struct QueueVideoOutput {
 
 #[derive(Debug, Clone)]
 pub(super) struct QueueVideoFrame {
-    pub frame: Option<Frame>,
+    pub(crate) frame: Option<Frame>,
     /// Track on this input ended.
-    pub is_eos: bool,
+    pub(crate) is_eos: bool,
 }
 
 impl QueueVideoFrame {
@@ -219,9 +219,9 @@ pub(super) struct QueueAudioOutput {
 
 #[derive(Debug, Clone)]
 pub(super) struct QueueAudioSamples {
-    pub samples: Vec<InputAudioSamples>,
+    pub(crate) samples: Vec<InputAudioSamples>,
     /// Track on this input ended.
-    pub is_eos: bool,
+    pub(crate) is_eos: bool,
 }
 
 impl QueueAudioSamples {

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -156,6 +156,15 @@ pub struct QueueContext {
 }
 
 impl QueueContext {
+    pub(crate) fn new(sync_point: Instant, side_channel_socket_dir: Option<Arc<Path>>) -> Self {
+        Self {
+            sync_point,
+            start_pts: Default::default(),
+            last_pts: Default::default(),
+            side_channel_socket_dir,
+        }
+    }
+
     pub(crate) fn effective_last_pts(&self) -> Duration {
         self.last_pts
             .value()
@@ -255,12 +264,7 @@ impl<T: Clone> Clone for PipelineEvent<T> {
 
 impl Queue {
     pub(crate) fn new(opts: QueueOptions) -> Arc<Self> {
-        let queue_ctx = QueueContext {
-            sync_point: Instant::now(),
-            start_pts: Default::default(),
-            last_pts: Default::default(),
-            side_channel_socket_dir: opts.side_channel_socket_dir,
-        };
+        let queue_ctx = QueueContext::new(Instant::now(), opts.side_channel_socket_dir);
         let (queue_start_sender, queue_start_receiver) = bounded(0);
         let (scheduled_event_sender, scheduled_event_receiver) = bounded(0);
         let queue = Arc::new(Queue {

--- a/smelter-core/src/queue/audio_input.rs
+++ b/smelter-core/src/queue/audio_input.rs
@@ -110,6 +110,23 @@ impl AudioQueueInput {
         pts_range: (Duration, Duration),
         queue_start_pts: Duration,
     ) -> QueueAudioSamples {
+        self.pop_samples_with_lookahead(pts_range, queue_start_pts, MIXER_STRETCH_BUFFER)
+    }
+
+    pub(super) fn pop_samples_before(
+        &mut self,
+        pts_range: (Duration, Duration),
+        queue_start_pts: Duration,
+    ) -> QueueAudioSamples {
+        self.pop_samples_with_lookahead(pts_range, queue_start_pts, Duration::ZERO)
+    }
+
+    fn pop_samples_with_lookahead(
+        &mut self,
+        pts_range: (Duration, Duration),
+        queue_start_pts: Duration,
+        lookahead: Duration,
+    ) -> QueueAudioSamples {
         if self.paused {
             return QueueAudioSamples::empty();
         }
@@ -130,7 +147,7 @@ impl AudioQueueInput {
             };
         }
 
-        let input_pts = (pts_range.1 + MIXER_STRETCH_BUFFER).saturating_sub(offset);
+        let input_pts = (pts_range.1 + lookahead).saturating_sub(offset);
         trace!(queue_pts=?pts_range, ?input_pts, "Try get samples batch");
 
         let mut samples = self.receiver.pop_before_pts(input_pts);

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use crate::{
     event::EventEmitter,
     queue::{
-        QueueContext,
+        QueueAudioSamples, QueueContext, QueueVideoFrame,
         audio_input::AudioQueueInput,
         side_channel::{AudioSideChannel, VideoSideChannel},
         utils::PauseState,
@@ -32,6 +32,13 @@ struct PendingTrack {
 }
 
 pub(crate) struct QueueSender<T>(crossbeam_channel::Sender<T>);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum QueueTrackAdvance {
+    Advanced,
+    CurrentTrackNotDrained,
+    WaitingForTrack,
+}
 
 impl<T> QueueSender<T> {
     pub(crate) fn new(sender: crossbeam_channel::Sender<T>) -> Self {
@@ -74,18 +81,30 @@ pub(super) struct InnerQueueInput {
 
 impl InnerQueueInput {
     fn maybe_start_next_track(&mut self) {
-        let video_eos_sent = self.video.as_ref().map(|v| v.eos_sent()).unwrap_or(true);
-        let audio_eos_sent = self.audio.as_ref().map(|a| a.eos_sent()).unwrap_or(true);
-        if video_eos_sent && audio_eos_sent {
-            self.replace_track()
-        }
+        let _ = self.advance_track();
     }
 
-    /// Replace current track with the next pending, do nothing if there is no pending
+    fn advance_track(&mut self) -> QueueTrackAdvance {
+        let video_eos_sent = self.video.as_ref().map(|v| v.eos_sent()).unwrap_or(true);
+        let audio_eos_sent = self.audio.as_ref().map(|a| a.eos_sent()).unwrap_or(true);
+        if !video_eos_sent || !audio_eos_sent {
+            return QueueTrackAdvance::CurrentTrackNotDrained;
+        }
+        let Ok(pending) = self.pending_receiver.try_recv() else {
+            return QueueTrackAdvance::WaitingForTrack;
+        };
+        self.install_track(pending);
+        QueueTrackAdvance::Advanced
+    }
+
     fn replace_track(&mut self) {
         let Ok(pending) = self.pending_receiver.try_recv() else {
             return;
         };
+        self.install_track(pending);
+    }
+
+    fn install_track(&mut self, pending: PendingTrack) {
         info!(input_id=%self.input_ref, "Push track to queue");
 
         self.video = pending.video;
@@ -335,6 +354,28 @@ impl QueueInput {
 
     pub(super) fn maybe_start_next_track(&self) {
         self.0.lock().unwrap().maybe_start_next_track();
+    }
+
+    pub(crate) fn pull_video(&self, pts: Duration) -> Option<QueueVideoFrame> {
+        self.0
+            .lock()
+            .unwrap()
+            .video
+            .as_mut()
+            .map(|video| video.get_frame(pts, Duration::ZERO))
+    }
+
+    pub(crate) fn pull_audio(&self, pts_range: (Duration, Duration)) -> Option<QueueAudioSamples> {
+        self.0
+            .lock()
+            .unwrap()
+            .audio
+            .as_mut()
+            .map(|audio| audio.pop_samples_before(pts_range, Duration::ZERO))
+    }
+
+    pub(crate) fn advance_track(&self) -> QueueTrackAdvance {
+        self.0.lock().unwrap().advance_track()
     }
 }
 


### PR DESCRIPTION
Add an opaque `MediaRuntime` and owned input/output handles for applications that reuse Smelter protocol media without its renderer, queue loop, or audio mixer. Existing `Pipeline` ownership remains unchanged.