### PR TITLE
Compensate FDK AAC encoder delay

### DIFF
--- a/smelter-core/src/pipeline/encoder/fdk_aac.rs
+++ b/smelter-core/src/pipeline/encoder/fdk_aac.rs
@@ -23,6 +23,7 @@ pub struct FdkAacEncoder {
     output_buffer: Vec<u8>,
     sample_rate: u32,
     samples_per_frame: u32,
+    codec_delay: u64,
 
     // This logic relies on the fact that input samples will always be continuous.
     first_input_pts: Option<Duration>,
@@ -114,6 +115,7 @@ impl AudioEncoder for FdkAacEncoder {
                 input_buffer: Vec::new(),
                 output_buffer: vec![0; info.maxOutBufBytes as usize],
                 sample_rate: options.sample_rate,
+                codec_delay: info.nDelay as u64,
                 first_input_pts: None,
                 encoded_samples: 0,
                 samples_per_frame: info.frameLength,
@@ -223,15 +225,23 @@ impl FdkAacEncoder {
 
             self.input_buffer.drain(..(out_args.numInSamples as usize));
 
-            let encoded_bytes = out_args.numOutBytes as usize;
-            if encoded_bytes > 0 {
-                let pts = self.first_input_pts.unwrap_or_default()
-                    + Duration::from_secs_f64(
-                        self.encoded_samples as f64 / self.sample_rate as f64,
-                    );
-
+            if out_args.numOutBytes > 0 {
                 // assume that encoder is always producing batches representing full frame
+                let frame_start = self.encoded_samples;
                 self.encoded_samples += self.samples_per_frame as u64;
+
+                if self.encoded_samples < self.codec_delay {
+                    continue;
+                }
+                let first_input_pts = self.first_input_pts.unwrap_or_default();
+                let offset = Duration::from_secs_f64(
+                    frame_start.abs_diff(self.codec_delay) as f64 / self.sample_rate as f64,
+                );
+                let pts = if frame_start >= self.codec_delay {
+                    first_input_pts + offset
+                } else {
+                    first_input_pts.saturating_sub(offset)
+                };
 
                 output.push(EncodedOutputChunk {
                     data: Bytes::copy_from_slice(

--- a/smelter-core/src/pipeline/encoder/fdk_aac.rs
+++ b/smelter-core/src/pipeline/encoder/fdk_aac.rs
@@ -233,15 +233,12 @@ impl FdkAacEncoder {
                 if self.encoded_samples < self.codec_delay {
                     continue;
                 }
-                let first_input_pts = self.first_input_pts.unwrap_or_default();
-                let offset = Duration::from_secs_f64(
-                    frame_start.abs_diff(self.codec_delay) as f64 / self.sample_rate as f64,
-                );
-                let pts = if frame_start >= self.codec_delay {
-                    first_input_pts + offset
-                } else {
-                    first_input_pts.saturating_sub(offset)
-                };
+
+                let first_pts = self.first_input_pts.unwrap_or_default();
+                let offset = Duration::from_secs_f64(frame_start as f64 / self.sample_rate as f64);
+                let codec_delay =
+                    Duration::from_secs_f64(self.codec_delay as f64 / self.sample_rate as f64);
+                let pts = (first_pts + offset).saturating_sub(codec_delay);
 
                 output.push(EncodedOutputChunk {
                     data: Bytes::copy_from_slice(


### PR DESCRIPTION
Use FDK AAC's reported encoder delay to timestamp access units by the content they carry. Drop only frames containing no real content and retain the first mixed priming/content frame, avoiding a persistent AAC A/V shift without discarding its real samples.