### PR TITLE
Add native input side channels

### DIFF
--- a/smelter-api/src/input/decklink_into.rs
+++ b/smelter-api/src/input/decklink_into.rs
@@ -31,8 +31,8 @@ impl TryFrom<DeckLink> for core::RegisterInputOptions {
                     let side_channel_delay = side_channel.delay()?;
                     core::QueueInputOptions {
                         required: value.required.unwrap_or(false),
-                        video_side_channel: side_channel.video.unwrap_or(false),
-                        audio_side_channel: side_channel.audio.unwrap_or(false),
+                        video_side_channel: side_channel.video.unwrap_or(false).into(),
+                        audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                         side_channel_delay,
                     }
                 },

--- a/smelter-api/src/input/hls_into.rs
+++ b/smelter-api/src/input/hls_into.rs
@@ -35,8 +35,8 @@ impl TryFrom<HlsInput> for core::RegisterInputOptions {
             video_decoders,
             queue_options: core::QueueInputOptions {
                 required,
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
             offset,

--- a/smelter-api/src/input/moq_client_into.rs
+++ b/smelter-api/src/input/moq_client_into.rs
@@ -35,8 +35,8 @@ impl TryFrom<MoqClientInput> for core::RegisterInputOptions {
             decoders: core::MoqInputDecoders { h264 },
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         };

--- a/smelter-api/src/input/moq_server_into.rs
+++ b/smelter-api/src/input/moq_server_into.rs
@@ -33,8 +33,8 @@ impl TryFrom<MoqServerInput> for core::RegisterInputOptions {
             decoders: core::MoqInputDecoders { h264 },
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         };

--- a/smelter-api/src/input/mp4_into.rs
+++ b/smelter-api/src/input/mp4_into.rs
@@ -58,8 +58,8 @@ impl TryFrom<Mp4Input> for core::RegisterInputOptions {
             offset,
             queue_options: core::QueueInputOptions {
                 required,
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         }))

--- a/smelter-api/src/input/rtmp_into.rs
+++ b/smelter-api/src/input/rtmp_into.rs
@@ -29,8 +29,8 @@ impl TryFrom<RtmpInput> for core::RegisterInputOptions {
             decoders: core::RtmpServerInputDecoders { h264 },
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         };

--- a/smelter-api/src/input/rtp_into.rs
+++ b/smelter-api/src/input/rtp_into.rs
@@ -61,8 +61,8 @@ impl TryFrom<RtpInput> for core::RegisterInputOptions {
             buffer_duration,
             queue_options: core::QueueInputOptions {
                 required,
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
             offset,

--- a/smelter-api/src/input/v4l2_into.rs
+++ b/smelter-api/src/input/v4l2_into.rs
@@ -18,8 +18,8 @@ impl TryFrom<V4l2Input> for core::RegisterInputOptions {
                 .transpose()?,
             queue_options: core::QueueInputOptions {
                 required: value.required.unwrap_or(false),
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         }))

--- a/smelter-api/src/input/whep_into.rs
+++ b/smelter-api/src/input/whep_into.rs
@@ -39,8 +39,8 @@ impl TryFrom<WhepInput> for core::RegisterInputOptions {
             jitter_buffer_size,
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         };

--- a/smelter-api/src/input/whip_into.rs
+++ b/smelter-api/src/input/whip_into.rs
@@ -37,8 +37,8 @@ impl TryFrom<WhipInput> for core::RegisterInputOptions {
             jitter_buffer_size,
             queue_options: core::QueueInputOptions {
                 required: required.unwrap_or(false),
-                video_side_channel: side_channel.video.unwrap_or(false),
-                audio_side_channel: side_channel.audio.unwrap_or(false),
+                video_side_channel: side_channel.video.unwrap_or(false).into(),
+                audio_side_channel: side_channel.audio.unwrap_or(false).into(),
                 side_channel_delay,
             },
         };

--- a/smelter-api/tests/input_deserialization.rs
+++ b/smelter-api/tests/input_deserialization.rs
@@ -20,8 +20,8 @@ type CoreInput = smelter_core::RegisterInputOptions;
 fn default_queue() -> QueueInputOptions {
     QueueInputOptions {
         required: false,
-        video_side_channel: false,
-        audio_side_channel: false,
+        video_side_channel: false.into(),
+        audio_side_channel: false.into(),
         side_channel_delay: Duration::ZERO,
     }
 }
@@ -176,8 +176,8 @@ fn rtmp_with_all_options() {
             },
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: true,
-                audio_side_channel: false,
+                video_side_channel: true.into(),
+                audio_side_channel: false.into(),
                 side_channel_delay: Duration::ZERO,
             },
         }),
@@ -327,8 +327,8 @@ fn rtp_video_and_audio() {
             audio: Some(RtpAudioOptions::Opus),
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: true,
-                audio_side_channel: false,
+                video_side_channel: true.into(),
+                audio_side_channel: false.into(),
                 side_channel_delay: Duration::ZERO,
             },
             offset: Some(Duration::from_millis(500)),
@@ -570,8 +570,8 @@ fn mp4_with_all_options() {
             offset: Some(Duration::from_secs(1)),
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: false,
-                audio_side_channel: true,
+                video_side_channel: false.into(),
+                audio_side_channel: true.into(),
                 side_channel_delay: Duration::ZERO,
             },
         }),
@@ -678,8 +678,8 @@ fn whip_with_all_options() {
             jitter_buffer_size: Some(Duration::from_millis(200)),
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: true,
-                audio_side_channel: true,
+                video_side_channel: true.into(),
+                audio_side_channel: true.into(),
                 side_channel_delay: Duration::ZERO,
             },
         }),
@@ -782,8 +782,8 @@ fn whep_with_all_options() {
             jitter_buffer_size: Some(Duration::from_millis(300)),
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: true,
-                audio_side_channel: false,
+                video_side_channel: true.into(),
+                audio_side_channel: false.into(),
                 side_channel_delay: Duration::ZERO,
             },
         }),
@@ -850,8 +850,8 @@ fn hls_with_all_options() {
             },
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: true,
-                audio_side_channel: true,
+                video_side_channel: true.into(),
+                audio_side_channel: true.into(),
                 side_channel_delay: Duration::ZERO,
             },
             offset: Some(Duration::from_millis(500)),
@@ -934,8 +934,8 @@ fn v4l2_with_all_options() {
             framerate: Some(smelter_render::Framerate { num: 30, den: 1 }),
             queue_options: QueueInputOptions {
                 required: true,
-                video_side_channel: true,
-                audio_side_channel: false,
+                video_side_channel: true.into(),
+                audio_side_channel: false.into(),
                 side_channel_delay: Duration::ZERO,
             },
         }),

--- a/smelter-core/src/lib.rs
+++ b/smelter-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod audio_mixer;
 mod queue;
-pub use queue::QueueInputOptions;
+pub use queue::{InputSideChannel, QueueInputOptions};
 
 pub mod codecs;
 pub mod error;

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -27,7 +27,7 @@ use crate::audio_mixer::InputSamplesSet;
 
 use crate::prelude::*;
 
-pub use self::queue_input::QueueInputOptions;
+pub use self::queue_input::{InputSideChannel, QueueInputOptions};
 pub(crate) use self::queue_input::{
     QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, WeakQueueInput,
 };

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use crossbeam_channel::{Receiver, Sender, bounded};
 use smelter_render::{Frame, InputId};
 use tracing::info;
 
@@ -237,23 +238,63 @@ impl std::fmt::Debug for WeakQueueInput {
     }
 }
 
+#[derive(Debug, Default, Clone)]
+pub enum InputSideChannel<T> {
+    #[default]
+    Disabled,
+    UnixSocket,
+    Native(Sender<T>),
+}
+
+impl<T> InputSideChannel<T> {
+    pub fn native(capacity: usize) -> (Self, Receiver<T>) {
+        let (sender, receiver) = bounded(capacity);
+        (Self::Native(sender), receiver)
+    }
+}
+
+impl<T> PartialEq for InputSideChannel<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Disabled, Self::Disabled) | (Self::UnixSocket, Self::UnixSocket) => true,
+            (Self::Native(left), Self::Native(right)) => left.same_channel(right),
+            _ => false,
+        }
+    }
+}
+
+impl<T> From<bool> for InputSideChannel<T> {
+    fn from(enabled: bool) -> Self {
+        match enabled {
+            true => Self::UnixSocket,
+            false => Self::Disabled,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct QueueInputOptions {
     pub required: bool,
-    pub audio_side_channel: bool,
-    pub video_side_channel: bool,
+    pub audio_side_channel: InputSideChannel<InputAudioSamples>,
+    pub video_side_channel: InputSideChannel<Frame>,
     pub side_channel_delay: Duration,
 }
 
 impl QueueInput {
     pub fn new(ctx: &Arc<PipelineCtx>, input_ref: &Ref<InputId>, opts: QueueInputOptions) -> Self {
         let socket_dir = ctx.queue_ctx.side_channel_socket_dir.as_deref();
-        let video_side_channel = match (opts.video_side_channel, socket_dir) {
-            (true, Some(dir)) => VideoSideChannel::new(ctx, input_ref, dir),
+        let video_side_channel = match (&opts.video_side_channel, socket_dir) {
+            (InputSideChannel::UnixSocket, Some(dir)) => VideoSideChannel::new(ctx, input_ref, dir),
+            (InputSideChannel::Native(sender), _) => {
+                Some(VideoSideChannel::native(ctx, sender.clone()))
+            }
             _ => None,
         };
-        let audio_side_channel = match (opts.audio_side_channel, socket_dir) {
-            (true, Some(dir)) => AudioSideChannel::new(ctx, input_ref, dir),
+        let audio_side_channel = match (&opts.audio_side_channel, socket_dir) {
+            (InputSideChannel::UnixSocket, Some(dir)) => AudioSideChannel::new(ctx, input_ref, dir),
+            (InputSideChannel::Native(sender), _) => {
+                Some(AudioSideChannel::native(ctx, sender.clone()))
+            }
             _ => None,
         };
         Self::new_inner(

--- a/smelter-core/src/queue/side_channel/mod.rs
+++ b/smelter-core/src/queue/side_channel/mod.rs
@@ -3,7 +3,7 @@ mod server;
 
 use std::{path::Path, sync::Arc};
 
-use crossbeam_channel::TrySendError;
+use crossbeam_channel::{Sender, TrySendError};
 use smelter_render::{Frame, InputId};
 use tracing::{debug, info};
 
@@ -19,7 +19,8 @@ use self::server::{AudioSideChannelServer, VideoSideChannelServer};
 pub struct VideoSideChannel {
     track_offset: TrackOffset,
     start_pts: SharedPts,
-    server: VideoSideChannelServer,
+    sender: Sender<Frame>,
+    _server: Option<VideoSideChannelServer>,
 }
 
 impl VideoSideChannel {
@@ -34,8 +35,18 @@ impl VideoSideChannel {
         Some(Self {
             track_offset: TrackOffset::default(),
             start_pts: ctx.queue_ctx.start_pts.clone(),
-            server,
+            sender: server.sender.clone(),
+            _server: Some(server),
         })
+    }
+
+    pub(super) fn native(ctx: &Arc<PipelineCtx>, sender: Sender<Frame>) -> Self {
+        Self {
+            track_offset: TrackOffset::default(),
+            start_pts: ctx.queue_ctx.start_pts.clone(),
+            sender,
+            _server: None,
+        }
     }
 
     pub(super) fn with_track_offset(&self, track_offset: &TrackOffset) -> Self {
@@ -53,7 +64,7 @@ impl VideoSideChannel {
         };
         let mut frame = frame.clone();
         frame.pts = (frame.pts + offset).saturating_sub(start_pts);
-        if let Err(TrySendError::Full(_)) = self.server.sender.try_send(frame) {
+        if let Err(TrySendError::Full(_)) = self.sender.try_send(frame) {
             debug!("Video side channel: dropping frame, channel full");
         }
     }
@@ -63,7 +74,8 @@ impl VideoSideChannel {
 pub struct AudioSideChannel {
     track_offset: TrackOffset,
     start_pts: SharedPts,
-    server: AudioSideChannelServer,
+    sender: Sender<InputAudioSamples>,
+    _server: Option<AudioSideChannelServer>,
 }
 
 impl AudioSideChannel {
@@ -78,8 +90,18 @@ impl AudioSideChannel {
         Some(Self {
             track_offset: TrackOffset::default(),
             start_pts: ctx.queue_ctx.start_pts.clone(),
-            server,
+            sender: server.sender.clone(),
+            _server: Some(server),
         })
+    }
+
+    pub(super) fn native(ctx: &Arc<PipelineCtx>, sender: Sender<InputAudioSamples>) -> Self {
+        Self {
+            track_offset: TrackOffset::default(),
+            start_pts: ctx.queue_ctx.start_pts.clone(),
+            sender,
+            _server: None,
+        }
     }
 
     pub(super) fn with_track_offset(&self, track_offset: &TrackOffset) -> Self {
@@ -97,7 +119,7 @@ impl AudioSideChannel {
         };
         let mut batch = batch.clone();
         batch.start_pts = (batch.start_pts + offset).saturating_sub(start_pts);
-        if let Err(TrySendError::Full(_)) = self.server.sender.try_send(batch) {
+        if let Err(TrySendError::Full(_)) = self.sender.try_send(batch) {
             debug!("Audio side channel: dropping samples, channel full");
         }
     }


### PR DESCRIPTION
Adds an in-process destination to the existing input side channels. Native receivers get the same normalized timestamps and non-blocking, drop-on-full behavior as Unix socket clients, without socket serialization.

The existing API booleans continue to select Unix sockets. Core callers can select a bounded native channel explicitly.