### PR TITLE
Expose external output audio sender

### DIFF
--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use crossbeam_channel::{Receiver, bounded};
+use crossbeam_channel::{Receiver, Sender, bounded};
 use glyphon::fontdb;
 use rtmp::RtmpServer;
 use tokio::runtime::Runtime;
@@ -193,6 +193,21 @@ impl Pipeline {
                 Ok((Box::new(output), result))
             },
         )
+    }
+
+    pub fn external_audio_sender(
+        pipeline: &Arc<Mutex<Self>>,
+        output_id: &OutputId,
+    ) -> Option<Sender<PipelineEvent<OutputAudioSamples>>> {
+        let guard = pipeline.lock().unwrap();
+        let output = guard.outputs.get(output_id)?;
+        if output.audio_end_condition.is_some() {
+            return None;
+        }
+        output
+            .output
+            .audio()
+            .map(|audio| audio.samples_batch_sender.clone())
     }
 
     pub fn unregister_output(&mut self, output_id: &OutputId) -> Result<(), UnregisterOutputError> {

--- a/smelter-core/src/pipeline/output.rs
+++ b/smelter-core/src/pipeline/output.rs
@@ -98,11 +98,6 @@ where
         Ref<OutputId>,
     ) -> Result<(Box<dyn Output>, NewOutputResult), OutputInitError>,
 {
-    let (has_video, has_audio) = (video.is_some(), audio.is_some());
-    if !has_video && !has_audio {
-        return Err(RegisterOutputError::NoVideoAndAudio(output_id));
-    }
-
     if pipeline.lock().unwrap().outputs.contains_key(&output_id) {
         return Err(RegisterOutputError::AlreadyRegistered(output_id));
     }
@@ -110,6 +105,10 @@ where
     let pipeline_ctx = pipeline.lock().unwrap().ctx.clone();
     let (output, output_result) = build_output(pipeline_ctx, Ref::new(&output_id))
         .map_err(|e| RegisterOutputError::OutputError(output_id.clone(), e))?;
+
+    if video.is_none() && audio.is_none() && output.audio().is_none() {
+        return Err(RegisterOutputError::NoVideoAndAudio(output_id));
+    }
 
     let mut guard = pipeline.lock().unwrap();
 


### PR DESCRIPTION
Allows an output audio sink to be fed directly when it is not owned by the Pipeline mixer. This supports already-mixed, Pipeline-clocked audio without an extra raw-input round trip or relay channel.

The caller owns PTS continuity and EOS. Mixer-owned outputs do not expose the sender.