### PR TITLE
Schedule output start and stop by PTS

### DIFF
--- a/smelter-core/src/pipeline/hls/hls_output.rs
+++ b/smelter-core/src/pipeline/hls/hls_output.rs
@@ -20,7 +20,7 @@ use crate::{
             vulkan_h264::VulkanH264Encoder,
         },
         ffmpeg_utils::{FfmpegOptions, StreamMutExt, write_extradata},
-        output::{Output, OutputAudio, OutputVideo},
+        output::{Output, OutputAudio, OutputTimestampOrigin, OutputVideo},
         utils::InitializableThread,
     },
 };
@@ -43,6 +43,7 @@ impl HlsOutput {
         ctx: Arc<PipelineCtx>,
         output_ref: Ref<OutputId>,
         options: HlsOutputOptions,
+        timestamp_origin: OutputTimestampOrigin,
     ) -> Result<Self, OutputInitError> {
         let (encoded_chunks_sender, encoded_chunks_receiver) = bounded(1);
 
@@ -129,6 +130,7 @@ impl HlsOutput {
                     video_stream,
                     audio_stream,
                     encoded_chunks_receiver,
+                    timestamp_origin,
                     ctx.output_framerate,
                     stats_sender,
                 );
@@ -288,18 +290,17 @@ fn run_ffmpeg_output_thread(
     mut video_stream: Option<StreamState>,
     mut audio_stream: Option<StreamState>,
     packets_receiver: Receiver<EncodedOutputEvent>,
+    mut timestamp_origin: OutputTimestampOrigin,
     framerate: Framerate,
     stats_sender: HlsOutputStatsSender,
 ) {
     let mut received_video_eos = video_stream.as_ref().map(|_| false);
     let mut received_audio_eos = audio_stream.as_ref().map(|_| false);
-    let mut timestamp_offset = None;
-
     for packet in packets_receiver {
         match packet {
             EncodedOutputEvent::Data(chunk) => {
                 stats_sender.bytes_sent_event(chunk.data.len(), chunk.kind.into());
-                let timestamp_offset = *timestamp_offset.get_or_insert(chunk.pts);
+                let timestamp_offset = timestamp_origin.resolve(chunk.pts);
                 write_chunk(
                     chunk,
                     &mut video_stream,

--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -30,7 +30,10 @@ use crate::{
         channel::{EncodedDataOutput, RawDataInput, RawDataOutput},
         input::{PipelineInput, new_external_input, register_pipeline_input},
         moq::{MoqServer, spawn_moq_server},
-        output::{OutputSender, PipelineOutput, new_external_output, register_pipeline_output},
+        output::{
+            OutputSender, OutputTimestampOrigin, PipelineOutput, new_external_output,
+            register_pipeline_output,
+        },
         rtmp::spawn_rtmp_server,
         webrtc::{
             WebrtcSettingEngineCtx, WhipWhepPipelineState, WhipWhepServer, WhipWhepServerHandle,
@@ -151,12 +154,41 @@ impl Pipeline {
         output_id: OutputId,
         register_options: RegisterOutputOptions,
     ) -> Result<Option<Port>, RegisterOutputError> {
+        Self::register_output_inner(pipeline, output_id, register_options, None)
+    }
+
+    pub fn register_output_at(
+        pipeline: &Arc<Mutex<Self>>,
+        output_id: OutputId,
+        register_options: RegisterOutputOptions,
+        start_at: Duration,
+    ) -> Result<Option<Port>, RegisterOutputError> {
+        Self::register_output_inner(pipeline, output_id, register_options, Some(start_at))
+    }
+
+    fn register_output_inner(
+        pipeline: &Arc<Mutex<Self>>,
+        output_id: OutputId,
+        register_options: RegisterOutputOptions,
+        start_at: Option<Duration>,
+    ) -> Result<Option<Port>, RegisterOutputError> {
+        let timestamp_origin = start_at
+            .map(OutputTimestampOrigin::Explicit)
+            .unwrap_or(OutputTimestampOrigin::FirstPacket);
         register_pipeline_output(
             pipeline,
             output_id,
             register_options.video,
             register_options.audio,
-            |ctx, output_ref| new_external_output(ctx, output_ref, register_options.output_options),
+            start_at,
+            |ctx, output_ref| {
+                new_external_output(
+                    ctx,
+                    output_ref,
+                    register_options.output_options,
+                    timestamp_origin,
+                )
+            },
         )
     }
 
@@ -170,6 +202,7 @@ impl Pipeline {
             output_id,
             register_options.video,
             register_options.audio,
+            None,
             |ctx, output_ref| {
                 let (output, handle) =
                     EncodedDataOutput::new(ctx, output_ref, register_options.output_options)?;
@@ -188,6 +221,7 @@ impl Pipeline {
             output_id,
             register_options.video,
             register_options.audio,
+            None,
             |_ctx, _output_ref| {
                 let (output, result) = RawDataOutput::new(register_options.output_options)?;
                 Ok((Box::new(output), result))
@@ -203,6 +237,19 @@ impl Pipeline {
         self.audio_mixer.unregister_output(output_id);
         self.outputs.remove(output_id);
         self.renderer.unregister_output(output_id);
+        Ok(())
+    }
+
+    pub fn stop_output_at(
+        &mut self,
+        output_id: &OutputId,
+        stop_at: Duration,
+    ) -> Result<(), UnregisterOutputError> {
+        let output = self
+            .outputs
+            .get_mut(output_id)
+            .ok_or_else(|| UnregisterOutputError::NotFound(output_id.clone()))?;
+        output.stop_at = Some(stop_at);
         Ok(())
     }
 
@@ -431,7 +478,7 @@ fn run_renderer_thread(
         }
 
         let output_frame_senders: HashMap<_, _> =
-            Pipeline::all_output_video_senders_iter(&pipeline)
+            Pipeline::all_output_video_senders_iter(&pipeline, input_frames.pts)
                 .filter_map(|(output_id, sender)| match sender {
                     OutputSender::ActiveSender(sender) => Some((output_id, sender)),
                     OutputSender::FinishedSender => {
@@ -454,7 +501,6 @@ fn run_renderer_thread(
 
         for (output_id, frame) in output_frames.frames {
             let Some(frame_sender) = output_frame_senders.get(&output_id) else {
-                warn!(?output_id, "Received new frame from renderer after EOS.");
                 continue;
             };
 
@@ -504,7 +550,7 @@ fn run_audio_mixer_thread(
 
         trace!("Prepare output senders");
         let output_samples_senders: HashMap<_, _> =
-            Pipeline::all_output_audio_senders_iter(&pipeline)
+            Pipeline::all_output_audio_senders_iter(&pipeline, samples.start_pts)
                 .filter_map(|(output_id, sender)| match sender {
                     OutputSender::ActiveSender(sender) => Some((output_id, sender)),
                     OutputSender::FinishedSender => {
@@ -520,7 +566,6 @@ fn run_audio_mixer_thread(
         for (output_id, batch) in mixed_samples.0 {
             trace!(?output_id, ?batch, "Send batch");
             let Some(samples_sender) = output_samples_senders.get(&output_id) else {
-                warn!(?output_id, "Received new mixed samples after EOS.");
                 continue;
             };
 

--- a/smelter-core/src/pipeline/mp4/mp4_output.rs
+++ b/smelter-core/src/pipeline/mp4/mp4_output.rs
@@ -20,7 +20,7 @@ use crate::{
             vulkan_h264::VulkanH264Encoder,
         },
         ffmpeg_utils::{FfmpegOptions, StreamMutExt, write_extradata},
-        output::{Output, OutputAudio, OutputVideo},
+        output::{Output, OutputAudio, OutputTimestampOrigin, OutputVideo},
     },
     utils::InitializableThread,
 };
@@ -43,6 +43,7 @@ impl Mp4Output {
         ctx: Arc<PipelineCtx>,
         output_ref: Ref<OutputId>,
         options: Mp4OutputOptions,
+        timestamp_origin: OutputTimestampOrigin,
     ) -> Result<Self, OutputInitError> {
         if options.output_path.exists() {
             let mut old_index = 0;
@@ -141,6 +142,7 @@ impl Mp4Output {
                     video_stream,
                     audio_stream,
                     encoded_chunks_receiver,
+                    timestamp_origin,
                 );
                 ctx.event_emitter
                     .emit(Event::OutputDone(output_ref.id().clone()));
@@ -300,9 +302,9 @@ fn run_ffmpeg_output_thread(
     mut video_stream: Option<StreamState>,
     mut audio_stream: Option<StreamState>,
     packets_receiver: Receiver<EncodedOutputEvent>,
+    mut timestamp_origin: OutputTimestampOrigin,
 ) {
     let mut eos_state = EosState::new(video_stream.is_some(), audio_stream.is_some());
-    let mut timestamp_offset = None;
 
     let stats_sender = Mp4OutputStatsSender {
         stats_sender: ctx.stats_sender.clone(),
@@ -312,7 +314,7 @@ fn run_ffmpeg_output_thread(
     for packet in packets_receiver {
         match packet {
             EncodedOutputEvent::Data(chunk) => {
-                let timestamp_offset = *timestamp_offset.get_or_insert(chunk.pts);
+                let timestamp_offset = timestamp_origin.resolve(chunk.pts);
                 let stream = match chunk.kind {
                     MediaKind::Video(_) => match &mut video_stream {
                         Some(stream) => stream,

--- a/smelter-core/src/pipeline/output.rs
+++ b/smelter-core/src/pipeline/output.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use crossbeam_channel::Sender;
@@ -22,6 +23,26 @@ pub(crate) struct PipelineOutput {
     pub output: Box<dyn Output>,
     pub video_end_condition: Option<PipelineOutputEndConditionState>,
     pub audio_end_condition: Option<PipelineOutputEndConditionState>,
+    pub start_at: Option<Duration>,
+    pub stop_at: Option<Duration>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum OutputTimestampOrigin {
+    FirstPacket,
+    Explicit(Duration),
+}
+
+impl OutputTimestampOrigin {
+    pub(crate) fn resolve(&mut self, first_packet_pts: Duration) -> Duration {
+        match self {
+            Self::FirstPacket => {
+                *self = Self::Explicit(first_packet_pts);
+                first_packet_pts
+            }
+            Self::Explicit(pts) => *pts,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -47,6 +68,7 @@ pub(super) fn new_external_output(
     ctx: Arc<PipelineCtx>,
     output_ref: Ref<OutputId>,
     options: ProtocolOutputOptions,
+    timestamp_origin: OutputTimestampOrigin,
 ) -> Result<(Box<dyn Output>, Option<Port>), OutputInitError> {
     match options {
         ProtocolOutputOptions::Rtp(opt) => {
@@ -58,11 +80,11 @@ pub(super) fn new_external_output(
             Ok((Box::new(output), None))
         }
         ProtocolOutputOptions::Mp4(opt) => {
-            let output = Mp4Output::new(ctx, output_ref, opt)?;
+            let output = Mp4Output::new(ctx, output_ref, opt, timestamp_origin)?;
             Ok((Box::new(output), None))
         }
         ProtocolOutputOptions::Hls(opt) => {
-            let output = HlsOutput::new(ctx, output_ref, opt)?;
+            let output = HlsOutput::new(ctx, output_ref, opt, timestamp_origin)?;
             Ok((Box::new(output), None))
         }
         ProtocolOutputOptions::Whip(opt) => {
@@ -90,6 +112,7 @@ pub(super) fn register_pipeline_output<BuildFn, NewOutputResult>(
     output_id: OutputId,
     video: Option<RegisterOutputVideoOptions>,
     audio: Option<RegisterOutputAudioOptions>,
+    start_at: Option<Duration>,
     build_output: BuildFn,
 ) -> Result<NewOutputResult, RegisterOutputError>
 where
@@ -125,6 +148,8 @@ where
         video_end_condition: video.as_ref().map(|video| {
             PipelineOutputEndConditionState::new_video(video.end_condition.clone(), &guard.inputs)
         }),
+        start_at,
+        stop_at: None,
     };
 
     if let (Some(video_opts), Some(video_output)) = (video.clone(), output.output.video()) {
@@ -158,6 +183,7 @@ where
 impl Pipeline {
     pub(super) fn all_output_video_senders_iter(
         pipeline: &Arc<Mutex<Pipeline>>,
+        pts: Duration,
     ) -> impl Iterator<Item = (OutputId, OutputSender<Sender<PipelineEvent<Frame>>>)> {
         let outputs: HashMap<_, _> = pipeline
             .lock()
@@ -165,7 +191,11 @@ impl Pipeline {
             .outputs
             .iter_mut()
             .filter_map(|(output_id, output)| {
-                let eos_status = output.video_end_condition.as_mut()?.eos_status();
+                if output.start_at.is_some_and(|start_at| pts < start_at) {
+                    return None;
+                }
+                let should_stop = output.stop_at.is_some_and(|stop_at| pts >= stop_at);
+                let eos_status = output.video_end_condition.as_mut()?.eos_status(should_stop);
                 let sender = output.output.video()?.frame_sender.clone();
                 Some((output_id.clone(), (sender, eos_status)))
             })
@@ -191,6 +221,7 @@ impl Pipeline {
 
     pub(super) fn all_output_audio_senders_iter(
         pipeline: &Arc<Mutex<Pipeline>>,
+        pts: Duration,
     ) -> impl Iterator<
         Item = (
             OutputId,
@@ -203,7 +234,11 @@ impl Pipeline {
             .outputs
             .iter_mut()
             .filter_map(|(output_id, output)| {
-                let eos_status = output.audio_end_condition.as_mut()?.eos_status();
+                if output.start_at.is_some_and(|start_at| pts < start_at) {
+                    return None;
+                }
+                let should_stop = output.stop_at.is_some_and(|stop_at| pts >= stop_at);
+                let eos_status = output.audio_end_condition.as_mut()?.eos_status(should_stop);
                 let sender = output.output.audio()?.samples_batch_sender.clone();
                 Some((output_id.clone(), (sender, eos_status)))
             })
@@ -282,8 +317,12 @@ impl PipelineOutputEndConditionState {
         }
     }
 
-    fn eos_status(&mut self) -> EosStatus {
-        self.on_event(StateChange::NoChanges);
+    fn eos_status(&mut self, should_stop: bool) -> EosStatus {
+        if should_stop {
+            self.did_end = true;
+        } else {
+            self.on_event(StateChange::NoChanges);
+        }
         if self.did_end {
             if !self.did_send_eos {
                 self.did_send_eos = true;


### PR DESCRIPTION
Adds PTS-gated start and stop for independently prepared outputs, so callers can give several outputs the same boundaries without a persistent group abstraction. Stop reuses the existing EOS path.

Scheduled MP4 and HLS outputs use the requested start PTS as their common timestamp origin instead of whichever encoded packet arrives first. Immediate output behavior is unchanged.

I kept origin selection at the muxer boundary to limit the diff. Rebasing timestamps once at the generic output boundary may be a cleaner long-term model if you prefer that direction.