### PR TITLE
Preserve exact MP4 loop timing

### DIFF
--- a/smelter-core/src/pipeline/decoder/fdk_aac.rs
+++ b/smelter-core/src/pipeline/decoder/fdk_aac.rs
@@ -143,7 +143,7 @@ impl Decoder {
                 let info = unsafe { *fdk::aacDecoder_GetStreamInfo(self.instance) };
                 let raw_frame_size = (info.aacSamplesPerFrame * info.channelConfig) as usize;
 
-                let samples = match info.channelConfig {
+                let mut samples = match info.channelConfig {
                     1 => AudioSamples::Mono(
                         self.decoded_samples_buffer[..raw_frame_size]
                             .iter()
@@ -176,6 +176,20 @@ impl Decoder {
                     0 => Duration::ZERO,
                     _ => Duration::from_secs_f64(info.outputDelay as f64 / sample_rate as f64),
                 };
+                let chunk_sample = ((chunk.pts.as_nanos() * sample_rate as u128 + 500_000_000)
+                    / 1_000_000_000) as usize;
+                let trimmed = (info.outputDelay.max(0) as usize).saturating_sub(chunk_sample);
+                match &mut samples {
+                    AudioSamples::Mono(samples) => {
+                        samples.drain(..trimmed.min(samples.len()));
+                    }
+                    AudioSamples::Stereo(samples) => {
+                        samples.drain(..trimmed.min(samples.len()));
+                    }
+                }
+                if samples.is_empty() {
+                    continue;
+                }
 
                 decoded_samples.push(InputAudioSamples {
                     samples,

--- a/smelter-core/src/pipeline/mp4/mp4_input.rs
+++ b/smelter-core/src/pipeline/mp4/mp4_input.rs
@@ -22,7 +22,10 @@ use crate::{
         mp4::reader::{DecoderOptions, Mp4FileReader, Track},
         utils::H264AvccToAnnexB,
     },
-    queue::{QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, WeakQueueInput},
+    queue::{
+        QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, QueueTrackTiming,
+        WeakQueueInput,
+    },
     utils::{
         InitializableThread, ShutdownCondition,
         channel::{SendTimeoutError, Sender},
@@ -51,10 +54,8 @@ const MIN_CHUNK_BUFFER_DURATION: Duration = Duration::from_millis(200);
 ///   - Register track with `QueueTrackOffset::None`
 ///
 /// ### On loop (`opts.should_loop = true`)
-/// - When the video reader reaches the end (or the audio reader if there is no
-///   video track), a new track is created with `QueueTrackOffset::None` and the
-///   remaining in-progress track is aborted.
-/// - PTS of first frame starts from zero again (same as initial registration).
+/// - The video presentation duration defines the iteration, or audio for audio-only files.
+/// - Each iteration continues from the preceding presentation boundary.
 ///
 /// ### Pause / Resume / Seek
 /// - Pausing stops queue consumption, reader threads continue running.
@@ -131,15 +132,26 @@ impl Mp4Input {
             ));
         }
 
+        let loop_duration = video_duration
+            .or(audio_duration)
+            .filter(|_| options.should_loop);
+        let initial_seek = options.seek;
         let queue_input = QueueInput::new(&ctx, &input_ref, options.queue_options.clone());
-        let (video_sender, audio_sender) = queue_input.queue_new_track(QueueTrackOptions {
+        let track_options = QueueTrackOptions {
             video: video_track.is_some(),
             audio: audio_track.is_some(),
             offset: match options.offset {
                 Some(offset) => QueueTrackOffset::FromStart(offset),
                 None => QueueTrackOffset::None,
             },
-        });
+        };
+        let (video_sender, audio_sender) = match loop_duration {
+            Some(duration) => queue_input.queue_new_timed_track(
+                track_options,
+                QueueTrackTiming::Finite(duration.saturating_sub(initial_seek.unwrap_or_default())),
+            ),
+            None => queue_input.queue_new_track(track_options),
+        };
 
         // Buffer needs to be smaller than half of the longest track, otherwise
         // reader threads of short looped files finish too far ahead of playback.
@@ -152,12 +164,12 @@ impl Mp4Input {
             None => MAX_CHUNK_BUFFER_DURATION,
         };
 
-        let initial_seek = options.seek;
         let (mut reader, events_sender) = TrackManagerThread::new(
             &ctx,
             &input_ref,
             options,
             source_file,
+            loop_duration,
             chunk_buffer_duration,
             queue_input.downgrade(),
         );
@@ -243,6 +255,7 @@ struct TrackManagerThread {
     track_ctx: TrackContext,
     video_thread: Option<(JoinHandle<Track<File>>, ShutdownCondition)>,
     audio_thread: Option<(JoinHandle<Track<File>>, ShutdownCondition)>,
+    loop_duration: Option<Duration>,
     chunk_buffer_duration: Duration,
     queue_input: WeakQueueInput,
 }
@@ -253,6 +266,7 @@ impl TrackManagerThread {
         input_ref: &Ref<InputId>,
         options: Mp4InputOptions,
         source_file: Arc<SourceFile>,
+        loop_duration: Option<Duration>,
         chunk_buffer_duration: Duration,
         queue_input: WeakQueueInput,
     ) -> (Self, crossbeam_channel::Sender<StateEvent>) {
@@ -275,6 +289,7 @@ impl TrackManagerThread {
                 track_ctx,
                 video_thread: None,
                 audio_thread: None,
+                loop_duration,
                 chunk_buffer_duration,
                 queue_input,
             },
@@ -325,18 +340,29 @@ impl TrackManagerThread {
             let Some(queue_input) = self.queue_input.upgrade() else {
                 return;
             };
-            queue_input.queue_new_track(QueueTrackOptions {
+            let track_options = QueueTrackOptions {
                 video: self.video_thread.is_some(),
                 audio: self.audio_thread.is_some(),
                 offset: QueueTrackOffset::None,
-            })
+            };
+            match (self.loop_duration, seek) {
+                (Some(duration), None) => queue_input
+                    .queue_new_timed_track(track_options, QueueTrackTiming::Continuation(duration)),
+                (Some(duration), Some(seek)) => queue_input.queue_new_timed_track(
+                    track_options,
+                    QueueTrackTiming::Finite(duration.saturating_sub(seek)),
+                ),
+                (None, _) => queue_input.queue_new_track(track_options),
+            }
         };
 
-        if let Some((_, cond)) = self.video_thread.as_ref() {
-            cond.mark_for_shutdown()
-        }
-        if let Some((_, cond)) = self.audio_thread.as_ref() {
-            cond.mark_for_shutdown()
+        if seek.is_some() {
+            if let Some((_, cond)) = self.video_thread.as_ref() {
+                cond.mark_for_shutdown()
+            }
+            if let Some((_, cond)) = self.audio_thread.as_ref() {
+                cond.mark_for_shutdown()
+            }
         }
 
         let video_track = self

--- a/smelter-core/src/pipeline/mp4/reader.rs
+++ b/smelter-core/src/pipeline/mp4/reader.rs
@@ -72,7 +72,8 @@ impl<Reader: Read + Seek + Send + 'static> Mp4FileReader<Reader> {
             sample_count: track.sample_count(),
             timescale: track.timescale(),
             track_id,
-            duration: track.duration(),
+            duration: Self::presentation_duration(track, self.reader.timescale())
+                .unwrap_or(track.duration()),
             decoder_options: DecoderOptions::Aac(asc),
             track_start_offset,
             presentation_delay,
@@ -118,7 +119,8 @@ impl<Reader: Read + Seek + Send + 'static> Mp4FileReader<Reader> {
             sample_count: track.sample_count(),
             timescale: track.timescale(),
             track_id,
-            duration: track.duration(),
+            duration: Self::presentation_duration(track, self.reader.timescale())
+                .unwrap_or(track.duration()),
             decoder_options: DecoderOptions::H264(h264_config),
             track_start_offset: offset,
             presentation_delay: delay,
@@ -159,6 +161,16 @@ impl<Reader: Read + Seek + Send + 'static> Mp4FileReader<Reader> {
         let presentation_delay =
             Duration::from_secs_f64(delay_ticks as f64 / movie_timescale as f64);
         (track_start_offset, presentation_delay)
+    }
+
+    fn presentation_duration(track: &Mp4Track, movie_timescale: u32) -> Option<Duration> {
+        let duration = track.trak.tkhd.duration;
+        if duration == 0 || duration == u32::MAX as u64 || duration == u64::MAX {
+            return None;
+        }
+        Some(Duration::from_secs_f64(
+            duration as f64 / movie_timescale as f64,
+        ))
     }
 }
 

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -29,7 +29,7 @@ use crate::prelude::*;
 
 pub use self::queue_input::QueueInputOptions;
 pub(crate) use self::queue_input::{
-    QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, WeakQueueInput,
+    QueueInput, QueueSender, QueueTrackOffset, QueueTrackOptions, QueueTrackTiming, WeakQueueInput,
 };
 
 use self::{
@@ -103,10 +103,8 @@ impl From<&PipelineOptions> for QueueOptions {
 ///
 /// - Example usage scenarios:
 ///   - MP4 input:
-///     - On seek, create a new track with `queue_new_track`, start new reader threads, then
-///       call `abort_old_track` to switch immediately.
-///     - On loop, create a new track; `abort_old_track` is optional. Skipping it may leak a
-///       few extra frames from the previous iteration depending on buffer size.
+///     - On seek, queue a finite track and call `abort_old_track` to switch to it.
+///     - Loop iterations are finite tracks chained at exact presentation boundaries.
 ///   - RTMP server input:
 ///     - Read `effective_last_pts` (valid before and after start).
 ///     - Register a track with `QueueTrackOffset::Pts(effective_last_pts + RTMP_BUFFER)`

--- a/smelter-core/src/queue/audio_input.rs
+++ b/smelter-core/src/queue/audio_input.rs
@@ -51,8 +51,10 @@ impl AudioQueueInput {
         track_offset: TrackOffset,
         side_channel: Option<AudioSideChannel>,
         side_channel_delay: Duration,
+        duration: Option<Duration>,
     ) -> (Self, Sender<InputAudioSamples>) {
-        let (receiver, sender) = AudioInputReceiver::new(side_channel_delay, side_channel);
+        let (receiver, sender) =
+            AudioInputReceiver::new(side_channel_delay, side_channel, duration);
         let input = Self {
             queue_ctx: queue_ctx.clone(),
             required,
@@ -150,8 +152,9 @@ impl AudioQueueInput {
 
     /// True on the first call after the track ended; also emits the EOS event.
     fn check_eos(&mut self) -> bool {
-        let is_eos =
-            matches!(self.receiver.state(), ReceiverState::Done) && !self.event_eos_guard.emited();
+        let is_eos = self.receiver.duration.is_none()
+            && matches!(self.receiver.state(), ReceiverState::Done)
+            && !self.event_eos_guard.emited();
         if is_eos {
             self.event_eos_guard.emit();
         }
@@ -241,12 +244,14 @@ pub(crate) struct AudioInputReceiver {
     state: ReceiverState,
     delay: Duration,
     side_channel: Option<AudioSideChannel>,
+    duration: Option<Duration>,
 }
 
 impl AudioInputReceiver {
     pub fn new(
         delay: Duration,
         side_channel: Option<AudioSideChannel>,
+        duration: Option<Duration>,
     ) -> (Self, Sender<InputAudioSamples>) {
         let (sender, receiver) = bounded(1);
         let track = Self {
@@ -257,6 +262,7 @@ impl AudioInputReceiver {
             state: ReceiverState::New,
             delay,
             side_channel,
+            duration,
         };
         (track, sender)
     }
@@ -312,6 +318,18 @@ impl AudioInputReceiver {
             match self.receiver.try_recv() {
                 Ok(mut batch) => {
                     trace!(pts_range=?batch.pts_range(), pending=self.receiver.len(), "Enqueue samples");
+                    if let Some(duration) = self.duration {
+                        let sample_count = (duration.saturating_sub(batch.start_pts).as_nanos()
+                            * batch.sample_rate as u128
+                            / 1_000_000_000) as usize;
+                        match &mut batch.samples {
+                            AudioSamples::Mono(samples) => samples.truncate(sample_count),
+                            AudioSamples::Stereo(samples) => samples.truncate(sample_count),
+                        }
+                        if batch.is_empty() {
+                            continue;
+                        }
+                    }
                     batch.start_pts += self.delay;
                     if let Some(side_channel) = &self.side_channel {
                         side_channel.send_samples(&batch);

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -29,6 +29,7 @@ struct PendingTrack {
     video: Option<VideoQueueInput>,
     audio: Option<AudioQueueInput>,
     track_offset: TrackOffset,
+    end: Option<TrackOffset>,
 }
 
 pub(crate) struct QueueSender<T>(crossbeam_channel::Sender<T>);
@@ -62,6 +63,8 @@ pub(super) struct InnerQueueInput {
     video: Option<VideoQueueInput>,
     audio: Option<AudioQueueInput>,
     track_offset: TrackOffset,
+    end: Option<TrackOffset>,
+    queued_end: Option<TrackOffset>,
     pause_state: PauseState,
 
     pending_sender: crossbeam_channel::Sender<PendingTrack>,
@@ -76,7 +79,14 @@ impl InnerQueueInput {
     fn maybe_start_next_track(&mut self) {
         let video_eos_sent = self.video.as_ref().map(|v| v.eos_sent()).unwrap_or(true);
         let audio_eos_sent = self.audio.as_ref().map(|a| a.eos_sent()).unwrap_or(true);
-        if video_eos_sent && audio_eos_sent {
+        let ended = self
+            .end
+            .as_ref()
+            .and_then(TrackOffset::get)
+            .map_or(video_eos_sent && audio_eos_sent, |end| {
+                self.queue_ctx.effective_last_pts() >= end
+            });
+        if ended {
             self.replace_track()
         }
     }
@@ -91,6 +101,7 @@ impl InnerQueueInput {
         self.video = pending.video;
         self.audio = pending.audio;
         self.track_offset = pending.track_offset;
+        self.end = pending.end;
         if self.pause_state.is_paused() {
             let pts = self.queue_ctx.effective_last_pts();
             if let Some(v) = self.video.as_mut() {
@@ -111,8 +122,9 @@ impl InnerQueueInput {
     }
 
     fn new_pending_track(
-        &self,
+        &mut self,
         opts: QueueTrackOptions,
+        timing: Option<QueueTrackTiming>,
     ) -> (
         PendingTrack,
         Option<QueueSender<Frame>>,
@@ -120,11 +132,26 @@ impl InnerQueueInput {
     ) {
         let input_id = self.input_ref.to_string();
         info!(?opts, input_id, "Create new queue track");
-        let (track_offset, offset_from_start) = match opts.offset {
-            QueueTrackOffset::None => (TrackOffset::default(), None),
-            QueueTrackOffset::Pts(duration) => (TrackOffset::new(duration), None),
-            QueueTrackOffset::FromStart(duration) => (TrackOffset::default(), Some(duration)),
+        let duration = timing.map(|timing| match timing {
+            QueueTrackTiming::Finite(duration) | QueueTrackTiming::Continuation(duration) => {
+                duration
+            }
+        });
+        let (track_offset, offset_from_start) = match timing {
+            Some(QueueTrackTiming::Continuation(_)) => (
+                self.queued_end
+                    .clone()
+                    .expect("continuation requires a preceding finite track"),
+                None,
+            ),
+            _ => match opts.offset {
+                QueueTrackOffset::None => (TrackOffset::default(), None),
+                QueueTrackOffset::Pts(duration) => (TrackOffset::new(duration), None),
+                QueueTrackOffset::FromStart(duration) => (TrackOffset::default(), Some(duration)),
+            },
         };
+        self.queued_end = duration.map(|duration| track_offset.after(duration));
+        let end = duration.map(|duration| track_offset.after(duration + self.side_channel_delay));
         let (video_input, video_sender) = if opts.video {
             let side_channel = self
                 .video_side_channel
@@ -139,6 +166,7 @@ impl InnerQueueInput {
                 track_offset.clone(),
                 side_channel,
                 self.side_channel_delay,
+                duration,
             );
             (Some(video_input), Some(QueueSender::new(video_sender)))
         } else {
@@ -158,6 +186,7 @@ impl InnerQueueInput {
                 track_offset.clone(),
                 side_channel,
                 self.side_channel_delay,
+                duration,
             );
             (Some(audio_input), Some(QueueSender::new(audio_sender)))
         } else {
@@ -168,6 +197,7 @@ impl InnerQueueInput {
                 video: video_input,
                 audio: audio_input,
                 track_offset,
+                end,
             },
             video_sender,
             audio_sender,
@@ -216,6 +246,12 @@ pub(crate) enum QueueTrackOffset {
     Pts(Duration),
     /// Offset from start point
     FromStart(Duration),
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum QueueTrackTiming {
+    Finite(Duration),
+    Continuation(Duration),
 }
 
 #[derive(Debug)]
@@ -283,6 +319,8 @@ impl QueueInput {
             video: None,
             audio: None,
             track_offset: TrackOffset::default(),
+            end: None,
+            queued_end: None,
 
             pending_sender,
             pending_receiver,
@@ -304,11 +342,36 @@ impl QueueInput {
         Option<QueueSender<Frame>>,
         Option<QueueSender<InputAudioSamples>>,
     ) {
+        self.queue_new_track_inner(opts, None)
+    }
+
+    pub(crate) fn queue_new_timed_track(
+        &self,
+        opts: QueueTrackOptions,
+        timing: QueueTrackTiming,
+    ) -> (
+        Option<QueueSender<Frame>>,
+        Option<QueueSender<InputAudioSamples>>,
+    ) {
+        self.queue_new_track_inner(opts, Some(timing))
+    }
+
+    fn queue_new_track_inner(
+        &self,
+        opts: QueueTrackOptions,
+        timing: Option<QueueTrackTiming>,
+    ) -> (
+        Option<QueueSender<Frame>>,
+        Option<QueueSender<InputAudioSamples>>,
+    ) {
         if !opts.video && !opts.audio {
             return (None, None);
         }
-        let guard = self.0.lock().unwrap();
-        let (track, video_sender, audio_sender) = guard.new_pending_track(opts);
+        let mut guard = self.0.lock().unwrap();
+        if matches!(timing, Some(QueueTrackTiming::Finite(_))) {
+            while guard.pending_receiver.try_recv().is_ok() {}
+        }
+        let (track, video_sender, audio_sender) = guard.new_pending_track(opts, timing);
         let pending_sender = guard.pending_sender.clone();
         drop(guard);
         // receiver is owned by InnerQueueInput, so send can't fail while
@@ -365,19 +428,24 @@ impl WeakQueueInput {
 }
 
 #[derive(Default, Clone)]
-pub(super) struct TrackOffset(Arc<Mutex<Option<Duration>>>);
+pub(super) struct TrackOffset(Arc<Mutex<Option<Duration>>>, Duration);
 
 impl TrackOffset {
     pub fn new(value: Duration) -> Self {
-        Self(Arc::new(Mutex::new(Some(value))))
+        Self(Arc::new(Mutex::new(Some(value))), Duration::ZERO)
+    }
+
+    fn after(&self, duration: Duration) -> Self {
+        Self(self.0.clone(), self.1 + duration)
     }
 
     pub fn get(&self) -> Option<Duration> {
-        *self.0.lock().unwrap()
+        self.0.lock().unwrap().map(|base| base + self.1)
     }
 
     pub fn get_or_init(&self, offset: Duration) -> Duration {
-        *self.0.lock().unwrap().get_or_insert(offset)
+        let mut base = self.0.lock().unwrap();
+        *base.get_or_insert(offset.saturating_sub(self.1)) + self.1
     }
 
     pub fn map_add(&self, duration: Duration) {

--- a/smelter-core/src/queue/video_input.rs
+++ b/smelter-core/src/queue/video_input.rs
@@ -48,8 +48,10 @@ impl VideoQueueInput {
         track_offset: TrackOffset,
         side_channel: Option<VideoSideChannel>,
         side_channel_delay: Duration,
+        duration: Option<Duration>,
     ) -> (Self, Sender<Frame>) {
-        let (receiver, sender) = VideoInputReceiver::new(side_channel_delay, side_channel);
+        let (receiver, sender) =
+            VideoInputReceiver::new(side_channel_delay, side_channel, duration);
         let input = Self {
             queue_ctx: queue_ctx.clone(),
             required,
@@ -254,10 +256,15 @@ pub(crate) struct VideoInputReceiver {
     state: ReceiverState,
     delay: Duration,
     side_channel: Option<VideoSideChannel>,
+    duration: Option<Duration>,
 }
 
 impl VideoInputReceiver {
-    pub fn new(delay: Duration, side_channel: Option<VideoSideChannel>) -> (Self, Sender<Frame>) {
+    pub fn new(
+        delay: Duration,
+        side_channel: Option<VideoSideChannel>,
+        duration: Option<Duration>,
+    ) -> (Self, Sender<Frame>) {
         let (sender, receiver) = bounded(1);
         let track = Self {
             max_size: Duration::from_millis(100),
@@ -267,6 +274,7 @@ impl VideoInputReceiver {
             state: ReceiverState::New,
             delay,
             side_channel,
+            duration,
         };
         (track, sender)
     }
@@ -285,7 +293,7 @@ impl VideoInputReceiver {
             None => return None,
             _ => {}
         }
-        if self.disconnected && self.buffer.len() == 1 {
+        if self.disconnected && self.buffer.len() == 1 && self.duration.is_none() {
             let frame = self.buffer.pop_front();
             self.maybe_transition_to_done();
             frame
@@ -352,6 +360,9 @@ impl VideoInputReceiver {
             match self.receiver.try_recv() {
                 Ok(mut frame) => {
                     trace!(pts=?frame.pts, pending=self.receiver.len(), "Enqueue frame");
+                    if self.duration.is_some_and(|duration| frame.pts >= duration) {
+                        continue;
+                    }
                     frame.pts += self.delay;
                     if let Some(side_channel) = &mut self.side_channel {
                         side_channel.send_frame(&frame);


### PR DESCRIPTION
MP4 loops currently follow reader completion rather than the container presentation boundary. AAC decoder priming and a final packet extending past that boundary can therefore change the duration of an iteration, producing an audio discontinuity or moving video off its declared cadence across loops.

Using current main unchanged does not leave a downstream repair point: by the time decoded media is observed, the queue has already selected the next track from reader EOS. Repairing it outside Smelter would duplicate MP4 timeline ownership.

This removes decoder priming from the initial decoded batches, reads the track presentation duration from `tkhd`, and chains finite queue tracks at that exact boundary. Samples beyond the boundary are clipped before entering the queue. Non-looping tracks keep their current behavior.

The changes stay in one PR because each part establishes the same invariant: decoding, queue transitions, and emitted media use the container presentation timeline.
