### PR TITLE
Fix MP4 loop frame cadence

### DIFF
--- a/smelter-core/src/pipeline/mp4/mp4_input.rs
+++ b/smelter-core/src/pipeline/mp4/mp4_input.rs
@@ -117,6 +117,9 @@ impl Mp4Input {
         let video_duration = video_track.as_ref().and_then(|track| track.duration());
         let audio_track = Mp4FileReader::from_path(&source_file.path)?.try_new_aac_track();
         let audio_duration = audio_track.as_ref().and_then(|track| track.duration());
+        let loop_duration = video_duration
+            .or(audio_duration)
+            .filter(|_| options.should_loop);
 
         if video_track.is_none() && audio_track.is_none() {
             return Err(Mp4InputError::NoTrack.into());
@@ -158,6 +161,7 @@ impl Mp4Input {
             &input_ref,
             options,
             source_file,
+            loop_duration,
             chunk_buffer_duration,
             queue_input.downgrade(),
         );
@@ -243,6 +247,7 @@ struct TrackManagerThread {
     track_ctx: TrackContext,
     video_thread: Option<(JoinHandle<Track<File>>, ShutdownCondition)>,
     audio_thread: Option<(JoinHandle<Track<File>>, ShutdownCondition)>,
+    loop_duration: Option<Duration>,
     chunk_buffer_duration: Duration,
     queue_input: WeakQueueInput,
 }
@@ -253,6 +258,7 @@ impl TrackManagerThread {
         input_ref: &Ref<InputId>,
         options: Mp4InputOptions,
         source_file: Arc<SourceFile>,
+        loop_duration: Option<Duration>,
         chunk_buffer_duration: Duration,
         queue_input: WeakQueueInput,
     ) -> (Self, crossbeam_channel::Sender<StateEvent>) {
@@ -275,6 +281,7 @@ impl TrackManagerThread {
                 track_ctx,
                 video_thread: None,
                 audio_thread: None,
+                loop_duration,
                 chunk_buffer_duration,
                 queue_input,
             },
@@ -328,7 +335,10 @@ impl TrackManagerThread {
             queue_input.queue_new_track(QueueTrackOptions {
                 video: self.video_thread.is_some(),
                 audio: self.audio_thread.is_some(),
-                offset: QueueTrackOffset::None,
+                offset: match (self.loop_duration, seek) {
+                    (Some(duration), None) => QueueTrackOffset::Continuation(duration),
+                    _ => QueueTrackOffset::None,
+                },
             })
         };
 

--- a/smelter-core/src/queue/queue_input.rs
+++ b/smelter-core/src/queue/queue_input.rs
@@ -62,6 +62,7 @@ pub(super) struct InnerQueueInput {
     video: Option<VideoQueueInput>,
     audio: Option<AudioQueueInput>,
     track_offset: TrackOffset,
+    queued_track_offset: Option<TrackOffset>,
     pause_state: PauseState,
 
     pending_sender: crossbeam_channel::Sender<PendingTrack>,
@@ -111,7 +112,7 @@ impl InnerQueueInput {
     }
 
     fn new_pending_track(
-        &self,
+        &mut self,
         opts: QueueTrackOptions,
     ) -> (
         PendingTrack,
@@ -124,7 +125,15 @@ impl InnerQueueInput {
             QueueTrackOffset::None => (TrackOffset::default(), None),
             QueueTrackOffset::Pts(duration) => (TrackOffset::new(duration), None),
             QueueTrackOffset::FromStart(duration) => (TrackOffset::default(), Some(duration)),
+            QueueTrackOffset::Continuation(duration) => (
+                self.queued_track_offset
+                    .as_ref()
+                    .expect("continuation requires a preceding track")
+                    .after(duration),
+                None,
+            ),
         };
+        self.queued_track_offset = Some(track_offset.clone());
         let (video_input, video_sender) = if opts.video {
             let side_channel = self
                 .video_side_channel
@@ -216,6 +225,7 @@ pub(crate) enum QueueTrackOffset {
     Pts(Duration),
     /// Offset from start point
     FromStart(Duration),
+    Continuation(Duration),
 }
 
 #[derive(Debug)]
@@ -283,6 +293,7 @@ impl QueueInput {
             video: None,
             audio: None,
             track_offset: TrackOffset::default(),
+            queued_track_offset: None,
 
             pending_sender,
             pending_receiver,
@@ -307,7 +318,7 @@ impl QueueInput {
         if !opts.video && !opts.audio {
             return (None, None);
         }
-        let guard = self.0.lock().unwrap();
+        let mut guard = self.0.lock().unwrap();
         let (track, video_sender, audio_sender) = guard.new_pending_track(opts);
         let pending_sender = guard.pending_sender.clone();
         drop(guard);
@@ -365,19 +376,24 @@ impl WeakQueueInput {
 }
 
 #[derive(Default, Clone)]
-pub(super) struct TrackOffset(Arc<Mutex<Option<Duration>>>);
+pub(super) struct TrackOffset(Arc<Mutex<Option<Duration>>>, Duration);
 
 impl TrackOffset {
     pub fn new(value: Duration) -> Self {
-        Self(Arc::new(Mutex::new(Some(value))))
+        Self(Arc::new(Mutex::new(Some(value))), Duration::ZERO)
+    }
+
+    fn after(&self, duration: Duration) -> Self {
+        Self(self.0.clone(), self.1 + duration)
     }
 
     pub fn get(&self) -> Option<Duration> {
-        *self.0.lock().unwrap()
+        self.0.lock().unwrap().map(|base| base + self.1)
     }
 
     pub fn get_or_init(&self, offset: Duration) -> Duration {
-        *self.0.lock().unwrap().get_or_insert(offset)
+        let mut base = self.0.lock().unwrap();
+        *base.get_or_insert(offset.saturating_sub(self.1)) + self.1
     }
 
     pub fn map_add(&self, duration: Duration) {


### PR DESCRIPTION
Each queued iteration currently resolves a fresh shared A/V offset from whichever track first reaches the queue. AAC chunk cadence does not generally align with the video frame grid, so that offset can move the next iteration past its first video frame. A 25 fps fixture consequently produced frames 0–11 on its first iteration and 1–11 thereafter.

This change only lets an input describe the next track as a continuation of the preceding track. The queue still owns offset resolution, while the MP4 input supplies its known iteration duration. It does not add finite-track scheduling, trimming, or broader end-of-stream policy.
Supersedes #2171.
