### PR TITLE
Release DeckLink capture configuration on drop

### DIFF
--- a/decklink/cpp/api.cpp
+++ b/decklink/cpp/api.cpp
@@ -157,7 +157,13 @@ HResult input_flush_streams(IDeckLinkInput *input) {
   return static_cast<HResult>(input->FlushStreams());
 }
 
-void input_release(IDeckLinkInput *input) { input->Release(); }
+void input_release(IDeckLinkInput *input) {
+  input->StopStreams();
+  input->DisableVideoInput();
+  input->DisableAudioInput();
+  input->SetCallback(nullptr);
+  input->Release();
+}
 
 //
 // IDeckLinkProfileManager

--- a/smelter-core/src/pipeline/decklink/mod.rs
+++ b/smelter-core/src/pipeline/decklink/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tracing::{Level, error, span};
+use tracing::{Level, span};
 
 use crate::pipeline::input::Input;
 use crate::queue::{QueueTrackOffset, QueueTrackOptions};
@@ -111,13 +111,5 @@ impl DeckLink {
             InputInitInfo::Other,
             queue_input,
         ))
-    }
-}
-
-impl Drop for DeckLink {
-    fn drop(&mut self) {
-        if let Err(err) = self.input.stop_streams() {
-            error!("Failed to stop streams: {:?}", err);
-        }
     }
 }


### PR DESCRIPTION
## Summary

- shut down DeckLink streams, video, audio, and callbacks before releasing the input interface
- centralize teardown in the owning `decklink::Input` RAII wrapper
- remove the partial Smelter Core destructor

This prevents one capture session from leaving DeckLink input configuration active for the next session.

Validated with `cargo check -p decklink` and `cargo test -p decklink`.