### PR TITLE
gpu-video: introduce MemoryBarrier2Masks struct

### DIFF
--- a/gpu-video/src/backends/vulkan/vulkan_decoder.rs
+++ b/gpu-video/src/backends/vulkan/vulkan_decoder.rs
@@ -269,6 +269,14 @@ impl<'a> VulkanDecoder<'a> {
         // begin video coding
         let mut cmd_buffer = self.tracker.command_buffer_pools.decode.begin_buffer()?;
 
+        let masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::VIDEO_DECODE_KHR,
+            dst_stage_mask: vk::PipelineStageFlags2::VIDEO_DECODE_KHR,
+            src_access_mask: vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR,
+            dst_access_mask: vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR
+                | vk::AccessFlags2::VIDEO_DECODE_READ_KHR,
+        };
+
         video_session_resources
             .decoding_images
             .dpb
@@ -276,11 +284,7 @@ impl<'a> VulkanDecoder<'a> {
             .image_with_view
             .transition_layout(
                 &mut cmd_buffer,
-                vk::PipelineStageFlags2::VIDEO_DECODE_KHR
-                    ..vk::PipelineStageFlags2::VIDEO_DECODE_KHR,
-                vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR
-                    ..vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR
-                        | vk::AccessFlags2::VIDEO_DECODE_READ_KHR,
+                masks,
                 vk::ImageLayout::VIDEO_DECODE_DPB_KHR,
                 vk::ImageSubresourceRange {
                     base_array_layer: 0,
@@ -294,11 +298,7 @@ impl<'a> VulkanDecoder<'a> {
         if let Some(dst) = &video_session_resources.decoding_images.dst_image {
             dst.image_with_view.transition_layout(
                 &mut cmd_buffer,
-                vk::PipelineStageFlags2::VIDEO_DECODE_KHR
-                    ..vk::PipelineStageFlags2::VIDEO_DECODE_KHR,
-                vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR
-                    ..vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR
-                        | vk::AccessFlags2::VIDEO_DECODE_READ_KHR,
+                masks,
                 vk::ImageLayout::VIDEO_DECODE_DST_KHR,
                 vk::ImageSubresourceRange {
                     base_array_layer: 0,
@@ -311,12 +311,10 @@ impl<'a> VulkanDecoder<'a> {
         }
 
         let memory_barrier = vk::MemoryBarrier2::default()
-            .src_stage_mask(vk::PipelineStageFlags2::VIDEO_DECODE_KHR)
-            .src_access_mask(vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR)
-            .dst_stage_mask(vk::PipelineStageFlags2::VIDEO_DECODE_KHR)
-            .dst_access_mask(
-                vk::AccessFlags2::VIDEO_DECODE_READ_KHR | vk::AccessFlags2::VIDEO_DECODE_WRITE_KHR,
-            );
+            .src_stage_mask(masks.src_stage_mask)
+            .src_access_mask(masks.src_access_mask)
+            .dst_stage_mask(masks.dst_stage_mask)
+            .dst_access_mask(masks.dst_access_mask);
 
         unsafe {
             self.decoding_device
@@ -586,18 +584,30 @@ impl<'a> VulkanDecoder<'a> {
 
         let mut cmd_buffer = self.tracker.command_buffer_pools.transfer.begin_buffer()?;
 
+        let read_masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::NONE,
+            dst_stage_mask: vk::PipelineStageFlags2::COPY,
+            src_access_mask: vk::AccessFlags2::NONE,
+            dst_access_mask: vk::AccessFlags2::TRANSFER_READ,
+        };
+
         decode_output.image.transition_layout_single_layer(
             &mut cmd_buffer,
-            vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::COPY,
-            vk::AccessFlags2::NONE..vk::AccessFlags2::TRANSFER_READ,
+            read_masks,
             vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
             decode_output.layer,
         )?;
 
+        let write_masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::NONE,
+            dst_stage_mask: vk::PipelineStageFlags2::COPY,
+            src_access_mask: vk::AccessFlags2::NONE,
+            dst_access_mask: vk::AccessFlags2::TRANSFER_WRITE,
+        };
+
         image.transition_layout_single_layer(
             &mut cmd_buffer,
-            vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::COPY,
-            vk::AccessFlags2::NONE..vk::AccessFlags2::TRANSFER_WRITE,
+            write_masks,
             vk::ImageLayout::TRANSFER_DST_OPTIMAL,
             0,
         )?;
@@ -812,10 +822,16 @@ impl<'a> VulkanDecoder<'a> {
     ) -> Result<(Buffer, SemaphoreWaitValue), VulkanDecoderError> {
         let mut cmd_buffer = self.tracker.command_buffer_pools.transfer.begin_buffer()?;
 
+        let masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::NONE,
+            dst_stage_mask: vk::PipelineStageFlags2::COPY,
+            src_access_mask: vk::AccessFlags2::NONE,
+            dst_access_mask: vk::AccessFlags2::TRANSFER_READ,
+        };
+
         image.transition_layout_single_layer(
             &mut cmd_buffer,
-            vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::COPY,
-            vk::AccessFlags2::NONE..vk::AccessFlags2::TRANSFER_READ,
+            masks,
             vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
             layer,
         )?;

--- a/gpu-video/src/backends/vulkan/vulkan_encoder.rs
+++ b/gpu-video/src/backends/vulkan/vulkan_encoder.rs
@@ -19,9 +19,9 @@ use crate::{
         vulkan_device::EncodingDevice,
         wrappers::{
             Buffer, CommandBufferPool, CommandBufferPoolStorage, DecodedPicturesBuffer, Image,
-            ImageLayoutTracker, ImageView, OpenCommandBuffer, ProfileInfo, QueryPool,
-            SemaphoreWaitValue, Tracker, TrackerKind, VideoEncodeQueueExt, VideoQueueExt,
-            VideoSession, VideoSessionParameters,
+            ImageLayoutTracker, ImageView, MemoryBarrier2Masks, OpenCommandBuffer, ProfileInfo,
+            QueryPool, SemaphoreWaitValue, Tracker, TrackerKind, VideoEncodeQueueExt,
+            VideoQueueExt, VideoSession, VideoSessionParameters,
         },
     },
     device::{ColorRange, ColorSpace, Rational},
@@ -729,10 +729,16 @@ impl<'a, C: EncodeCodec + 'a> VulkanEncoder<'a, C> {
 
         let mut cmd_buffer = self.tracker.command_buffer_pools.transfer.begin_buffer()?;
 
+        let masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::NONE,
+            dst_stage_mask: vk::PipelineStageFlags2::COPY,
+            src_access_mask: vk::AccessFlags2::NONE,
+            dst_access_mask: vk::AccessFlags2::TRANSFER_WRITE,
+        };
+
         image.transition_layout_single_layer(
             &mut cmd_buffer,
-            vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::COPY,
-            vk::AccessFlags2::NONE..vk::AccessFlags2::TRANSFER_WRITE,
+            masks,
             vk::ImageLayout::TRANSFER_DST_OPTIMAL,
             0,
         )?;
@@ -1107,10 +1113,16 @@ impl<'a, C: EncodeCodec + 'a> DynVulkanEncoder<'a> for VulkanEncoder<'a, C> {
 
         let mut cmd_buffer = self.tracker.command_buffer_pools.encode.begin_buffer()?;
 
+        let masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::NONE,
+            dst_stage_mask: vk::PipelineStageFlags2::VIDEO_ENCODE_KHR,
+            src_access_mask: vk::AccessFlags2::NONE,
+            dst_access_mask: vk::AccessFlags2::VIDEO_ENCODE_READ_KHR,
+        };
+
         image.transition_layout_single_layer(
             &mut cmd_buffer,
-            vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::VIDEO_ENCODE_KHR,
-            vk::AccessFlags2::NONE..vk::AccessFlags2::VIDEO_ENCODE_READ_KHR,
+            masks,
             vk::ImageLayout::VIDEO_ENCODE_SRC_KHR,
             0,
         )?;

--- a/gpu-video/src/backends/vulkan/wrappers/mem.rs
+++ b/gpu-video/src/backends/vulkan/wrappers/mem.rs
@@ -337,6 +337,14 @@ impl std::ops::Deref for Buffer {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MemoryBarrier2Masks {
+    pub src_stage_mask: vk::PipelineStageFlags2,
+    pub dst_stage_mask: vk::PipelineStageFlags2,
+    pub src_access_mask: vk::AccessFlags2,
+    pub dst_access_mask: vk::AccessFlags2,
+}
+
 pub(crate) struct Image {
     pub(crate) image: vk::Image,
     allocation: vk_mem::Allocation,
@@ -414,16 +422,15 @@ impl Image {
         &self,
         command_buffer: vk::CommandBuffer,
         layout: &mut [vk::ImageLayout],
-        stages: std::ops::Range<vk::PipelineStageFlags2>,
-        accesses: std::ops::Range<vk::AccessFlags2>,
+        masks: MemoryBarrier2Masks,
         new_layout: vk::ImageLayout,
         subresource_range: vk::ImageSubresourceRange,
     ) -> Result<(), VulkanCommonError> {
         let barrier = vk::ImageMemoryBarrier2::default()
-            .src_stage_mask(stages.start)
-            .dst_stage_mask(stages.end)
-            .src_access_mask(accesses.start)
-            .dst_access_mask(accesses.end)
+            .src_stage_mask(masks.src_stage_mask)
+            .dst_stage_mask(masks.dst_stage_mask)
+            .src_access_mask(masks.src_access_mask)
+            .dst_access_mask(masks.dst_access_mask)
             .new_layout(new_layout)
             .src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
             .dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
@@ -517,36 +524,26 @@ impl Image {
     pub(crate) fn transition_layout(
         &self,
         command_buffer: &mut OpenCommandBuffer,
-        stages: std::ops::Range<vk::PipelineStageFlags2>,
-        accesses: std::ops::Range<vk::AccessFlags2>,
+        masks: MemoryBarrier2Masks,
         new_layout: vk::ImageLayout,
         subresource_range: vk::ImageSubresourceRange,
     ) -> Result<(), VulkanCommonError> {
         let raw_buffer = command_buffer.buffer();
         let layout = command_buffer.image_layout(self.key(), &self.tracker)?;
 
-        self.transition_layout_raw(
-            raw_buffer,
-            layout,
-            stages,
-            accesses,
-            new_layout,
-            subresource_range,
-        )
+        self.transition_layout_raw(raw_buffer, layout, masks, new_layout, subresource_range)
     }
 
     pub(crate) fn transition_layout_single_layer(
         &self,
         command_buffer: &mut OpenCommandBuffer,
-        stages: std::ops::Range<vk::PipelineStageFlags2>,
-        accesses: std::ops::Range<vk::AccessFlags2>,
+        masks: MemoryBarrier2Masks,
         new_layout: vk::ImageLayout,
         base_array_layer: u32,
     ) -> Result<(), VulkanCommonError> {
         self.transition_layout(
             command_buffer,
-            stages,
-            accesses,
+            masks,
             new_layout,
             vk::ImageSubresourceRange {
                 aspect_mask: vk::ImageAspectFlags::COLOR,

--- a/gpu-video/src/backends/vulkan/wrappers/video.rs
+++ b/gpu-video/src/backends/vulkan/wrappers/video.rs
@@ -7,7 +7,7 @@ use crate::{
         VulkanCommonError,
         codec::Codec,
         vulkan_device::{VulkanDevice, queues::VideoQueues},
-        wrappers::{ImageLayoutTracker, OpenCommandBuffer},
+        wrappers::{ImageLayoutTracker, MemoryBarrier2Masks, OpenCommandBuffer},
     },
     parser::reference_manager::{PictureInfo, ReferencePictureInfo},
 };
@@ -291,19 +291,14 @@ impl ImageWithView {
     pub(crate) fn transition_layout(
         &self,
         command_buffer: &mut OpenCommandBuffer,
-        stages: std::ops::Range<vk::PipelineStageFlags2>,
-        accesses: std::ops::Range<vk::AccessFlags2>,
+        masks: MemoryBarrier2Masks,
         new_layout: vk::ImageLayout,
         subresource_range: vk::ImageSubresourceRange,
     ) -> Result<(), VulkanCommonError> {
         match self {
-            ImageWithView::Single { image, .. } => image.transition_layout(
-                command_buffer,
-                stages,
-                accesses,
-                new_layout,
-                subresource_range,
-            ),
+            ImageWithView::Single { image, .. } => {
+                image.transition_layout(command_buffer, masks, new_layout, subresource_range)
+            }
 
             ImageWithView::Multiple { images, .. } => {
                 let start_layer = subresource_range.base_array_layer as usize;
@@ -317,8 +312,7 @@ impl ImageWithView {
                     let subresource_range = subresource_range.base_array_layer(0).layer_count(1);
                     image.transition_layout(
                         command_buffer,
-                        stages.clone(),
-                        accesses.clone(),
+                        masks,
                         new_layout,
                         subresource_range,
                     )?;
@@ -397,8 +391,12 @@ impl<'a> CodingImageBundle<'a> {
             layer_count: vk::REMAINING_ARRAY_LAYERS,
         };
 
-        let accesses = vk::AccessFlags2::NONE..vk::AccessFlags2::NONE;
-        let stages = vk::PipelineStageFlags2::NONE..vk::PipelineStageFlags2::NONE;
+        let masks = MemoryBarrier2Masks {
+            src_stage_mask: vk::PipelineStageFlags2::NONE,
+            dst_stage_mask: vk::PipelineStageFlags2::NONE,
+            src_access_mask: vk::AccessFlags2::NONE,
+            dst_access_mask: vk::AccessFlags2::NONE,
+        };
 
         let image_with_view = if use_separate_images {
             let images = (0..array_layer_count)
@@ -443,13 +441,7 @@ impl<'a> CodingImageBundle<'a> {
                 .collect::<Result<Vec<_>, _>>()?;
 
             for image in &images {
-                image.transition_layout(
-                    command_buffer,
-                    stages.clone(),
-                    accesses.clone(),
-                    layout,
-                    subresource_range,
-                )?;
+                image.transition_layout(command_buffer, masks, layout, subresource_range)?;
             }
 
             ImageWithView::Multiple {
@@ -485,13 +477,7 @@ impl<'a> CodingImageBundle<'a> {
                 &image_view_create_info,
             )?;
 
-            image.transition_layout(
-                command_buffer,
-                stages.clone(),
-                accesses.clone(),
-                layout,
-                subresource_range,
-            )?;
+            image.transition_layout(command_buffer, masks, layout, subresource_range)?;
 
             ImageWithView::Single { image, image_view }
         };


### PR DESCRIPTION
The `Range` struct is abused here to reduce the argument count, but the values are absolutely not a range.  This was confusing when reading the code because of the semantic mismatch.  Introduce a dedicated struct to achieve the desired effect of reducing argument count.