### PR TITLE
Stop droping first frame on mp4 loop input

### DIFF
--- a/smelter-core/src/pipeline/decoder/fdk_aac.rs
+++ b/smelter-core/src/pipeline/decoder/fdk_aac.rs
@@ -1,7 +1,6 @@
 use fdk_aac_sys as fdk;
-use std::sync::Arc;
-use std::time::Duration;
-use tracing::{error, info};
+use std::{sync::Arc, time::Duration};
+use tracing::{error, info, trace};
 
 use crate::pipeline::decoder::{AudioDecoder, EncodedInputEvent};
 
@@ -29,6 +28,7 @@ impl AudioDecoder for FdkAacDecoder {
         &mut self,
         event: EncodedInputEvent,
     ) -> Result<Vec<InputAudioSamples>, DecodingError> {
+        trace!(?event, "FDK AAC decoder received an event.");
         let chunk = match event {
             EncodedInputEvent::Chunk(chunk) => chunk,
             EncodedInputEvent::LostData | EncodedInputEvent::AuDelimiter => return Ok(vec![]),
@@ -177,11 +177,13 @@ impl Decoder {
                     _ => Duration::from_secs_f64(info.outputDelay as f64 / sample_rate as f64),
                 };
 
-                decoded_samples.push(InputAudioSamples {
+                let samples = InputAudioSamples {
                     samples,
                     start_pts: chunk.pts.saturating_sub(output_delay),
                     sample_rate,
-                })
+                };
+                trace!(?samples, "FDK AAC decoder produced a samples.");
+                decoded_samples.push(samples)
             }
         }
         Ok(decoded_samples)

--- a/smelter-core/src/queue/queue_thread.rs
+++ b/smelter-core/src/queue/queue_thread.rs
@@ -142,19 +142,19 @@ impl QueueThreadAfterStart {
                 .first_key_value()
                 .map(|(pts, _)| *pts + self.queue_start_pts);
 
-            self.audio_processor
-                .queue
-                .audio_queue
-                .lock()
-                .unwrap()
-                .should_push_for_pts_range(audio_pts_range, self.queue_start_pts);
-
             self.video_processor
                 .queue
                 .video_queue
                 .lock()
                 .unwrap()
                 .should_push_next_frameset(video_pts, self.queue_start_pts);
+
+            self.audio_processor
+                .queue
+                .audio_queue
+                .lock()
+                .unwrap()
+                .should_push_for_pts_range(audio_pts_range, self.queue_start_pts);
 
             if let Some(event_pts) = event_pts
                 && event_pts < video_pts

--- a/smelter-core/src/queue/tests/harness.rs
+++ b/smelter-core/src/queue/tests/harness.rs
@@ -7,8 +7,8 @@
 //!
 //! Typical test structure:
 //! - `TestQueue::new` + `add_input` (before or after `start`, depending on scenario)
-//! - send frames/samples via `TestInput` (or `stream_video_then_eos` for sends
-//!   that must not block the test thread, e.g. before queue start)
+//! - send frames/samples via `TestInput`; both go through a relay thread, so
+//!   sends never block the test thread
 //! - `start()` the queue
 //! - read output with `next_video_batch`/`next_audio_batch` and compare against
 //!   expected `VideoBatch`/`AudioBatch` values; all PTS in summaries are relative
@@ -370,8 +370,8 @@ impl TestQueue {
         TestInput {
             input_id,
             queue_input,
-            video,
-            audio: audio.map(spawn_audio_relay),
+            video: video.map(spawn_relay),
+            audio: audio.map(spawn_relay),
             next_frame_id: 0,
             next_samples_id: 0,
         }
@@ -494,15 +494,15 @@ impl Drop for TestQueue {
     }
 }
 
-/// Relay audio batches from an unbounded channel to the queue's bounded track
-/// channel, so test sends never block on the queue's ~100ms internal buffer.
-/// Dropping the returned sender stops the relay, which closes the track once
-/// every pending batch is forwarded.
-fn spawn_audio_relay(queue_sender: QueueSender<InputAudioSamples>) -> Sender<InputAudioSamples> {
+/// Relay frames or sample batches from an unbounded channel to the queue's
+/// bounded track channel, so test sends never block on the queue's ~100ms
+/// internal buffer. Dropping the returned sender stops the relay, which closes
+/// the track once everything pending is forwarded.
+fn spawn_relay<T: Send + 'static>(queue_sender: QueueSender<T>) -> Sender<T> {
     let (sender, receiver) = unbounded();
     thread::spawn(move || {
-        for batch in receiver {
-            if queue_sender.send(batch).is_err() {
+        for item in receiver {
+            if queue_sender.send(item).is_err() {
                 return;
             }
         }
@@ -513,7 +513,7 @@ fn spawn_audio_relay(queue_sender: QueueSender<InputAudioSamples>) -> Sender<Inp
 pub struct TestInput {
     pub input_id: InputId,
     pub queue_input: QueueInput,
-    video: Option<QueueSender<Frame>>,
+    video: Option<Sender<Frame>>,
     audio: Option<Sender<InputAudioSamples>>,
     next_frame_id: u32,
     next_samples_id: u32,
@@ -526,13 +526,13 @@ impl TestInput {
     /// tracks.
     pub fn new_track(&mut self, track: QueueTrackOptions) {
         let (video, audio) = self.queue_input.queue_new_track(track);
-        self.video = video;
-        self.audio = audio.map(spawn_audio_relay);
+        self.video = video.map(spawn_relay);
+        self.audio = audio.map(spawn_relay);
     }
 
     /// Send a single frame and return its id (n-th video frame sent on this input).
-    /// Blocks on queue backpressure (the queue buffers ~100ms of input plus one
-    /// frame in the channel).
+    /// Never blocks: a relay thread forwards frames to the queue as fast as its
+    /// internal buffer allows.
     pub fn send_frame(&mut self, pts: Duration) -> u32 {
         let id = self.next_frame_id;
         self.next_frame_id += 1;
@@ -544,27 +544,10 @@ impl TestInput {
         id
     }
 
-    /// Close the video track; the queue emits EOS once buffered frames drain.
+    /// Close the video track; the relay forwards the remaining frames and the
+    /// queue emits EOS once buffered frames drain.
     pub fn end_video(&mut self) {
         self.video.take().expect("video track not active");
-    }
-
-    /// Send frames from a background thread and close the video track afterwards.
-    /// Use when sends would block the test thread, e.g. before the queue starts.
-    pub fn stream_video_then_eos(&mut self, frame_pts: Vec<Duration>) -> thread::JoinHandle<()> {
-        let sender = self.video.take().expect("video track not active");
-        let first_id = self.next_frame_id;
-        self.next_frame_id += frame_pts.len() as u32;
-        thread::spawn(move || {
-            for (index, pts) in frame_pts.into_iter().enumerate() {
-                if sender
-                    .send(test_frame(first_id + index as u32, pts))
-                    .is_err()
-                {
-                    return;
-                }
-            }
-        })
     }
 
     /// Send a batch of samples and return its id (n-th sample batch sent on this
@@ -579,13 +562,6 @@ impl TestInput {
             .send(test_samples(id, start_pts, duration))
             .expect("audio channel closed");
         id
-    }
-
-    /// Send `count` batches starting at `first_pts`, back to back.
-    pub fn send_sample_batches(&mut self, first_pts: Duration, duration: Duration, count: u32) {
-        for index in 0..count {
-            self.send_samples(first_pts + duration * index, duration);
-        }
     }
 
     /// Close the audio track; the relay forwards the remaining batches and

--- a/smelter-core/src/queue/tests/mod.rs
+++ b/smelter-core/src/queue/tests/mod.rs
@@ -1,4 +1,5 @@
 mod audio;
 mod events;
 mod harness;
+mod track_switch;
 mod video;

--- a/smelter-core/src/queue/tests/track_switch.rs
+++ b/smelter-core/src/queue/tests/track_switch.rs
@@ -83,11 +83,13 @@ fn next_track_equal_fps_keeps_first_frame() {
     // nothing until 50ms, then audio first so it is the medium that resolves
     // track 1's `None` offset, pinning it to the 60ms slot
     sleep(ms(50));
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
-    }
+    input.send_samples(ms(0), INPUT_BATCH_DURATION);
+    input.send_samples(ms(15), INPUT_BATCH_DURATION);
+    input.send_samples(ms(30), INPUT_BATCH_DURATION);
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     // next track, queued while track 1 is still draining. Sending both media up
     // front means the queue observes them on the same tick.
@@ -96,8 +98,12 @@ fn next_track_equal_fps_keeps_first_frame() {
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..12).map(|index| ms(20) * index).collect());
+    for index in 0..10 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..12 {
+        input.send_frame(ms(20) * index);
+    }
 
     sleep(ms(120));
 
@@ -139,19 +145,25 @@ fn next_track_lower_fps_keeps_first_frame() {
     queue.start();
 
     sleep(ms(50));
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
-    }
+    input.send_samples(ms(0), INPUT_BATCH_DURATION);
+    input.send_samples(ms(15), INPUT_BATCH_DURATION);
+    input.send_samples(ms(30), INPUT_BATCH_DURATION);
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     input.new_track(QueueTrackOptions {
         video: true,
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..12).map(|index| ms(25) * index).collect());
+    for index in 0..10 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..12 {
+        input.send_frame(ms(25) * index);
+    }
 
     sleep(ms(120));
 
@@ -193,19 +205,25 @@ fn next_track_higher_fps_keeps_first_frame() {
     queue.start();
 
     sleep(ms(50));
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
-    }
+    input.send_samples(ms(0), INPUT_BATCH_DURATION);
+    input.send_samples(ms(15), INPUT_BATCH_DURATION);
+    input.send_samples(ms(30), INPUT_BATCH_DURATION);
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     input.new_track(QueueTrackOptions {
         video: true,
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..24).map(|index| ms(10) * index).collect());
+    for index in 0..10 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..24 {
+        input.send_frame(ms(10) * index);
+    }
 
     sleep(ms(120));
 
@@ -250,19 +268,25 @@ fn next_track_audio_starting_later_keeps_first_frame() {
     queue.start();
 
     sleep(ms(50));
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
-    }
+    input.send_samples(ms(0), INPUT_BATCH_DURATION);
+    input.send_samples(ms(15), INPUT_BATCH_DURATION);
+    input.send_samples(ms(30), INPUT_BATCH_DURATION);
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     input.new_track(QueueTrackOptions {
         video: true,
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(20), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..12).map(|index| ms(20) * index).collect());
+    for index in 0..10 {
+        input.send_samples(ms(20) + INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..12 {
+        input.send_frame(ms(20) * index);
+    }
 
     sleep(ms(120));
 
@@ -307,19 +331,25 @@ fn next_track_video_starting_later_renders_empty_batch() {
     queue.start();
 
     sleep(ms(50));
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
-    }
+    input.send_samples(ms(0), INPUT_BATCH_DURATION);
+    input.send_samples(ms(15), INPUT_BATCH_DURATION);
+    input.send_samples(ms(30), INPUT_BATCH_DURATION);
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     input.new_track(QueueTrackOptions {
         video: true,
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..12).map(|index| ms(20) + ms(20) * index).collect());
+    for index in 0..10 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..12 {
+        input.send_frame(ms(20) + ms(20) * index);
+    }
 
     sleep(ms(120));
 
@@ -358,19 +388,25 @@ fn next_track_video_starting_much_later_renders_empty_batches() {
     queue.start();
 
     sleep(ms(50));
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
-    }
+    input.send_samples(ms(0), INPUT_BATCH_DURATION);
+    input.send_samples(ms(15), INPUT_BATCH_DURATION);
+    input.send_samples(ms(30), INPUT_BATCH_DURATION);
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     input.new_track(QueueTrackOptions {
         video: true,
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..12).map(|index| ms(40) + ms(20) * index).collect());
+    for index in 0..10 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..12 {
+        input.send_frame(ms(40) + ms(20) * index);
+    }
 
     sleep(ms(140));
 
@@ -416,19 +452,25 @@ fn next_track_after_audio_ends_last_keeps_first_frame() {
 
     sleep(ms(50));
     // 300ms of audio: the buffer only empties on the chunk at 260ms
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 20);
-    sleep(ms(2));
-    for index in 0..4 {
-        input.send_frame(ms(20) * index);
+    for index in 0..20 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
     }
+    input.send_frame(ms(0));
+    input.send_frame(ms(20));
+    input.send_frame(ms(40));
+    input.send_frame(ms(60));
 
     input.new_track(QueueTrackOptions {
         video: true,
         audio: true,
         offset: QueueTrackOffset::None,
     });
-    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
-    input.stream_video_then_eos((0..12).map(|index| ms(20) * index).collect());
+    for index in 0..10 {
+        input.send_samples(INPUT_BATCH_DURATION * index, INPUT_BATCH_DURATION);
+    }
+    for index in 0..12 {
+        input.send_frame(ms(20) * index);
+    }
 
     sleep(ms(260));
 
@@ -453,9 +495,13 @@ fn next_track_after_audio_ends_last_keeps_first_frame() {
     );
 
     // video ended, audio has not: nothing is delivered for 140ms
-    for pts in [140, 160, 180, 200, 220, 240, 260] {
-        assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(pts), true);
-    }
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(140), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(160), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(180), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(200), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(220), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(240), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(260), true);
 
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),

--- a/smelter-core/src/queue/tests/track_switch.rs
+++ b/smelter-core/src/queue/tests/track_switch.rs
@@ -1,0 +1,481 @@
+//! Track switching on a single input, as `Mp4Input` does when it loops: both
+//! tracks are registered with [`QueueTrackOffset::None`], the next one is queued
+//! while the previous is still draining, and the queue swaps once both media of
+//! the old track delivered EOS.
+//!
+//! The two media of a track share a single `TrackOffset`, so whichever resolves
+//! it first decides where that track's zero lands. The audio queue is processed
+//! before the video queue on each tick and also carries the swap, so audio wins
+//! that race and anchors the offset to the *audio* slot (the next 20ms chunk)
+//! instead of the *video* slot (the next output batch).
+//!
+//! With the harness defaults both slots sit on the same 20ms grid, and within a
+//! tick the queue pushes video before audio when they are equal. That makes the
+//! gap deterministic: when the video EOS is the later of the two, the swap lands
+//! on the iteration right after a video batch was pushed, so the audio slot is
+//! one batch behind the video slot and the video looks up input PTS 20ms
+//! instead of 0.
+//!
+//! Every test shares the same track 1: nothing for the first 50ms (three empty
+//! batches), then 45ms of audio followed by video frames at 0/20/40/60ms. The
+//! audio is sent first and given a tick to land, so it is the medium that
+//! resolves the offset, pinning it to the 60ms slot. A chunk pops everything up
+//! to chunk end + 80ms, so 45ms of audio drains on its first chunk and the video
+//! EOS at 120ms is the later of the two (the last test inverts this).
+//!
+//! That puts the swap at the 140ms video slot with the offset at 120ms. Frame
+//! ids keep incrementing across tracks, so the next track's first frame is
+//! always id 4.
+
+use std::{thread::sleep, time::Duration};
+
+use crate::queue::{QueueInputOptions, QueueTrackOffset, QueueTrackOptions};
+
+use super::harness::{
+    INPUT_BATCH_DURATION, InputFrame, TestInput, TestQueue, TestQueueOptions, VideoBatch,
+    assert_empty_video_batch, assert_video_batch_eq, frames, ms,
+};
+
+fn frame(id: u32, pts: Duration) -> InputFrame {
+    InputFrame::frame(id, pts)
+}
+
+fn frame_eos(id: u32, pts: Duration) -> InputFrame {
+    InputFrame::frame_eos(id, pts)
+}
+
+/// A batch with a single frame from the required "input_1".
+fn batch(pts: Duration, frame: InputFrame) -> VideoBatch {
+    VideoBatch {
+        pts,
+        required: true,
+        frames: frames([("input_1", frame)]),
+    }
+}
+
+/// Create a queue with a single required input carrying both video and audio,
+/// with its first track registered the way `Mp4Input` registers one without an
+/// explicit offset. The queue is not started yet.
+fn create_queue_with_av_input() -> (TestQueue, TestInput) {
+    let queue = TestQueue::new(TestQueueOptions::default());
+    let input = queue.add_input(
+        "input_1",
+        QueueInputOptions {
+            required: true,
+            ..Default::default()
+        },
+        QueueTrackOptions {
+            video: true,
+            audio: true,
+            offset: QueueTrackOffset::None,
+        },
+    );
+    (queue, input)
+}
+
+/// Both media of the next track start at 0 and its frames are 20ms apart, the
+/// output batch duration.
+///
+/// The offset is locked to the audio slot at 120ms while the video slot is
+/// already at 140ms, so the video looks up input PTS 20ms and `prepare_for_pts`
+/// promotes past the track's first frame — the second one sits exactly at 20ms.
+///
+/// Expected at 140ms is `frame(4, ms(120))`; frame 4 is never rendered.
+#[test]
+fn next_track_equal_fps_drops_first_frame() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    // nothing until 50ms, then audio first so it is the medium that resolves
+    // the `None` offset, pinning it to the 60ms slot
+    sleep(ms(50));
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    // next track, queued while track 1 is still draining. Sending both media up
+    // front means the queue observes them on the same tick.
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..12).map(|index| ms(20) * index).collect());
+
+    sleep(ms(120));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(140), frame(5, ms(140))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(160), frame(6, ms(160))),
+    );
+}
+
+/// Next track below the output framerate (frames 25ms apart).
+///
+/// Same 20ms lookup, but the second frame is at 25ms so `prepare_for_pts` has
+/// nothing to promote to: the track's first frame survives, stamped 20ms before
+/// the batch carrying it.
+#[test]
+fn next_track_lower_fps_keeps_first_frame() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    sleep(ms(50));
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..12).map(|index| ms(25) * index).collect());
+
+    sleep(ms(120));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(140), frame(4, ms(120))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(160), frame(5, ms(145))),
+    );
+}
+
+/// Next track above the output framerate (frames 10ms apart). The 20ms lookup
+/// now covers two input frames, so the track starts 20ms into its media.
+#[test]
+fn next_track_higher_fps_drops_first_two_frames() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    sleep(ms(50));
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..24).map(|index| ms(10) * index).collect());
+
+    sleep(ms(120));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(140), frame(6, ms(140))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(160), frame(8, ms(160))),
+    );
+}
+
+/// Next track's audio starts 20ms into its media while its video starts at 0.
+///
+/// The offset stores the queue PTS that observed the first packet, never the
+/// packet's own PTS, so shifting the audio changes nothing for the video: the
+/// result is identical to [`next_track_equal_fps_drops_first_frame`]. The audio
+/// keeps its 20ms head start, delivered 20ms after the offset.
+#[test]
+fn next_track_audio_starting_later_drops_first_frame() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    sleep(ms(50));
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(20), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..12).map(|index| ms(20) * index).collect());
+
+    sleep(ms(120));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(140), frame(5, ms(140))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(160), frame(6, ms(160))),
+    );
+}
+
+/// The other way round: the next track's video starts 20ms into its media while
+/// its audio starts at 0.
+///
+/// The 20ms the video is short by is exactly the 20ms the lookup is ahead by, so
+/// the two cancel and the track's first frame lands on the first batch. Nothing
+/// about the offset changed — the track just happens to be missing the frames
+/// that would otherwise be discarded.
+#[test]
+fn next_track_video_starting_later_keeps_first_frame() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    sleep(ms(50));
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..12).map(|index| ms(20) + ms(20) * index).collect());
+
+    sleep(ms(120));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(140), frame(4, ms(140))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(160), frame(5, ms(160))),
+    );
+}
+
+/// Next track's video starts 40ms into its media (what a leading empty edit in
+/// the `elst` box produces), audio at 0.
+///
+/// Now the head start outruns the 20ms lookup: the first batch of the new track
+/// carries no frame at all, and the track's first frame lands one batch later.
+#[test]
+fn next_track_video_starting_much_later_renders_empty_batch() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    sleep(ms(50));
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..12).map(|index| ms(40) + ms(20) * index).collect());
+
+    sleep(ms(120));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(140), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(160), frame(4, ms(160))),
+    );
+}
+
+/// Track 1's audio outlives its video, so the *audio* EOS is the later one and
+/// the swap lands right after an audio chunk was pushed. There both slots are
+/// equal, the offset matches the video slot, the lookup is 0, and the next
+/// track's first frame survives — the same scenario as
+/// [`next_track_equal_fps_drops_first_frame`] except for which medium ended last.
+///
+/// It also shows the other seam problem: the swap waits for both media, so the
+/// input delivers nothing between its video EOS at 120ms and the audio draining
+/// at 280ms.
+#[test]
+fn next_track_after_audio_ends_last_keeps_first_frame() {
+    let (mut queue, mut input) = create_queue_with_av_input();
+    queue.start();
+
+    sleep(ms(50));
+    // 300ms of audio: the buffer only empties on the chunk at 260ms
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 20);
+    sleep(ms(2));
+    for index in 0..4 {
+        input.send_frame(ms(20) * index);
+    }
+
+    input.new_track(QueueTrackOptions {
+        video: true,
+        audio: true,
+        offset: QueueTrackOffset::None,
+    });
+    input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
+    input.stream_video_then_eos((0..12).map(|index| ms(20) * index).collect());
+
+    sleep(ms(260));
+
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(40), true);
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(60), frame(0, ms(60))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(80), frame(1, ms(80))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(100), frame(2, ms(100))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(120), frame_eos(3, ms(120))),
+    );
+
+    // video ended, audio has not: nothing is delivered for 140ms
+    for pts in [140, 160, 180, 200, 220, 240, 260] {
+        assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(pts), true);
+    }
+
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(280), frame(4, ms(280))),
+    );
+    assert_video_batch_eq(
+        &queue.next_video_batch().unwrap(),
+        &batch(ms(300), frame(5, ms(300))),
+    );
+}

--- a/smelter-core/src/queue/tests/track_switch.rs
+++ b/smelter-core/src/queue/tests/track_switch.rs
@@ -4,28 +4,27 @@
 //! the old track delivered EOS.
 //!
 //! The two media of a track share a single `TrackOffset`, so whichever resolves
-//! it first decides where that track's zero lands. The audio queue is processed
-//! before the video queue on each tick and also carries the swap, so audio wins
-//! that race and anchors the offset to the *audio* slot (the next 20ms chunk)
-//! instead of the *video* slot (the next output batch).
+//! it first decides where that track's zero lands. The queue processes the video
+//! queue before the audio queue on each tick, so video both starts the pending
+//! track and anchors the offset to the *video* slot — the batch it is about to
+//! emit — which makes the first lookup on the new track exactly 0.
 //!
-//! With the harness defaults both slots sit on the same 20ms grid, and within a
-//! tick the queue pushes video before audio when they are equal. That makes the
-//! gap deterministic: when the video EOS is the later of the two, the swap lands
-//! on the iteration right after a video batch was pushed, so the audio slot is
-//! one batch behind the video slot and the video looks up input PTS 20ms
-//! instead of 0.
+//! That ordering matters because the two paths handle a non-zero lookup
+//! differently: `prepare_for_pts` discards frames older than it, while
+//! `pop_before_pts` only re-stamps sample batches. Anchoring on the audio slot
+//! instead would put the offset one batch (20ms) earlier, and the tests below
+//! would lose the new track's first frame.
 //!
 //! Every test shares the same track 1: nothing for the first 50ms (three empty
 //! batches), then 45ms of audio followed by video frames at 0/20/40/60ms. The
 //! audio is sent first and given a tick to land, so it is the medium that
-//! resolves the offset, pinning it to the 60ms slot. A chunk pops everything up
-//! to chunk end + 80ms, so 45ms of audio drains on its first chunk and the video
-//! EOS at 120ms is the later of the two (the last test inverts this).
+//! resolves track 1's offset, pinning it to the 60ms slot. A chunk pops
+//! everything up to chunk end + 80ms, so 45ms of audio drains on its first chunk
+//! and the video EOS at 120ms is the later of the two (the last test inverts
+//! this).
 //!
-//! That puts the swap at the 140ms video slot with the offset at 120ms. Frame
-//! ids keep incrementing across tracks, so the next track's first frame is
-//! always id 4.
+//! That puts the swap at the 140ms video slot. Frame ids keep incrementing
+//! across tracks, so the next track's first frame is always id 4.
 
 use std::{thread::sleep, time::Duration};
 
@@ -74,20 +73,15 @@ fn create_queue_with_av_input() -> (TestQueue, TestInput) {
 }
 
 /// Both media of the next track start at 0 and its frames are 20ms apart, the
-/// output batch duration.
-///
-/// The offset is locked to the audio slot at 120ms while the video slot is
-/// already at 140ms, so the video looks up input PTS 20ms and `prepare_for_pts`
-/// promotes past the track's first frame — the second one sits exactly at 20ms.
-///
-/// Expected at 140ms is `frame(4, ms(120))`; frame 4 is never rendered.
+/// output batch duration. The offset lands on the 140ms video slot, the lookup
+/// is 0, and the track plays from its first frame.
 #[test]
-fn next_track_equal_fps_drops_first_frame() {
+fn next_track_equal_fps_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
     queue.start();
 
     // nothing until 50ms, then audio first so it is the medium that resolves
-    // the `None` offset, pinning it to the 60ms slot
+    // track 1's `None` offset, pinning it to the 60ms slot
     sleep(ms(50));
     input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 3);
     sleep(ms(2));
@@ -128,19 +122,17 @@ fn next_track_equal_fps_drops_first_frame() {
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(140), frame(5, ms(140))),
+        &batch(ms(140), frame(4, ms(140))),
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(160), frame(6, ms(160))),
+        &batch(ms(160), frame(5, ms(160))),
     );
 }
 
-/// Next track below the output framerate (frames 25ms apart).
-///
-/// Same 20ms lookup, but the second frame is at 25ms so `prepare_for_pts` has
-/// nothing to promote to: the track's first frame survives, stamped 20ms before
-/// the batch carrying it.
+/// Next track below the output framerate (frames 25ms apart). The first frame
+/// still lands on the first batch, and is repeated on the next one because the
+/// track has nothing newer to offer yet.
 #[test]
 fn next_track_lower_fps_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
@@ -184,18 +176,19 @@ fn next_track_lower_fps_keeps_first_frame() {
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(140), frame(4, ms(120))),
+        &batch(ms(140), frame(4, ms(140))),
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(160), frame(5, ms(145))),
+        &batch(ms(160), frame(4, ms(140))),
     );
 }
 
-/// Next track above the output framerate (frames 10ms apart). The 20ms lookup
-/// now covers two input frames, so the track starts 20ms into its media.
+/// Next track above the output framerate (frames 10ms apart). The first frame
+/// lands on the first batch; the decimation only starts on the next one, where
+/// the 20ms lookup skips over frame 5.
 #[test]
-fn next_track_higher_fps_drops_first_two_frames() {
+fn next_track_higher_fps_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
     queue.start();
 
@@ -237,11 +230,11 @@ fn next_track_higher_fps_drops_first_two_frames() {
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(140), frame(6, ms(140))),
+        &batch(ms(140), frame(4, ms(140))),
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(160), frame(8, ms(160))),
+        &batch(ms(160), frame(6, ms(160))),
     );
 }
 
@@ -249,10 +242,10 @@ fn next_track_higher_fps_drops_first_two_frames() {
 ///
 /// The offset stores the queue PTS that observed the first packet, never the
 /// packet's own PTS, so shifting the audio changes nothing for the video: the
-/// result is identical to [`next_track_equal_fps_drops_first_frame`]. The audio
+/// result is identical to [`next_track_equal_fps_keeps_first_frame`]. The audio
 /// keeps its 20ms head start, delivered 20ms after the offset.
 #[test]
-fn next_track_audio_starting_later_drops_first_frame() {
+fn next_track_audio_starting_later_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
     queue.start();
 
@@ -294,23 +287,22 @@ fn next_track_audio_starting_later_drops_first_frame() {
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(140), frame(5, ms(140))),
+        &batch(ms(140), frame(4, ms(140))),
     );
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(160), frame(6, ms(160))),
+        &batch(ms(160), frame(5, ms(160))),
     );
 }
 
 /// The other way round: the next track's video starts 20ms into its media while
 /// its audio starts at 0.
 ///
-/// The 20ms the video is short by is exactly the 20ms the lookup is ahead by, so
-/// the two cancel and the track's first frame lands on the first batch. Nothing
-/// about the offset changed — the track just happens to be missing the frames
-/// that would otherwise be discarded.
+/// The offset is still the video slot, so the track's head start is preserved
+/// rather than absorbed: the first batch of the new track carries no frame and
+/// the first frame lands one batch later, 20ms after the offset.
 #[test]
-fn next_track_video_starting_later_keeps_first_frame() {
+fn next_track_video_starting_later_renders_empty_batch() {
     let (mut queue, mut input) = create_queue_with_av_input();
     queue.start();
 
@@ -350,23 +342,18 @@ fn next_track_video_starting_later_keeps_first_frame() {
         &queue.next_video_batch().unwrap(),
         &batch(ms(120), frame_eos(3, ms(120))),
     );
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(140), true);
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(140), frame(4, ms(140))),
-    );
-    assert_video_batch_eq(
-        &queue.next_video_batch().unwrap(),
-        &batch(ms(160), frame(5, ms(160))),
+        &batch(ms(160), frame(4, ms(160))),
     );
 }
 
 /// Next track's video starts 40ms into its media (what a leading empty edit in
-/// the `elst` box produces), audio at 0.
-///
-/// Now the head start outruns the 20ms lookup: the first batch of the new track
-/// carries no frame at all, and the track's first frame lands one batch later.
+/// the `elst` box produces), audio at 0. Same as the 20ms case, two batches
+/// wide.
 #[test]
-fn next_track_video_starting_much_later_renders_empty_batch() {
+fn next_track_video_starting_much_later_renders_empty_batches() {
     let (mut queue, mut input) = create_queue_with_av_input();
     queue.start();
 
@@ -385,7 +372,7 @@ fn next_track_video_starting_much_later_renders_empty_batch() {
     input.send_sample_batches(ms(0), INPUT_BATCH_DURATION, 10);
     input.stream_video_then_eos((0..12).map(|index| ms(40) + ms(20) * index).collect());
 
-    sleep(ms(120));
+    sleep(ms(140));
 
     assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
     assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
@@ -407,21 +394,21 @@ fn next_track_video_starting_much_later_renders_empty_batch() {
         &batch(ms(120), frame_eos(3, ms(120))),
     );
     assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(140), true);
+    assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(160), true);
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
-        &batch(ms(160), frame(4, ms(160))),
+        &batch(ms(180), frame(4, ms(180))),
     );
 }
 
 /// Track 1's audio outlives its video, so the *audio* EOS is the later one and
-/// the swap lands right after an audio chunk was pushed. There both slots are
-/// equal, the offset matches the video slot, the lookup is 0, and the next
-/// track's first frame survives — the same scenario as
-/// [`next_track_equal_fps_drops_first_frame`] except for which medium ended last.
+/// the swap lands one iteration later, right after an audio chunk was pushed.
+/// The offset is still the video slot and the outcome matches
+/// [`next_track_equal_fps_keeps_first_frame`].
 ///
-/// It also shows the other seam problem: the swap waits for both media, so the
-/// input delivers nothing between its video EOS at 120ms and the audio draining
-/// at 280ms.
+/// It also shows the seam problem the offset ordering does not fix: the swap
+/// waits for both media, so the input delivers nothing between its video EOS at
+/// 120ms and the audio draining at 280ms.
 #[test]
 fn next_track_after_audio_ends_last_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();

--- a/smelter-core/src/queue/tests/track_switch.rs
+++ b/smelter-core/src/queue/tests/track_switch.rs
@@ -16,23 +16,24 @@
 //! would lose the new track's first frame.
 //!
 //! Every test shares the same track 1: nothing for the first 50ms (three empty
-//! batches), then 45ms of audio followed by video frames at 0/20/40/60ms. The
-//! audio is sent first and given a tick to land, so it is the medium that
-//! resolves track 1's offset, pinning it to the 60ms slot. A chunk pops
-//! everything up to chunk end + 80ms, so 45ms of audio drains on its first chunk
-//! and the video EOS at 120ms is the later of the two (the last test inverts
-//! this).
+//! batches and chunks), then 45ms of audio and video frames at 0/20/40/60ms,
+//! with the offset resolving to the 60ms slot. A chunk carries every batch up to
+//! chunk end + 80ms (`MIXER_STRETCH_BUFFER`), so those 45ms of audio are all
+//! delivered in the first chunk that sees them and the video EOS at 120ms is the
+//! later of the two (the last test inverts this).
 //!
-//! That puts the swap at the 140ms video slot. Frame ids keep incrementing
-//! across tracks, so the next track's first frame is always id 4.
+//! That puts the swap at the 140ms video slot. Ids keep incrementing across
+//! tracks, so the next track always starts with frame id 4 and sample batch
+//! id 3.
 
 use std::{thread::sleep, time::Duration};
 
 use crate::queue::{QueueInputOptions, QueueTrackOffset, QueueTrackOptions};
 
 use super::harness::{
-    INPUT_BATCH_DURATION, InputFrame, TestInput, TestQueue, TestQueueOptions, VideoBatch,
-    assert_empty_video_batch, assert_video_batch_eq, frames, ms,
+    AudioBatch, BATCH_DURATION, INPUT_BATCH_DURATION, InputFrame, InputSamples, TestInput,
+    TestQueue, TestQueueOptions, VideoBatch, assert_audio_batch_eq, assert_empty_audio_batch,
+    assert_empty_video_batch, assert_video_batch_eq, frames, ms, samples,
 };
 
 fn frame(id: u32, pts: Duration) -> InputFrame {
@@ -49,6 +50,26 @@ fn batch(pts: Duration, frame: InputFrame) -> VideoBatch {
         pts,
         required: true,
         frames: frames([("input_1", frame)]),
+    }
+}
+
+/// A chunk with sample batches from the required "input_1".
+fn chunk(start_pts: Duration, batches: Vec<(u32, Duration, Duration)>) -> AudioBatch {
+    AudioBatch {
+        start_pts,
+        end_pts: start_pts + BATCH_DURATION,
+        required: true,
+        samples: samples([("input_1", InputSamples::batches(batches))]),
+    }
+}
+
+/// Like [`chunk`], but the track ended and EOS is delivered with these batches.
+fn chunk_eos(start_pts: Duration, batches: Vec<(u32, Duration, Duration)>) -> AudioBatch {
+    AudioBatch {
+        start_pts,
+        end_pts: start_pts + BATCH_DURATION,
+        required: true,
+        samples: samples([("input_1", InputSamples::batches_eos(batches))]),
     }
 }
 
@@ -74,14 +95,14 @@ fn create_queue_with_av_input() -> (TestQueue, TestInput) {
 
 /// Both media of the next track start at 0 and its frames are 20ms apart, the
 /// output batch duration. The offset lands on the 140ms video slot, the lookup
-/// is 0, and the track plays from its first frame.
+/// is 0, and the track plays from its first frame. Its audio starts at 140ms
+/// too, delivered ahead of time in the chunk that precedes it.
 #[test]
 fn next_track_equal_fps_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
     queue.start();
 
-    // nothing until 50ms, then audio first so it is the medium that resolves
-    // track 1's `None` offset, pinning it to the 60ms slot
+    // nothing until 50ms, so track 1's `None` offset resolves to the 60ms slot
     sleep(ms(50));
     input.send_samples(ms(0), INPUT_BATCH_DURATION);
     input.send_samples(ms(15), INPUT_BATCH_DURATION);
@@ -134,11 +155,42 @@ fn next_track_equal_fps_keeps_first_frame() {
         &queue.next_video_batch().unwrap(),
         &batch(ms(160), frame(5, ms(160))),
     );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+            ],
+        ),
+    );
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(80), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(100), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(120),
+            vec![
+                (3, ms(140), ms(155)),
+                (4, ms(155), ms(170)),
+                (5, ms(170), ms(185)),
+                (6, ms(185), ms(200)),
+                (7, ms(200), ms(215)),
+                (8, ms(215), ms(230)),
+            ],
+        ),
+    );
 }
 
 /// Next track below the output framerate (frames 25ms apart). The first frame
 /// still lands on the first batch, and is repeated on the next one because the
-/// track has nothing newer to offer yet.
+/// track has nothing newer to offer yet. Audio is unaffected by the framerate.
 #[test]
 fn next_track_lower_fps_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
@@ -193,6 +245,37 @@ fn next_track_lower_fps_keeps_first_frame() {
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
         &batch(ms(160), frame(4, ms(140))),
+    );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+            ],
+        ),
+    );
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(80), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(100), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(120),
+            vec![
+                (3, ms(140), ms(155)),
+                (4, ms(155), ms(170)),
+                (5, ms(170), ms(185)),
+                (6, ms(185), ms(200)),
+                (7, ms(200), ms(215)),
+                (8, ms(215), ms(230)),
+            ],
+        ),
     );
 }
 
@@ -254,14 +337,45 @@ fn next_track_higher_fps_keeps_first_frame() {
         &queue.next_video_batch().unwrap(),
         &batch(ms(160), frame(6, ms(160))),
     );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+            ],
+        ),
+    );
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(80), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(100), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(120),
+            vec![
+                (3, ms(140), ms(155)),
+                (4, ms(155), ms(170)),
+                (5, ms(170), ms(185)),
+                (6, ms(185), ms(200)),
+                (7, ms(200), ms(215)),
+                (8, ms(215), ms(230)),
+            ],
+        ),
+    );
 }
 
 /// Next track's audio starts 20ms into its media while its video starts at 0.
 ///
 /// The offset stores the queue PTS that observed the first packet, never the
 /// packet's own PTS, so shifting the audio changes nothing for the video: the
-/// result is identical to [`next_track_equal_fps_keeps_first_frame`]. The audio
-/// keeps its 20ms head start, delivered 20ms after the offset.
+/// video output is identical to [`next_track_equal_fps_keeps_first_frame`]. The
+/// audio keeps its 20ms head start, landing at 160ms instead of 140ms.
 #[test]
 fn next_track_audio_starting_later_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
@@ -317,6 +431,35 @@ fn next_track_audio_starting_later_keeps_first_frame() {
         &queue.next_video_batch().unwrap(),
         &batch(ms(160), frame(5, ms(160))),
     );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+            ],
+        ),
+    );
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(80), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(100), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(120),
+            vec![
+                (3, ms(160), ms(175)),
+                (4, ms(175), ms(190)),
+                (5, ms(190), ms(205)),
+                (6, ms(205), ms(220)),
+            ],
+        ),
+    );
 }
 
 /// The other way round: the next track's video starts 20ms into its media while
@@ -324,7 +467,8 @@ fn next_track_audio_starting_later_keeps_first_frame() {
 ///
 /// The offset is still the video slot, so the track's head start is preserved
 /// rather than absorbed: the first batch of the new track carries no frame and
-/// the first frame lands one batch later, 20ms after the offset.
+/// the first frame lands one batch later, 20ms after the offset. The audio still
+/// starts on the offset, so the 20ms gap between the two media is kept.
 #[test]
 fn next_track_video_starting_later_renders_empty_batch() {
     let (mut queue, mut input) = create_queue_with_av_input();
@@ -376,6 +520,37 @@ fn next_track_video_starting_later_renders_empty_batch() {
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
         &batch(ms(160), frame(4, ms(160))),
+    );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+            ],
+        ),
+    );
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(80), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(100), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(120),
+            vec![
+                (3, ms(140), ms(155)),
+                (4, ms(155), ms(170)),
+                (5, ms(170), ms(185)),
+                (6, ms(185), ms(200)),
+                (7, ms(200), ms(215)),
+                (8, ms(215), ms(230)),
+            ],
+        ),
     );
 }
 
@@ -435,16 +610,47 @@ fn next_track_video_starting_much_later_renders_empty_batches() {
         &queue.next_video_batch().unwrap(),
         &batch(ms(180), frame(4, ms(180))),
     );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+            ],
+        ),
+    );
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(80), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(100), true);
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(120),
+            vec![
+                (3, ms(140), ms(155)),
+                (4, ms(155), ms(170)),
+                (5, ms(170), ms(185)),
+                (6, ms(185), ms(200)),
+                (7, ms(200), ms(215)),
+                (8, ms(215), ms(230)),
+            ],
+        ),
+    );
 }
 
 /// Track 1's audio outlives its video, so the *audio* EOS is the later one and
 /// the swap lands one iteration later, right after an audio chunk was pushed.
 /// The offset is still the video slot and the outcome matches
-/// [`next_track_equal_fps_keeps_first_frame`].
+/// [`next_track_equal_fps_keeps_first_frame`], shifted to the 280ms slot.
 ///
 /// It also shows the seam problem the offset ordering does not fix: the swap
-/// waits for both media, so the input delivers nothing between its video EOS at
-/// 120ms and the audio draining at 280ms.
+/// waits for both media, so the video delivers nothing between its EOS at 120ms
+/// and the audio draining at 280ms.
 #[test]
 fn next_track_after_audio_ends_last_keeps_first_frame() {
     let (mut queue, mut input) = create_queue_with_av_input();
@@ -472,7 +678,7 @@ fn next_track_after_audio_ends_last_keeps_first_frame() {
         input.send_frame(ms(20) * index);
     }
 
-    sleep(ms(260));
+    sleep(ms(290));
 
     assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(0), true);
     assert_empty_video_batch(&queue.next_video_batch().unwrap(), ms(20), true);
@@ -510,5 +716,90 @@ fn next_track_after_audio_ends_last_keeps_first_frame() {
     assert_video_batch_eq(
         &queue.next_video_batch().unwrap(),
         &batch(ms(300), frame(5, ms(300))),
+    );
+
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(0), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(20), true);
+    assert_empty_audio_batch(&queue.next_audio_batch().unwrap(), ms(40), true);
+
+    // track 1's audio keeps draining while the video is already over
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(60),
+            vec![
+                (0, ms(60), ms(75)),
+                (1, ms(75), ms(90)),
+                (2, ms(90), ms(105)),
+                (3, ms(105), ms(120)),
+                (4, ms(120), ms(135)),
+                (5, ms(135), ms(150)),
+                (6, ms(150), ms(165)),
+            ],
+        ),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(80), vec![(7, ms(165), ms(180))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(100), vec![(8, ms(180), ms(195)), (9, ms(195), ms(210))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(120), vec![(10, ms(210), ms(225))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(140), vec![(11, ms(225), ms(240))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(160),
+            vec![(12, ms(240), ms(255)), (13, ms(255), ms(270))],
+        ),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(180), vec![(14, ms(270), ms(285))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(200), vec![(15, ms(285), ms(300))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(220),
+            vec![(16, ms(300), ms(315)), (17, ms(315), ms(330))],
+        ),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(ms(240), vec![(18, ms(330), ms(345))]),
+    );
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk_eos(ms(260), vec![(19, ms(345), ms(360))]),
+    );
+
+    // swap happened right after that chunk, so the next track's audio is
+    // anchored to the 280ms video slot
+    assert_audio_batch_eq(
+        &queue.next_audio_batch().unwrap(),
+        &chunk(
+            ms(280),
+            vec![
+                (20, ms(280), ms(295)),
+                (21, ms(295), ms(310)),
+                (22, ms(310), ms(325)),
+                (23, ms(325), ms(340)),
+                (24, ms(340), ms(355)),
+                (25, ms(355), ms(370)),
+                (26, ms(370), ms(385)),
+            ],
+        ),
     );
 }


### PR DESCRIPTION
In input like mp4 when existing tracks ends the next one should already be "ready", but even with this assumption
there are 2 scenarios where it breaks

Case 1: next chunk that the queue expects is audio 

Depending on fps:
  - input fps above output fps - the step covers one or more frames, they're gone
  - input fps equal to output fps - the step is exactly one frame interval, so the first frame is gone, but only when the two grids happen to line up at that moment
  - input fps below output fps - the step is shorter than the distance to the track's second frame, nothing is lost

Case 2: next chunk that queue expects is video

Offset is still calculated based on next audio pts, so even PTS 0 for video is resolved in the future. As a result, in that iteration we can't return any frame, which leads to a blank frame.

After the fix:
- if the next chunk from the queue is audio (so `audio_pts.0 < video_pts`)
  - offset is resolved based on video, so the first video frame is never dropped.
  - audio will start in the middle of the requested batch; nothing is dropped.
- if next chunk from queue is video (so. `video_pts <= audio_pts.0` 
  - offset is resolved based on video, so first video frame is never dropped
  - audio will be pushed on the next audio batch, so we can drop at most `audio_pts.0 - video_pts < 20ms` 