### PR TITLE
Add a CODEOWNERS file to notify @jerzywilczek on PRs to gpu-video

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/gpu-video/ @jerzywilczek


### PR DESCRIPTION
I missed a community PR recently and adding me as a codeowner of `gpu-video` would allow me to not change my workflow and get notifications about such PRs in the future