### PR TITLE
Register output with start time (HLS+MP4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add `SMELTER_RENDER_MAX_LAYOUTS_COUNT` environment variable to configure the maximum number of layouts (default 100) by [@wkozyra95](https://github.com/wkozyra95)
 - Support FFmpeg 9 by [@wkozyra95](https://github.com/wkozyra95)
+- Add `start_at_ms` option to MP4 and HLS outputs. Output is created when the register request is handled, but it starts producing data at the specified time by [@wkozyra95](https://github.com/wkozyra95)
 
 ### 🐛 Bug fixes
 

--- a/integration-tests/src/pipeline_tests.rs
+++ b/integration-tests/src/pipeline_tests.rs
@@ -1,6 +1,7 @@
 mod audio_only;
 pub mod harness;
 mod offline_processing;
+mod output_start_at;
 mod push_input_before_start;
 mod required_inputs;
 mod schedule_update;
@@ -19,6 +20,7 @@ pub fn pipeline_tests() -> Vec<&'static PipelineTest> {
     [
         audio_only::TESTS,
         offline_processing::TESTS,
+        output_start_at::TESTS,
         push_input_before_start::TESTS,
         required_inputs::TESTS,
         schedule_update::TESTS,

--- a/integration-tests/src/pipeline_tests/output_start_at.rs
+++ b/integration-tests/src/pipeline_tests/output_start_at.rs
@@ -1,0 +1,330 @@
+//! Realtime (not ahead-of-time) coverage for the MP4 output `start_at_ms` option.
+//!
+//! Runs with the default config, so the queue is throttled to realtime
+//! and the scheduled start has to happen on the wall clock. The MP4
+//! muxer normalizes the first chunk to PTS 0, so an output that starts
+//! at 4 s and is unregistered at 12 s produces an 8 s file whose PTS 0
+//! is the input at 4 s — the duration checks cover the former, the
+//! snapshot the latter.
+//!
+//! The second test is the baseline it is measured against: the same 4 s
+//! delay, but produced by sleeping before the register request instead
+//! of scheduling the start.
+
+use std::{fs, path::Path, thread, time::Duration};
+
+use anyhow::{Result, bail};
+use bytes::Bytes;
+use crossbeam_channel::Receiver;
+use integration_tests_macros::pipeline_test;
+use serde_json::json;
+use smelter_render::Frame;
+use tokio_tungstenite::tungstenite;
+
+use crate::{
+    CompositorInstance,
+    media::TestSample,
+    pipeline_tests::{
+        PipelineTest,
+        harness::{
+            AudioCompareConfig, FftCompareConfig, VideoCompareConfig, compare_audio_dumps,
+            compare_video_dumps,
+            fft::{Mode, RealTolerance},
+        },
+        start_server_msg_listener,
+    },
+    tools::{
+        mp4_source::{Mp4VideoFrameSource, decode_aac_audio},
+        video_diff_iter::LazyFrameSource,
+    },
+};
+
+#[allow(dead_code)]
+pub const TESTS: &[PipelineTest] = &[MP4_OUTPUT_START_AT, MP4_OUTPUT_START_AT_DEFAULT];
+
+#[pipeline_test(
+    description = "
+        Realtime MP4 output registered with `start_at_ms`.
+
+        Start the queue, then register an MP4 output with `start_at_ms: 4000` and
+        unregister it at 12 s. The file is created while the register request is
+        handled, but the output is only connected to the renderer/audio mixer once the
+        queue reaches 4 s, so it holds 8 s of video and audio instead of 12 s.
+    ",
+    snapshot_name = "mp4_output_start_at.mp4"
+)]
+pub fn mp4_output_start_at() -> Result<()> {
+    const START_AT: Duration = Duration::from_millis(4000);
+    const UNREGISTER_AT: Duration = Duration::from_secs(12);
+
+    let output_file = format!("/tmp/{OUTPUT_DUMP_FILE}");
+    if Path::new(&output_file).exists() {
+        fs::remove_file(&output_file)?;
+    }
+
+    let instance = CompositorInstance::start(None);
+    let (msg_sender, msg_receiver) = crossbeam_channel::unbounded();
+    start_server_msg_listener(instance.api_port, msg_sender);
+
+    instance.send_request(
+        "input/input_1/register",
+        json!({
+            "type": "mp4",
+            "path": TestSample::BigBuckBunnyH264AAC.ensure_path()?,
+            "offset_ms": 0,
+            "decoder_map": {
+                "h264": "ffmpeg_h264"
+            },
+            "required": true
+        }),
+    )?;
+
+    instance.send_request("start", json!({}))?;
+
+    register_mp4_output(&instance, &output_file, Some(START_AT))?;
+
+    // The output is created while the register request is handled, well before the
+    // queue reaches `start_at` — only the moment it starts receiving media is delayed.
+    if !Path::new(&output_file).exists() {
+        bail!("{output_file} was not created when the output was registered");
+    }
+
+    instance.send_request(
+        "output/output_1/unregister",
+        json!({
+            "schedule_time_ms": UNREGISTER_AT.as_millis()
+        }),
+    )?;
+
+    wait_for_output_done(&msg_receiver, "output_1");
+
+    let dump = Bytes::from(fs::read(&output_file)?);
+    let expected = UNREGISTER_AT - START_AT;
+
+    check_duration("video", video_duration(&dump)?, expected)?;
+    check_duration("audio", audio_duration(&dump)?, expected)?;
+
+    // The durations above only prove the output ran for the right amount of time.
+    // The snapshot proves it started at the right point in the input: PTS 0 of the
+    // file has to be `input_1` at 4 s, not at 0 s.
+    compare_video_dumps(
+        OUTPUT_DUMP_FILE,
+        &dump,
+        VideoCompareConfig {
+            validation_intervals: vec![Duration::ZERO..Duration::from_secs(7)],
+            max_failed_pairs: 10,
+            ..Default::default()
+        },
+    )?;
+
+    let mut fft_cfg = FftCompareConfig::real(vec![Duration::ZERO..Duration::from_secs(7)]);
+    fft_cfg.mode = Mode::Real(RealTolerance {
+        max_frequency_level: 5.0,
+        average_level: 15.0,
+        median_level: 15.0,
+        general_level: 5.0,
+        ..Default::default()
+    });
+
+    compare_audio_dumps(
+        OUTPUT_DUMP_FILE,
+        &dump,
+        AudioCompareConfig {
+            fft: Some(fft_cfg),
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
+}
+
+#[pipeline_test(
+    description = "
+        Realtime MP4 output registered without `start_at_ms`, as a baseline for
+        `mp4_output_start_at`.
+
+        Start the queue, sleep 4 s, then register an MP4 output and unregister it at
+        12 s. The output starts as soon as the register request is handled, so the same
+        8 s of media ends up in the file — reached by delaying the request instead of
+        scheduling the start.
+    ",
+    snapshot_name = "mp4_output_start_at_default.mp4"
+)]
+pub fn mp4_output_start_at_default() -> Result<()> {
+    const REGISTER_AT: Duration = Duration::from_millis(4000);
+    const UNREGISTER_AT: Duration = Duration::from_secs(12);
+
+    let output_file = format!("/tmp/{OUTPUT_DUMP_FILE}");
+    if Path::new(&output_file).exists() {
+        fs::remove_file(&output_file)?;
+    }
+
+    let instance = CompositorInstance::start(None);
+    let (msg_sender, msg_receiver) = crossbeam_channel::unbounded();
+    start_server_msg_listener(instance.api_port, msg_sender);
+
+    instance.send_request(
+        "input/input_1/register",
+        json!({
+            "type": "mp4",
+            "path": TestSample::BigBuckBunnyH264AAC.ensure_path()?,
+            "offset_ms": 0,
+            "decoder_map": {
+                "h264": "ffmpeg_h264"
+            },
+            "required": true
+        }),
+    )?;
+
+    instance.send_request("start", json!({}))?;
+
+    thread::sleep(REGISTER_AT);
+
+    register_mp4_output(&instance, &output_file, None)?;
+
+    instance.send_request(
+        "output/output_1/unregister",
+        json!({
+            "schedule_time_ms": UNREGISTER_AT.as_millis()
+        }),
+    )?;
+
+    wait_for_output_done(&msg_receiver, "output_1");
+
+    let dump = Bytes::from(fs::read(&output_file)?);
+    // Approximate: the output starts once the register request is handled, so it is
+    // late by the request roundtrip on top of the sleep. That is well inside TOLERANCE.
+    let expected = UNREGISTER_AT - REGISTER_AT;
+
+    check_duration("video", video_duration(&dump)?, expected)?;
+    check_duration("audio", audio_duration(&dump)?, expected)?;
+
+    // Same as in `mp4_output_start_at`, except PTS 0 here is the input at whatever
+    // point the register request landed, so it drifts by a frame or two between runs.
+    compare_video_dumps(
+        OUTPUT_DUMP_FILE,
+        &dump,
+        VideoCompareConfig {
+            validation_intervals: vec![Duration::ZERO..Duration::from_secs(7)],
+            max_failed_pairs: 10,
+            ..Default::default()
+        },
+    )?;
+
+    let mut fft_cfg = FftCompareConfig::real(vec![Duration::ZERO..Duration::from_secs(7)]);
+    fft_cfg.mode = Mode::Real(RealTolerance {
+        max_frequency_level: 5.0,
+        average_level: 15.0,
+        median_level: 15.0,
+        general_level: 5.0,
+        ..Default::default()
+    });
+
+    compare_audio_dumps(
+        OUTPUT_DUMP_FILE,
+        &dump,
+        AudioCompareConfig {
+            fft: Some(fft_cfg),
+            ..Default::default()
+        },
+    )?;
+
+    Ok(())
+}
+
+fn register_mp4_output(
+    instance: &CompositorInstance,
+    output_file: &str,
+    start_at: Option<Duration>,
+) -> Result<()> {
+    let mut request = json!({
+        "type": "mp4",
+        "path": output_file,
+        "video": {
+            "resolution": {
+                "width": 640,
+                "height": 320
+            },
+            "encoder": {
+                "type": "ffmpeg_h264",
+                "preset": "ultrafast",
+            },
+            "initial": {
+                "root": {
+                    "type": "rescaler",
+                    "child": {
+                        "type": "input_stream",
+                        "input_id": "input_1"
+                    }
+                }
+            }
+        },
+        "audio": {
+            "channels": "stereo",
+            "encoder": {
+                "type": "aac",
+                // The audio decode path runs at 48 kHz; the default
+                // for MP4 outputs is 44.1 kHz.
+                "sample_rate": 48000,
+            },
+            "initial": {
+                "inputs": [{ "input_id": "input_1" }]
+            }
+        }
+    });
+    if let Some(start_at) = start_at {
+        request["start_at_ms"] = json!(start_at.as_millis());
+    }
+
+    instance.send_request("output/output_1/register", request)?;
+    Ok(())
+}
+
+/// Allowed drift on the produced media duration. The queue can be a frame or two off
+/// around the scheduled start and unregister PTS; it cannot be off by anything close
+/// to the `start_at` offset the tests measure.
+const TOLERANCE: Duration = Duration::from_millis(750);
+
+fn wait_for_output_done(receiver: &Receiver<tungstenite::Message>, output_id: &str) {
+    let expected = format!("\"type\":\"OUTPUT_DONE\",\"output_id\":\"{output_id}\"");
+    for msg in receiver.iter() {
+        if let tungstenite::Message::Text(msg) = msg
+            && msg.contains(&expected)
+        {
+            return;
+        }
+    }
+}
+
+/// PTS of the last decoded video frame. `Mp4VideoFrameSource` normalizes the first
+/// frame to zero, so this is the duration of the track minus its final frame.
+fn video_duration(dump: &Bytes) -> Result<Duration> {
+    let mut source = Mp4VideoFrameSource::from_bytes(dump)?;
+    let mut frames: Vec<Frame> = Vec::new();
+    while let Some(batch) = source.next_batch()? {
+        frames.extend(batch);
+    }
+    match frames.last() {
+        Some(frame) => Ok(frame.pts),
+        None => bail!("MP4 output has no video frames"),
+    }
+}
+
+/// Audio counterpart of [`video_duration`]; `decode_aac_audio` normalizes the same way.
+fn audio_duration(dump: &Bytes) -> Result<Duration> {
+    let batches = decode_aac_audio(dump, 48_000)?;
+    match batches.last() {
+        Some(batch) => Ok(batch.pts),
+        None => bail!("MP4 output has no audio samples"),
+    }
+}
+
+fn check_duration(track: &str, actual: Duration, expected: Duration) -> Result<()> {
+    if actual.abs_diff(expected) > TOLERANCE {
+        bail!(
+            "{track}: MP4 output holds {actual:.2?} of media, expected {expected:.2?} \
+             (tolerance {TOLERANCE:?})"
+        );
+    }
+    Ok(())
+}

--- a/smelter-api/src/output/common_into.rs
+++ b/smelter-api/src/output/common_into.rs
@@ -114,6 +114,17 @@ impl TryFrom<VideoEncoderBitrate> for core::VideoEncoderBitrate {
     }
 }
 
+pub(crate) fn duration_from_start_at(
+    start_at_ms: Option<f64>,
+) -> Result<Option<Duration>, TypeError> {
+    match start_at_ms {
+        Some(time) if time < 0.0 => Err(TypeError::new("Start time cannot be negative.")),
+        // Saturating cast, `Duration::from_secs_f64` would panic on out of range values.
+        Some(time) => Ok(Some(Duration::from_millis(time.round() as u64))),
+        None => Ok(None),
+    }
+}
+
 pub(crate) fn duration_from_keyframe_interval(
     keyframe_interval: &Option<f64>,
 ) -> Result<Duration, TypeError> {

--- a/smelter-api/src/output/common_into.rs
+++ b/smelter-api/src/output/common_into.rs
@@ -114,13 +114,26 @@ impl TryFrom<VideoEncoderBitrate> for core::VideoEncoderBitrate {
     }
 }
 
+/// Overflow guard for duration options in the API, `Duration::from_secs_f64` panics on values
+/// that do not fit.
+const MAX_DURATION_MS: f64 = 365.0 * 24.0 * 60.0 * 60.0 * 1000.0;
+
+/// Milliseconds from a request into a `Duration`, keeping the sub-millisecond part.
+fn duration_from_millis_f64(millis: f64) -> Duration {
+    if millis.is_nan() {
+        return Duration::ZERO;
+    }
+    Duration::from_secs_f64(millis.clamp(0.0, MAX_DURATION_MS) / 1000.0)
+}
+
 pub(crate) fn duration_from_start_at(
     start_at_ms: Option<f64>,
 ) -> Result<Option<Duration>, TypeError> {
     match start_at_ms {
-        Some(time) if time < 0.0 => Err(TypeError::new("Start time cannot be negative.")),
-        // Saturating cast, `Duration::from_secs_f64` would panic on out of range values.
-        Some(time) => Ok(Some(Duration::from_millis(time.round() as u64))),
+        Some(time) if time < 0.0 || time.is_nan() => {
+            Err(TypeError::new("Start time cannot be negative."))
+        }
+        Some(time) => Ok(Some(duration_from_millis_f64(time))),
         None => Ok(None),
     }
 }
@@ -131,11 +144,10 @@ pub(crate) fn duration_from_keyframe_interval(
     const DEFAULT_KEYFRAME_INTERVAL: Duration = Duration::from_millis(5000);
 
     match keyframe_interval {
-        Some(ki) if *ki < 0.0 => Err(TypeError::new("Keyframe interval cannot be negative.")),
-        Some(ki) => {
-            let ki = ki.round() as u64;
-            Ok(Duration::from_millis(ki))
+        Some(ki) if *ki < 0.0 || ki.is_nan() => {
+            Err(TypeError::new("Keyframe interval cannot be negative."))
         }
+        Some(ki) => Ok(duration_from_millis_f64(*ki)),
         None => Ok(DEFAULT_KEYFRAME_INTERVAL),
     }
 }

--- a/smelter-api/src/output/hls.rs
+++ b/smelter-api/src/output/hls.rs
@@ -22,6 +22,10 @@ pub struct HlsOutput {
     /// Raw FFmpeg muxer options. See [docs](https://ffmpeg.org/ffmpeg-formats.html) for more.
     /// Note: keys here may override defaults, including `hls_list_size` derived from `max_playlist_size`.
     pub ffmpeg_options: Option<HashMap<Arc<str>, Arc<str>>>,
+    /// Time in milliseconds when this output should start producing data. Value `0` represents
+    /// time of the start request. Output is always created when this request is handled (e.g.
+    /// playlist is created), only the moment it starts receiving frames/samples is delayed.
+    pub start_at_ms: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]

--- a/smelter-api/src/output/hls_into.rs
+++ b/smelter-api/src/output/hls_into.rs
@@ -11,6 +11,7 @@ impl TryFrom<HlsOutput> for core::RegisterOutputOptions {
             video,
             audio,
             ffmpeg_options,
+            start_at_ms,
         } = request;
 
         if video.is_none() && audio.is_none() {
@@ -66,6 +67,7 @@ impl TryFrom<HlsOutput> for core::RegisterOutputOptions {
             video: video_encoder_options,
             audio: audio_encoder_options,
             raw_options: ffmpeg_options.unwrap_or_default().into_iter().collect(),
+            start_at: duration_from_start_at(start_at_ms)?,
         });
 
         Ok(Self {

--- a/smelter-api/src/output/mp4.rs
+++ b/smelter-api/src/output/mp4.rs
@@ -18,6 +18,10 @@ pub struct Mp4Output {
     pub audio: Option<OutputMp4AudioOptions>,
     /// Raw FFmpeg muxer options. See [docs](https://ffmpeg.org/ffmpeg-formats.html) for more.
     pub ffmpeg_options: Option<HashMap<Arc<str>, Arc<str>>>,
+    /// Time in milliseconds when this output should start producing data. Value `0` represents
+    /// time of the start request. Output is always created when this request is handled (e.g.
+    /// file is created), only the moment it starts receiving frames/samples is delayed.
+    pub start_at_ms: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ToSchema)]

--- a/smelter-api/src/output/mp4_into.rs
+++ b/smelter-api/src/output/mp4_into.rs
@@ -10,6 +10,7 @@ impl TryFrom<Mp4Output> for core::RegisterOutputOptions {
             video,
             audio,
             ffmpeg_options,
+            start_at_ms,
         } = request;
 
         if video.is_none() && audio.is_none() {
@@ -64,6 +65,7 @@ impl TryFrom<Mp4Output> for core::RegisterOutputOptions {
             video: video_encoder_options,
             audio: audio_encoder_options,
             raw_options: ffmpeg_options.unwrap_or_default().into_iter().collect(),
+            start_at: duration_from_start_at(start_at_ms)?,
         });
 
         Ok(Self {

--- a/smelter-api/tests/output_deserialization.rs
+++ b/smelter-api/tests/output_deserialization.rs
@@ -1061,6 +1061,7 @@ fn mp4_video_only() {
                     )),
                     audio: None,
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
@@ -1094,6 +1095,7 @@ fn mp4_audio_only() {
                         },
                     )),
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: None,
@@ -1151,6 +1153,7 @@ fn mp4_video_and_audio_with_ffmpeg_options() {
                         },
                     )),
                     raw_options: vec![(Arc::from("movflags"), Arc::from("faststart"))],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
@@ -1195,10 +1198,46 @@ fn mp4_vulkan_encoder() {
                     )),
                     audio: None,
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
             audio: None,
+        },
+    );
+}
+
+#[test]
+fn mp4_start_at() {
+    check_mp4(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4",
+                "start_at_ms": 2500.0,
+                "audio": {
+                    "encoder": { "type": "aac" },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Mp4(
+                smelter_core::protocols::Mp4OutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/output.mp4")),
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 44100,
+                            bitstream_format: smelter_core::codecs::AacBitstreamFormat::Raw,
+                        },
+                    )),
+                    raw_options: vec![],
+                    start_at: Some(Duration::from_millis(2500)),
+                },
+            ),
+            video: None,
+            audio: Some(default_audio()),
         },
     );
 }
@@ -1212,6 +1251,23 @@ fn err_mp4_no_video_no_audio() {
             }
         }),
         "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+#[test]
+fn err_mp4_negative_start_at() {
+    check_mp4_err(
+        json!({
+            "output": {
+                "path": "/tmp/output.mp4",
+                "start_at_ms": -1.0,
+                "audio": {
+                    "encoder": { "type": "aac" },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        "Start time cannot be negative.",
     );
 }
 
@@ -1679,6 +1735,7 @@ fn hls_video_only() {
                     )),
                     audio: None,
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
@@ -1713,6 +1770,7 @@ fn hls_audio_only() {
                         },
                     )),
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: None,
@@ -1766,6 +1824,7 @@ fn hls_video_and_audio_with_playlist_size() {
                         },
                     )),
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
@@ -1806,6 +1865,7 @@ fn hls_vulkan_encoder() {
                     )),
                     audio: None,
                     raw_options: vec![],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
@@ -1862,9 +1922,46 @@ fn hls_video_and_audio_with_ffmpeg_options() {
                         },
                     )),
                     raw_options: vec![(Arc::from("hls_list_size"), Arc::from("5"))],
+                    start_at: None,
                 },
             ),
             video: Some(default_video()),
+            audio: Some(default_audio()),
+        },
+    );
+}
+
+#[test]
+fn hls_start_at() {
+    check_hls(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8",
+                "start_at_ms": 0.0,
+                "audio": {
+                    "encoder": { "type": "aac", "sample_rate": 48000 },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        CoreOutput {
+            output_options: smelter_core::ProtocolOutputOptions::Hls(
+                smelter_core::protocols::HlsOutputOptions {
+                    output_path: Arc::from(Path::new("/tmp/stream.m3u8")),
+                    max_playlist_size: None,
+                    video: None,
+                    audio: Some(smelter_core::codecs::AudioEncoderOptions::FdkAac(
+                        smelter_core::codecs::FdkAacEncoderOptions {
+                            channels: smelter_core::AudioChannels::Stereo,
+                            sample_rate: 48000,
+                            bitstream_format: smelter_core::codecs::AacBitstreamFormat::Raw,
+                        },
+                    )),
+                    raw_options: vec![],
+                    start_at: Some(Duration::ZERO),
+                },
+            ),
+            video: None,
             audio: Some(default_audio()),
         },
     );
@@ -1879,6 +1976,23 @@ fn err_hls_no_video_no_audio() {
             }
         }),
         "At least one of \"video\" and \"audio\" fields have to be specified.",
+    );
+}
+
+#[test]
+fn err_hls_negative_start_at() {
+    check_hls_err(
+        json!({
+            "output": {
+                "path": "/tmp/stream.m3u8",
+                "start_at_ms": -0.5,
+                "audio": {
+                    "encoder": { "type": "aac" },
+                    "initial": audio_scene()
+                }
+            }
+        }),
+        "Start time cannot be negative.",
     );
 }
 

--- a/smelter-core/src/lib.rs
+++ b/smelter-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod audio_mixer;
 mod queue;
-pub use queue::{InputSideChannel, QueueInputOptions};
+pub use queue::{InputSideChannel, LateEventPolicy, QueueInputOptions};
 
 pub mod codecs;
 pub mod error;

--- a/smelter-core/src/output.rs
+++ b/smelter-core/src/output.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use bytes::Bytes;
 use crossbeam_channel::Receiver;
 use smelter_render::scene::Component;
@@ -34,6 +36,23 @@ pub enum ProtocolOutputOptions {
     Whip(WhipOutputOptions),
     Whep(WhepOutputOptions),
     MoqClient(MoqClientOutputOptions),
+}
+
+impl ProtocolOutputOptions {
+    /// Timestamp (relative to the queue start) the output should start producing data
+    /// at. Only supported by protocols that write to a file/playlist, where delaying the
+    /// start does not mean stalling a live connection.
+    pub fn start_at(&self) -> Option<Duration> {
+        match self {
+            ProtocolOutputOptions::Mp4(options) => options.start_at,
+            ProtocolOutputOptions::Hls(options) => options.start_at,
+            ProtocolOutputOptions::Rtp(_)
+            | ProtocolOutputOptions::Rtmp(_)
+            | ProtocolOutputOptions::Whip(_)
+            | ProtocolOutputOptions::Whep(_)
+            | ProtocolOutputOptions::MoqClient(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/smelter-core/src/pipeline/encoder/fdk_aac.rs
+++ b/smelter-core/src/pipeline/encoder/fdk_aac.rs
@@ -230,7 +230,7 @@ impl FdkAacEncoder {
                 let frame_start = self.encoded_samples;
                 self.encoded_samples += self.samples_per_frame as u64;
 
-                if self.encoded_samples < self.codec_delay {
+                if self.encoded_samples <= self.codec_delay {
                     continue;
                 }
 

--- a/smelter-core/src/pipeline/ffmpeg_utils.rs
+++ b/smelter-core/src/pipeline/ffmpeg_utils.rs
@@ -1,6 +1,154 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use ffmpeg_next::{Dictionary, StreamMut, ffi::AVCodecParameters};
+use tracing::warn;
+
+use crate::{prelude::*, queue::QueueContext};
+
+const OFFSET_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Timestamp offset subtracted from every chunk on output.
+///
+/// Offset is resolved in this order:
+/// - `start_at` - output start in pts counted from queue start. Packets are in units relative
+///   to queue sync_point, so offset is `start_at + queue_ctx.start_pts`
+/// - If only one track is present, take offset from first packet
+/// - If both tracks are present, buffer until first packet of each kind is present and select
+///   the lowest
+///   - Wait at most `OFFSET_RESOLUTION_TIMEOUT` for that, if not fallback to first pts
+pub(crate) struct TimestampOffset {
+    queue_ctx: QueueContext,
+    /// Relative to the queue start, not to the sync point the chunk PTS use.
+    start_at: Option<Duration>,
+    state: State,
+}
+
+enum State {
+    Resolved(Duration),
+    Pending {
+        waiting_for_video: bool,
+        waiting_for_audio: bool,
+        lowest_pts: Option<Duration>,
+        buffered: Vec<EncodedOutputChunk>,
+    },
+}
+
+impl TimestampOffset {
+    pub fn new(
+        queue_ctx: QueueContext,
+        start_at: Option<Duration>,
+        has_video: bool,
+        has_audio: bool,
+    ) -> Self {
+        Self {
+            queue_ctx,
+            start_at,
+            // Not resolved here even when `start_at` is set, we need to wait for queue start
+            state: State::Pending {
+                waiting_for_video: has_video,
+                waiting_for_audio: has_audio,
+                lowest_pts: None,
+                buffered: Vec::new(),
+            },
+        }
+    }
+
+    /// Chunks ready to be written, each with the offset to apply. Empty while the offset
+    /// is still pending, in which case the chunk is buffered until it resolves.
+    pub fn resolve(&mut self, chunk: EncodedOutputChunk) -> Vec<(Duration, EncodedOutputChunk)> {
+        let (waiting_for_video, waiting_for_audio, lowest_pts, buffered) = match &mut self.state {
+            State::Resolved(offset) => return vec![(*offset, chunk)],
+            State::Pending {
+                waiting_for_video,
+                waiting_for_audio,
+                lowest_pts,
+                buffered,
+            } => (waiting_for_video, waiting_for_audio, lowest_pts, buffered),
+        };
+
+        match chunk.kind {
+            MediaKind::Video(_) => *waiting_for_video = false,
+            MediaKind::Audio(_) => *waiting_for_audio = false,
+        }
+        let lowest = match *lowest_pts {
+            Some(lowest) => Duration::min(lowest, chunk.pts),
+            None => chunk.pts,
+        };
+        *lowest_pts = Some(lowest);
+
+        let timed_out = chunk.pts.saturating_sub(lowest) > OFFSET_RESOLUTION_TIMEOUT;
+        if timed_out {
+            warn!(
+                ?lowest,
+                waiting_for_video = *waiting_for_video,
+                waiting_for_audio = *waiting_for_audio,
+                "Timed out waiting for the first chunk of the other track, anchoring output timestamps on what arrived so far."
+            );
+        }
+        buffered.push(chunk);
+
+        let still_waiting = *waiting_for_video || *waiting_for_audio;
+        if still_waiting && !timed_out {
+            return Vec::new();
+        }
+        self.force_resolve(lowest)
+    }
+
+    /// A track ended; stop waiting for a first chunk it is never going to produce. Returns
+    /// the buffered chunks if this was the last track the offset was waiting on.
+    pub fn on_track_eos(&mut self, kind: MediaKind) -> Vec<(Duration, EncodedOutputChunk)> {
+        let (waiting_for_video, waiting_for_audio, lowest_pts) = match &mut self.state {
+            // Already anchored, so nothing was buffered.
+            State::Resolved(_) => return Vec::new(),
+            State::Pending {
+                waiting_for_video,
+                waiting_for_audio,
+                lowest_pts,
+                ..
+            } => (waiting_for_video, waiting_for_audio, lowest_pts),
+        };
+
+        match kind {
+            MediaKind::Video(_) => *waiting_for_video = false,
+            MediaKind::Audio(_) => *waiting_for_audio = false,
+        }
+        // Nothing to anchor on yet — stay pending until some chunk shows up.
+        let Some(lowest) = *lowest_pts else {
+            return Vec::new();
+        };
+        if *waiting_for_video || *waiting_for_audio {
+            return Vec::new();
+        }
+        self.force_resolve(lowest)
+    }
+
+    /// The packet stream ended before the offset resolved on its own. Anchor on whatever
+    /// arrived so far, so buffered chunks are not lost.
+    pub fn flush(&mut self) -> Vec<(Duration, EncodedOutputChunk)> {
+        let lowest_pts = match &self.state {
+            State::Resolved(_) => return Vec::new(),
+            State::Pending { lowest_pts, .. } => *lowest_pts,
+        };
+        // Nothing ever arrived, so there is nothing buffered either.
+        let Some(lowest) = lowest_pts else {
+            return Vec::new();
+        };
+        self.force_resolve(lowest)
+    }
+
+    fn force_resolve(&mut self, lowest_pts: Duration) -> Vec<(Duration, EncodedOutputChunk)> {
+        let offset = self
+            .start_at
+            .and_then(|start_at| self.queue_ctx.pts_from_start(start_at))
+            .unwrap_or(lowest_pts);
+
+        let buffered = match std::mem::replace(&mut self.state, State::Resolved(offset)) {
+            State::Pending { buffered, .. } => buffered,
+            State::Resolved(_) => Vec::new(),
+        };
+        buffered.into_iter().map(|chunk| (offset, chunk)).collect()
+    }
+}
 
 #[derive(Debug, Default)]
 pub(super) struct FfmpegOptions(HashMap<String, String>);

--- a/smelter-core/src/pipeline/ffmpeg_utils.rs
+++ b/smelter-core/src/pipeline/ffmpeg_utils.rs
@@ -11,7 +11,8 @@ const OFFSET_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(500);
 ///
 /// Offset is resolved in this order:
 /// - `start_at` - output start in pts counted from queue start. Packets are in units relative
-///   to queue sync_point, so offset is `start_at + queue_ctx.start_pts`
+///   to queue sync_point, so offset is `start_at + queue_ctx.start_pts`. Nothing is buffered
+///   in that case, the offset does not depend on the chunks.
 /// - If only one track is present, take offset from first packet
 /// - If both tracks are present, buffer until first packet of each kind is present and select
 ///   the lowest
@@ -88,7 +89,8 @@ impl TimestampOffset {
         buffered.push(chunk);
 
         let still_waiting = *waiting_for_video || *waiting_for_audio;
-        if still_waiting && !timed_out {
+        let start_at_known = self.start_at.is_some() && self.queue_ctx.start_pts().is_some();
+        if still_waiting && !timed_out && !start_at_known {
             return Vec::new();
         }
         self.force_resolve(lowest)
@@ -137,10 +139,10 @@ impl TimestampOffset {
     }
 
     fn force_resolve(&mut self, lowest_pts: Duration) -> Vec<(Duration, EncodedOutputChunk)> {
-        let offset = self
-            .start_at
-            .and_then(|start_at| self.queue_ctx.pts_from_start(start_at))
-            .unwrap_or(lowest_pts);
+        let offset = match (self.start_at, self.queue_ctx.start_pts()) {
+            (Some(start_at), Some(queue_start_pts)) => start_at + queue_start_pts,
+            _ => lowest_pts,
+        };
 
         let buffered = match std::mem::replace(&mut self.state, State::Resolved(offset)) {
             State::Pending { buffered, .. } => buffered,

--- a/smelter-core/src/pipeline/hls/hls_output.rs
+++ b/smelter-core/src/pipeline/hls/hls_output.rs
@@ -19,7 +19,7 @@ use crate::{
             ffmpeg_h264::FfmpegH264Encoder,
             vulkan_h264::VulkanH264Encoder,
         },
-        ffmpeg_utils::{FfmpegOptions, StreamMutExt, write_extradata},
+        ffmpeg_utils::{FfmpegOptions, StreamMutExt, TimestampOffset, write_extradata},
         output::{Output, OutputAudio, OutputVideo},
         utils::InitializableThread,
     },
@@ -44,6 +44,7 @@ impl HlsOutput {
         output_ref: Ref<OutputId>,
         options: HlsOutputOptions,
     ) -> Result<Self, OutputInitError> {
+        let start_at = options.start_at;
         let (encoded_chunks_sender, encoded_chunks_receiver) = bounded(1);
 
         ctx.stats_sender.send(StatsEvent::NewOutput {
@@ -114,6 +115,13 @@ impl HlsOutput {
             None => (None, None),
         };
 
+        let offset = TimestampOffset::new(
+            ctx.queue_ctx.clone(),
+            start_at,
+            video_stream.is_some(),
+            audio_stream.is_some(),
+        );
+
         std::thread::Builder::new()
             .name(format!("HLS writer thread for output {output_ref}"))
             .spawn(move || {
@@ -131,6 +139,7 @@ impl HlsOutput {
                     encoded_chunks_receiver,
                     ctx.output_framerate,
                     stats_sender,
+                    offset,
                 );
                 ctx.event_emitter
                     .emit(Event::OutputDone(output_ref.id().clone()));
@@ -290,52 +299,61 @@ fn run_ffmpeg_output_thread(
     packets_receiver: Receiver<EncodedOutputEvent>,
     framerate: Framerate,
     stats_sender: HlsOutputStatsSender,
+    mut offset: TimestampOffset,
 ) {
     let mut received_video_eos = video_stream.as_ref().map(|_| false);
     let mut received_audio_eos = audio_stream.as_ref().map(|_| false);
-    let mut timestamp_offset = None;
 
-    for packet in packets_receiver {
-        match packet {
-            EncodedOutputEvent::Data(chunk) => {
-                stats_sender.bytes_sent_event(chunk.data.len(), chunk.kind.into());
-                let timestamp_offset = *timestamp_offset.get_or_insert(chunk.pts);
-                write_chunk(
-                    chunk,
-                    &mut video_stream,
-                    &mut audio_stream,
-                    &mut output_ctx,
-                    framerate.get_interval_duration(),
-                    timestamp_offset,
-                );
+    for packet in packets_receiver.into_iter().map(Some).chain([None]) {
+        let chunks = match packet {
+            Some(EncodedOutputEvent::Data(chunk)) => offset.resolve(chunk),
+            Some(EncodedOutputEvent::VideoEOS) => {
+                match received_video_eos {
+                    Some(false) => received_video_eos = Some(true),
+                    Some(true) => {
+                        error!("Received multiple video EOS events.");
+                    }
+                    None => {
+                        error!("Received video EOS event on non video output.");
+                    }
+                }
+                offset.on_track_eos(MediaKind::Video(VideoCodec::H264))
             }
-            EncodedOutputEvent::VideoEOS => match received_video_eos {
-                Some(false) => received_video_eos = Some(true),
-                Some(true) => {
-                    error!("Received multiple video EOS events.");
+            Some(EncodedOutputEvent::AudioEOS) => {
+                match received_audio_eos {
+                    Some(false) => received_audio_eos = Some(true),
+                    Some(true) => {
+                        error!("Received multiple audio EOS events.");
+                    }
+                    None => {
+                        error!("Received audio EOS event on non audio output.");
+                    }
                 }
-                None => {
-                    error!("Received video EOS event on non video output.");
-                }
-            },
-            EncodedOutputEvent::AudioEOS => match received_audio_eos {
-                Some(false) => received_audio_eos = Some(true),
-                Some(true) => {
-                    error!("Received multiple audio EOS events.");
-                }
-                None => {
-                    error!("Received audio EOS event on non audio output.");
-                }
-            },
+                offset.on_track_eos(MediaKind::Audio(AudioCodec::Aac))
+            }
+            None => offset.flush(),
         };
 
+        for (timestamp_offset, chunk) in chunks {
+            stats_sender.bytes_sent_event(chunk.data.len(), chunk.kind.into());
+            write_chunk(
+                chunk,
+                &mut video_stream,
+                &mut audio_stream,
+                &mut output_ctx,
+                framerate.get_interval_duration(),
+                timestamp_offset,
+            );
+        }
+
         if received_video_eos.unwrap_or(true) && received_audio_eos.unwrap_or(true) {
-            if let Err(err) = output_ctx.write_trailer() {
-                error!("Failed to write trailer to m3u8 file: {}.", err);
-            };
             break;
         }
     }
+
+    if let Err(err) = output_ctx.write_trailer() {
+        error!("Failed to write trailer to m3u8 file: {}.", err);
+    };
 }
 
 fn write_chunk(
@@ -367,23 +385,16 @@ fn write_chunk(
         },
     };
 
-    let pts = chunk.pts.saturating_sub(timestamp_offset);
+    let offset = timestamp_offset.as_nanos() as i128;
+    let pts = (chunk.pts.as_nanos() as i128 - offset) as i64;
     let dts = chunk
         .dts
-        .map(|dts| dts.saturating_sub(timestamp_offset))
+        .map(|dts| (dts.as_nanos() as i128 - offset) as i64)
         .unwrap_or(pts);
 
     let mut packet = ffmpeg::Packet::copy(&chunk.data);
-    packet.set_pts(Some(Rescale::rescale(
-        &(pts.as_nanos() as i64),
-        NS_TIME_BASE,
-        stream.time_base,
-    )));
-    packet.set_dts(Some(Rescale::rescale(
-        &(dts.as_nanos() as i64),
-        NS_TIME_BASE,
-        stream.time_base,
-    )));
+    packet.set_pts(Some(Rescale::rescale(&pts, NS_TIME_BASE, stream.time_base)));
+    packet.set_dts(Some(Rescale::rescale(&dts, NS_TIME_BASE, stream.time_base)));
     packet.set_duration(Rescale::rescale(
         &(frame_duration.as_nanos() as i64),
         NS_TIME_BASE,

--- a/smelter-core/src/pipeline/input.rs
+++ b/smelter-core/src/pipeline/input.rs
@@ -156,7 +156,7 @@ where
 
     if pipeline_input.audio_eos_received.is_some() {
         for output in guard.outputs.values_mut() {
-            if let Some(ref mut cond) = output.audio_end_condition {
+            if let Some(cond) = output.audio_end_condition_mut() {
                 cond.on_input_registered(&input_id);
             }
         }
@@ -164,7 +164,7 @@ where
 
     if pipeline_input.video_eos_received.is_some() {
         for output in guard.outputs.values_mut() {
-            if let Some(ref mut cond) = output.video_end_condition {
+            if let Some(cond) = output.video_end_condition_mut() {
                 cond.on_input_registered(&input_id);
             }
         }

--- a/smelter-core/src/pipeline/instance.rs
+++ b/smelter-core/src/pipeline/instance.rs
@@ -30,7 +30,10 @@ use crate::{
         channel::{EncodedDataOutput, RawDataInput, RawDataOutput},
         input::{PipelineInput, new_external_input, register_pipeline_input},
         moq::{MoqServer, spawn_moq_server},
-        output::{OutputSender, PipelineOutput, new_external_output, register_pipeline_output},
+        output::{
+            OutputSender, OutputState, PipelineOutput, new_external_output,
+            register_pipeline_output,
+        },
         rtmp::spawn_rtmp_server,
         webrtc::{
             WebrtcSettingEngineCtx, WhipWhepPipelineState, WhipWhepServer, WhipWhepServerHandle,
@@ -136,10 +139,10 @@ impl Pipeline {
         self.renderer.unregister_input(input_id);
         self.audio_mixer.unregister_input(input_id);
         for output in self.outputs.values_mut() {
-            if let Some(ref mut cond) = output.audio_end_condition {
+            if let Some(cond) = output.audio_end_condition_mut() {
                 cond.on_input_unregistered(input_id);
             }
-            if let Some(ref mut cond) = output.video_end_condition {
+            if let Some(cond) = output.video_end_condition_mut() {
                 cond.on_input_unregistered(input_id);
             }
         }
@@ -151,12 +154,20 @@ impl Pipeline {
         output_id: OutputId,
         register_options: RegisterOutputOptions,
     ) -> Result<Option<Port>, RegisterOutputError> {
+        let RegisterOutputOptions {
+            output_options,
+            video,
+            audio,
+        } = register_options;
+        let start_at = output_options.start_at();
+
         register_pipeline_output(
             pipeline,
             output_id,
-            register_options.video,
-            register_options.audio,
-            |ctx, output_ref| new_external_output(ctx, output_ref, register_options.output_options),
+            video,
+            audio,
+            start_at,
+            |ctx, output_ref| new_external_output(ctx, output_ref, output_options),
         )
     }
 
@@ -170,6 +181,7 @@ impl Pipeline {
             output_id,
             register_options.video,
             register_options.audio,
+            None,
             |ctx, output_ref| {
                 let (output, handle) =
                     EncodedDataOutput::new(ctx, output_ref, register_options.output_options)?;
@@ -188,6 +200,7 @@ impl Pipeline {
             output_id,
             register_options.video,
             register_options.audio,
+            None,
             |_ctx, _output_ref| {
                 let (output, result) = RawDataOutput::new(register_options.output_options)?;
                 Ok((Box::new(output), result))
@@ -270,9 +283,7 @@ impl Pipeline {
         let Some(output) = self.outputs.get(output_id) else {
             return Err(UpdateSceneError::OutputNotRegistered(output_id.clone()));
         };
-        if output.audio_end_condition.is_some() != audio.is_some()
-            || output.video_end_condition.is_some() != video.is_some()
-        {
+        if output.has_audio() != audio.is_some() || output.has_video() != video.is_some() {
             return Err(UpdateSceneError::AudioVideoNotMatching(output_id.clone()));
         }
         if video.is_none() && audio.is_none() {
@@ -288,10 +299,10 @@ impl Pipeline {
     ) -> Result<(), UpdateSceneError> {
         let output = self
             .outputs
-            .get(&output_id)
+            .get_mut(&output_id)
             .ok_or_else(|| UpdateSceneError::OutputNotRegistered(output_id.clone()))?;
 
-        if let Some(cond) = &output.video_end_condition
+        if let Some(cond) = output.video_end_condition()
             && cond.did_output_end()
         {
             // Ignore updates after EOS
@@ -304,6 +315,14 @@ impl Pipeline {
         };
 
         info!(?output_id, "Update scene {:?}", scene_root);
+
+        if let OutputState::NotStarted { video, .. } = &mut output.state {
+            // Output is not connected to the renderer yet, update the scene it will start with.
+            if let Some(video) = video {
+                video.initial = scene_root;
+            }
+            return Ok(());
+        }
 
         self.renderer.update_scene(
             output_id,
@@ -320,10 +339,10 @@ impl Pipeline {
     ) -> Result<(), UpdateSceneError> {
         let output = self
             .outputs
-            .get(output_id)
+            .get_mut(output_id)
             .ok_or_else(|| UpdateSceneError::OutputNotRegistered(output_id.clone()))?;
 
-        if let Some(cond) = &output.audio_end_condition
+        if let Some(cond) = output.audio_end_condition()
             && cond.did_output_end()
         {
             // Ignore updates after EOS
@@ -332,6 +351,18 @@ impl Pipeline {
         }
 
         info!(?output_id, "Update audio mixer {:?}", audio);
+
+        if let OutputState::NotStarted {
+            audio: audio_opts, ..
+        } = &mut output.state
+        {
+            // Output is not connected to the audio mixer yet, update the config it will start with.
+            if let Some(audio_opts) = audio_opts {
+                audio_opts.initial = audio;
+            }
+            return Ok(());
+        }
+
         self.audio_mixer.update_output(output_id, audio)
     }
 
@@ -363,6 +394,7 @@ impl Pipeline {
     pub fn schedule_event<F: FnOnce(&mut Self) + Send + 'static>(
         pipeline: &Arc<Mutex<Self>>,
         pts: Duration,
+        late_policy: LateEventPolicy,
         callback: F,
     ) {
         let weak = Arc::downgrade(pipeline);
@@ -372,6 +404,7 @@ impl Pipeline {
         let queue = pipeline.lock().unwrap().queue.clone();
         queue.schedule_event(
             pts,
+            late_policy,
             Box::new(move || {
                 let Some(pipeline) = weak.upgrade() else {
                     warn!("Unable to call scheduled callback. Pipeline already dropped.");
@@ -423,7 +456,7 @@ fn run_renderer_thread(
                     input.on_video_eos();
                 }
                 for output in guard.outputs.values_mut() {
-                    if let Some(ref mut cond) = output.video_end_condition {
+                    if let Some(cond) = output.video_end_condition_mut() {
                         cond.on_input_eos(input_id);
                     }
                 }
@@ -495,7 +528,7 @@ fn run_audio_mixer_thread(
                     input.on_audio_eos();
                 }
                 for output in guard.outputs.values_mut() {
-                    if let Some(ref mut cond) = output.audio_end_condition {
+                    if let Some(cond) = output.audio_end_condition_mut() {
                         cond.on_input_eos(input_id);
                     }
                 }

--- a/smelter-core/src/pipeline/mp4/mp4_output.rs
+++ b/smelter-core/src/pipeline/mp4/mp4_output.rs
@@ -19,7 +19,7 @@ use crate::{
             ffmpeg_h264::FfmpegH264Encoder,
             vulkan_h264::VulkanH264Encoder,
         },
-        ffmpeg_utils::{FfmpegOptions, StreamMutExt, write_extradata},
+        ffmpeg_utils::{FfmpegOptions, StreamMutExt, TimestampOffset, write_extradata},
         output::{Output, OutputAudio, OutputVideo},
     },
     utils::InitializableThread,
@@ -74,6 +74,7 @@ impl Mp4Output {
             kind: OutputProtocolKind::Mp4,
         });
 
+        let start_at = options.start_at;
         let (encoded_chunks_sender, encoded_chunks_receiver) = bounded(1);
         let mut output_ctx = ffmpeg::format::output_as(&options.output_path, "mp4")
             .map_err(OutputInitError::FfmpegError)?;
@@ -128,6 +129,13 @@ impl Mp4Output {
             None => (None, None),
         };
 
+        let offset = TimestampOffset::new(
+            ctx.queue_ctx.clone(),
+            start_at,
+            video_stream.is_some(),
+            audio_stream.is_some(),
+        );
+
         std::thread::Builder::new()
             .name(format!("MP4 writer thread for output {output_ref}"))
             .spawn(move || {
@@ -141,6 +149,7 @@ impl Mp4Output {
                     video_stream,
                     audio_stream,
                     encoded_chunks_receiver,
+                    offset,
                 );
                 ctx.event_emitter
                     .emit(Event::OutputDone(output_ref.id().clone()));
@@ -300,72 +309,79 @@ fn run_ffmpeg_output_thread(
     mut video_stream: Option<StreamState>,
     mut audio_stream: Option<StreamState>,
     packets_receiver: Receiver<EncodedOutputEvent>,
+    mut offset: TimestampOffset,
 ) {
     let mut eos_state = EosState::new(video_stream.is_some(), audio_stream.is_some());
-    let mut timestamp_offset = None;
-
     let stats_sender = Mp4OutputStatsSender {
         stats_sender: ctx.stats_sender.clone(),
         output_ref: output_ref.clone(),
     };
 
-    for packet in packets_receiver {
-        match packet {
-            EncodedOutputEvent::Data(chunk) => {
-                let timestamp_offset = *timestamp_offset.get_or_insert(chunk.pts);
-                let stream = match chunk.kind {
-                    MediaKind::Video(_) => match &mut video_stream {
-                        Some(stream) => stream,
-                        None => {
-                            error!("Received unexpected video chunk.");
-                            continue;
-                        }
-                    },
-                    MediaKind::Audio(_) => match &mut audio_stream {
-                        Some(stream) => stream,
-                        None => {
-                            error!("Received unexpected audio chunk.");
-                            continue;
-                        }
-                    },
-                };
-
-                stats_sender.bytes_sent_event(chunk.data.len(), chunk.kind.into());
-                if let Err(err) = write_chunk(chunk, stream, &mut output_ctx, timestamp_offset) {
-                    let try_write_trailer =
-                        !matches!(err, OutputMp4RuntimeError::NoSpaceLeftOnDevice);
-                    ctx.event_emitter.emit(Event::OutputError {
-                        output_id: output_ref.id().clone(),
-                        err: err.into(),
-                        severity: ErrorSeverity::Critical,
-                    });
-                    match try_write_trailer {
-                        true => eos_state.mark_for_abort(),
-                        false => return,
-                    }
-                }
+    for packet in packets_receiver.into_iter().map(Some).chain([None]) {
+        let chunks = match packet {
+            Some(EncodedOutputEvent::Data(chunk)) => offset.resolve(chunk),
+            Some(EncodedOutputEvent::VideoEOS) => {
+                eos_state.on_video_eos();
+                offset.on_track_eos(MediaKind::Video(VideoCodec::H264))
             }
-            EncodedOutputEvent::VideoEOS => eos_state.on_video_eos(),
-            EncodedOutputEvent::AudioEOS => eos_state.on_audio_eos(),
+            Some(EncodedOutputEvent::AudioEOS) => {
+                eos_state.on_audio_eos();
+                offset.on_track_eos(MediaKind::Audio(AudioCodec::Aac))
+            }
+            None => offset.flush(),
         };
 
-        if eos_state.is_complete() {
-            if let Err(err) = output_ctx.write_trailer() {
-                let err = match err {
-                    ffmpeg::Error::Other {
-                        errno: ffmpeg::error::ENOSPC,
-                    } => OutputMp4RuntimeError::NoSpaceLeftOnDevice,
-                    err => OutputMp4RuntimeError::TrailerWriteError(err),
-                };
+        for (timestamp_offset, chunk) in chunks {
+            let stream = match chunk.kind {
+                MediaKind::Video(_) => match &mut video_stream {
+                    Some(stream) => stream,
+                    None => {
+                        error!("Received unexpected video chunk.");
+                        continue;
+                    }
+                },
+                MediaKind::Audio(_) => match &mut audio_stream {
+                    Some(stream) => stream,
+                    None => {
+                        error!("Received unexpected audio chunk.");
+                        continue;
+                    }
+                },
+            };
+
+            stats_sender.bytes_sent_event(chunk.data.len(), chunk.kind.into());
+            if let Err(err) = write_chunk(chunk, stream, &mut output_ctx, timestamp_offset) {
+                let try_write_trailer = !matches!(err, OutputMp4RuntimeError::NoSpaceLeftOnDevice);
                 ctx.event_emitter.emit(Event::OutputError {
                     output_id: output_ref.id().clone(),
                     err: err.into(),
                     severity: ErrorSeverity::Critical,
                 });
-            };
+                match try_write_trailer {
+                    true => eos_state.mark_for_abort(),
+                    false => return,
+                }
+            }
+        }
+
+        if eos_state.is_complete() {
             break;
         }
     }
+
+    if let Err(err) = output_ctx.write_trailer() {
+        let err = match err {
+            ffmpeg::Error::Other {
+                errno: ffmpeg::error::ENOSPC,
+            } => OutputMp4RuntimeError::NoSpaceLeftOnDevice,
+            err => OutputMp4RuntimeError::TrailerWriteError(err),
+        };
+        ctx.event_emitter.emit(Event::OutputError {
+            output_id: output_ref.id().clone(),
+            err: err.into(),
+            severity: ErrorSeverity::Critical,
+        });
+    };
 }
 
 fn write_chunk(
@@ -374,23 +390,16 @@ fn write_chunk(
     output_ctx: &mut ffmpeg::format::context::Output,
     timestamp_offset: Duration,
 ) -> Result<(), OutputMp4RuntimeError> {
-    let pts = chunk.pts.saturating_sub(timestamp_offset);
+    let offset = timestamp_offset.as_nanos() as i128;
+    let pts = (chunk.pts.as_nanos() as i128 - offset) as i64;
     let dts = chunk
         .dts
-        .map(|dts| dts.saturating_sub(timestamp_offset))
+        .map(|dts| (dts.as_nanos() as i128 - offset) as i64)
         .unwrap_or(pts);
 
     let mut packet = ffmpeg::Packet::copy(&chunk.data);
-    packet.set_pts(Some(Rescale::rescale(
-        &(pts.as_nanos() as i64),
-        NS_TIME_BASE,
-        stream.time_base,
-    )));
-    packet.set_dts(Some(Rescale::rescale(
-        &(dts.as_nanos() as i64),
-        NS_TIME_BASE,
-        stream.time_base,
-    )));
+    packet.set_pts(Some(Rescale::rescale(&pts, NS_TIME_BASE, stream.time_base)));
+    packet.set_dts(Some(Rescale::rescale(&dts, NS_TIME_BASE, stream.time_base)));
     packet.set_time_base(stream.time_base);
     packet.set_stream(stream.index);
 

--- a/smelter-core/src/pipeline/output.rs
+++ b/smelter-core/src/pipeline/output.rs
@@ -1,11 +1,12 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use crossbeam_channel::Sender;
-use smelter_render::OutputFrameFormat;
-use tracing::{info, warn};
+use smelter_render::{OutputFrameFormat, error::ErrorStack};
+use tracing::{error, info, warn};
 
 use crate::pipeline::{
     hls::HlsOutput,
@@ -20,8 +21,94 @@ use crate::prelude::*;
 
 pub(crate) struct PipelineOutput {
     pub output: Box<dyn Output>,
-    pub video_end_condition: Option<PipelineOutputEndConditionState>,
-    pub audio_end_condition: Option<PipelineOutputEndConditionState>,
+    /// Unique per registration, unlike `OutputId` which can be reused after unregister.
+    pub output_ref: Ref<OutputId>,
+    pub state: OutputState,
+}
+
+pub(crate) enum OutputState {
+    /// Output was registered with `start_at` and did not reach that timestamp yet. It is
+    /// already created (e.g. connection with a server is established), but it is not
+    /// connected to the renderer/audio mixer.
+    NotStarted {
+        video: Option<RegisterOutputVideoOptions>,
+        audio: Option<RegisterOutputAudioOptions>,
+    },
+    /// Output is connected to the renderer/audio mixer and receives frames/samples.
+    Started {
+        video_end_condition: Option<PipelineOutputEndConditionState>,
+        audio_end_condition: Option<PipelineOutputEndConditionState>,
+    },
+}
+
+impl PipelineOutput {
+    /// End conditions are set for exactly those tracks the output was registered with,
+    /// so they double as the "has video"/"has audio" flag after the start.
+    pub(super) fn has_video(&self) -> bool {
+        match &self.state {
+            OutputState::NotStarted { video, .. } => video.is_some(),
+            OutputState::Started {
+                video_end_condition,
+                ..
+            } => video_end_condition.is_some(),
+        }
+    }
+
+    pub(super) fn has_audio(&self) -> bool {
+        match &self.state {
+            OutputState::NotStarted { audio, .. } => audio.is_some(),
+            OutputState::Started {
+                audio_end_condition,
+                ..
+            } => audio_end_condition.is_some(),
+        }
+    }
+
+    /// `None` until the output starts.
+    pub(super) fn video_end_condition(&self) -> Option<&PipelineOutputEndConditionState> {
+        match &self.state {
+            OutputState::NotStarted { .. } => None,
+            OutputState::Started {
+                video_end_condition,
+                ..
+            } => video_end_condition.as_ref(),
+        }
+    }
+
+    pub(super) fn video_end_condition_mut(
+        &mut self,
+    ) -> Option<&mut PipelineOutputEndConditionState> {
+        match &mut self.state {
+            OutputState::NotStarted { .. } => None,
+            OutputState::Started {
+                video_end_condition,
+                ..
+            } => video_end_condition.as_mut(),
+        }
+    }
+
+    /// `None` until the output starts.
+    pub(super) fn audio_end_condition(&self) -> Option<&PipelineOutputEndConditionState> {
+        match &self.state {
+            OutputState::NotStarted { .. } => None,
+            OutputState::Started {
+                audio_end_condition,
+                ..
+            } => audio_end_condition.as_ref(),
+        }
+    }
+
+    pub(super) fn audio_end_condition_mut(
+        &mut self,
+    ) -> Option<&mut PipelineOutputEndConditionState> {
+        match &mut self.state {
+            OutputState::NotStarted { .. } => None,
+            OutputState::Started {
+                audio_end_condition,
+                ..
+            } => audio_end_condition.as_mut(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -85,11 +172,15 @@ pub(super) enum OutputSender<T> {
     FinishedSender,
 }
 
+/// Creates the output. If `start_at` is set, then output is only created, and it is connected
+/// to the renderer/audio mixer after the queue reaches that timestamp. Otherwise, it is
+/// connected immediately.
 pub(super) fn register_pipeline_output<BuildFn, NewOutputResult>(
     pipeline: &Arc<Mutex<Pipeline>>,
     output_id: OutputId,
     video: Option<RegisterOutputVideoOptions>,
     audio: Option<RegisterOutputAudioOptions>,
+    start_at: Option<Duration>,
     build_output: BuildFn,
 ) -> Result<NewOutputResult, RegisterOutputError>
 where
@@ -98,64 +189,128 @@ where
         Ref<OutputId>,
     ) -> Result<(Box<dyn Output>, NewOutputResult), OutputInitError>,
 {
-    let (has_video, has_audio) = (video.is_some(), audio.is_some());
-    if !has_video && !has_audio {
+    if video.is_none() && audio.is_none() {
         return Err(RegisterOutputError::NoVideoAndAudio(output_id));
     }
 
-    if pipeline.lock().unwrap().outputs.contains_key(&output_id) {
-        return Err(RegisterOutputError::AlreadyRegistered(output_id));
-    }
+    let pipeline_ctx = {
+        // Do not hold the pipeline lock for the whole scope, because output creation
+        // can potentially take a relatively long time.
+        let guard = pipeline.lock().unwrap();
+        if guard.outputs.contains_key(&output_id) {
+            return Err(RegisterOutputError::AlreadyRegistered(output_id));
+        }
+        guard.ctx.clone()
+    };
 
-    let pipeline_ctx = pipeline.lock().unwrap().ctx.clone();
-    let (output, output_result) = build_output(pipeline_ctx, Ref::new(&output_id))
-        .map_err(|e| RegisterOutputError::OutputError(output_id.clone(), e))?;
+    let output_ref = Ref::new(&output_id);
+    let (output, output_result) = build_output(pipeline_ctx, output_ref.clone())
+        .map_err(|err| RegisterOutputError::OutputError(output_id.clone(), err))?;
 
     let mut guard = pipeline.lock().unwrap();
-
     if guard.outputs.contains_key(&output_id) {
         return Err(RegisterOutputError::AlreadyRegistered(output_id));
     }
 
-    let output = PipelineOutput {
-        output,
-        audio_end_condition: audio.as_ref().map(|audio| {
-            PipelineOutputEndConditionState::new_audio(audio.end_condition.clone(), &guard.inputs)
-        }),
-        video_end_condition: video.as_ref().map(|video| {
-            PipelineOutputEndConditionState::new_video(video.end_condition.clone(), &guard.inputs)
-        }),
-    };
+    guard.outputs.insert(
+        output_id.clone(),
+        PipelineOutput {
+            output,
+            output_ref: output_ref.clone(),
+            state: OutputState::NotStarted { video, audio },
+        },
+    );
 
-    if let (Some(video_opts), Some(video_output)) = (video.clone(), output.output.video()) {
-        let result = guard.renderer.update_scene(
-            output_id.clone(),
-            video_output.resolution,
-            video_output.frame_format,
-            video_opts.initial,
-        );
-
-        if let Err(err) = result {
-            guard.renderer.unregister_output(&output_id);
-            return Err(RegisterOutputError::SceneError(output_id.clone(), err));
+    let Some(start_at) = start_at else {
+        // Start while still holding the lock, so errors (e.g. invalid scene) are reported
+        // by this call instead of asynchronously.
+        if let Err(err) = guard.start_registered_output(&output_ref) {
+            guard.outputs.remove(&output_id);
+            return Err(err);
         }
+        return Ok(output_result);
     };
 
-    if let Some(audio_opts) = audio.clone() {
-        guard.audio_mixer.register_output(
-            output_id.clone(),
-            audio_opts.initial,
-            audio_opts.mixing_strategy,
-            audio_opts.channels,
-        );
-    }
-
-    guard.outputs.insert(output_id.clone(), output);
+    // Do not hold the pipeline lock across `Pipeline::schedule_event(...)`.
+    drop(guard);
+    Pipeline::schedule_event(
+        pipeline,
+        start_at,
+        LateEventPolicy::AlwaysRun,
+        move |pipeline| {
+            if let Err(err) = pipeline.start_registered_output(&output_ref) {
+                pipeline.outputs.remove(output_ref.id());
+                error!(
+                    "Error while starting output scheduled for pts {}ms: {}",
+                    start_at.as_millis(),
+                    ErrorStack::new(&err).into_string()
+                )
+            }
+        },
+    );
 
     Ok(output_result)
 }
 
 impl Pipeline {
+    /// Connects already created output to the renderer/audio mixer, from that point
+    /// output starts receiving frames/samples.
+    fn start_registered_output(
+        &mut self,
+        output_ref: &Ref<OutputId>,
+    ) -> Result<(), RegisterOutputError> {
+        let inputs = &self.inputs;
+        let output_id = output_ref.id();
+        let Some(output) = self.outputs.get_mut(output_id) else {
+            // output was unregistered before it started
+            return Ok(());
+        };
+        if &output.output_ref != output_ref {
+            // different output with the same id
+            return Ok(());
+        }
+
+        let OutputState::NotStarted { video, audio } = &mut output.state else {
+            warn!(output_id=%output_ref, "Output already started");
+            return Ok(());
+        };
+        let (video, audio) = (video.take(), audio.take());
+
+        output.state = OutputState::Started {
+            video_end_condition: video.as_ref().map(|video| {
+                PipelineOutputEndConditionState::new_video(video.end_condition.clone(), inputs)
+            }),
+            audio_end_condition: audio.as_ref().map(|audio| {
+                PipelineOutputEndConditionState::new_audio(audio.end_condition.clone(), inputs)
+            }),
+        };
+
+        if let (Some(video_opts), Some(video_output)) = (video, output.output.video()) {
+            let result = self.renderer.update_scene(
+                output_id.clone(),
+                video_output.resolution,
+                video_output.frame_format,
+                video_opts.initial,
+            );
+
+            if let Err(err) = result {
+                self.renderer.unregister_output(output_id);
+                return Err(RegisterOutputError::SceneError(output_id.clone(), err));
+            }
+        };
+
+        if let Some(audio_opts) = audio {
+            self.audio_mixer.register_output(
+                output_id.clone(),
+                audio_opts.initial,
+                audio_opts.mixing_strategy,
+                audio_opts.channels,
+            );
+        }
+
+        Ok(())
+    }
+
     pub(super) fn all_output_video_senders_iter(
         pipeline: &Arc<Mutex<Pipeline>>,
     ) -> impl Iterator<Item = (OutputId, OutputSender<Sender<PipelineEvent<Frame>>>)> {
@@ -165,7 +320,7 @@ impl Pipeline {
             .outputs
             .iter_mut()
             .filter_map(|(output_id, output)| {
-                let eos_status = output.video_end_condition.as_mut()?.eos_status();
+                let eos_status = output.video_end_condition_mut()?.eos_status();
                 let sender = output.output.video()?.frame_sender.clone();
                 Some((output_id.clone(), (sender, eos_status)))
             })
@@ -203,7 +358,7 @@ impl Pipeline {
             .outputs
             .iter_mut()
             .filter_map(|(output_id, output)| {
-                let eos_status = output.audio_end_condition.as_mut()?.eos_status();
+                let eos_status = output.audio_end_condition_mut()?.eos_status();
                 let sender = output.output.audio()?.samples_batch_sender.clone();
                 Some((output_id.clone(), (sender, eos_status)))
             })

--- a/smelter-core/src/prelude.rs
+++ b/smelter-core/src/prelude.rs
@@ -8,6 +8,8 @@ pub use crate::output::*;
 
 pub use crate::types::*;
 
+pub use crate::queue::LateEventPolicy;
+
 pub(crate) use crate::stats::*;
 
 pub use smelter_render::{Frame, InputId, OutputId, Resolution};

--- a/smelter-core/src/protocols/hls.rs
+++ b/smelter-core/src/protocols/hls.rs
@@ -18,6 +18,11 @@ pub struct HlsOutputOptions {
     pub video: Option<VideoEncoderOptions>,
     pub audio: Option<AudioEncoderOptions>,
     pub raw_options: Vec<(Arc<str>, Arc<str>)>,
+    /// If set, the output is created immediately, but starts producing data only after
+    /// the queue reaches this timestamp (relative to the queue start). It doubles as the
+    /// timestamp offset of the produced playlist, so PTS 0 is exactly this moment rather
+    /// than whenever the first chunk happened to be encoded.
+    pub start_at: Option<Duration>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/smelter-core/src/protocols/mp4.rs
+++ b/smelter-core/src/protocols/mp4.rs
@@ -19,6 +19,11 @@ pub struct Mp4OutputOptions {
     pub video: Option<VideoEncoderOptions>,
     pub audio: Option<AudioEncoderOptions>,
     pub raw_options: Vec<(Arc<str>, Arc<str>)>,
+    /// If set, the output is created immediately, but starts producing data only after
+    /// the queue reaches this timestamp (relative to the queue start). It doubles as the
+    /// timestamp offset of the produced file, so PTS 0 in the file is exactly this
+    /// moment rather than whenever the first chunk happened to be encoded.
+    pub start_at: Option<Duration>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -162,10 +162,9 @@ impl QueueContext {
             .unwrap_or_else(|| self.sync_point.elapsed())
     }
 
-    /// Translate a timestamp relative to the queue start into the queue PTS space
-    /// (relative to `sync_point`). `None` before the queue is started.
-    pub(crate) fn pts_from_start(&self, offset: Duration) -> Option<Duration> {
-        self.start_pts.value().map(|start_pts| start_pts + offset)
+    // PTS of queue start time
+    pub fn start_pts(&self) -> Option<Duration> {
+        self.start_pts.value()
     }
 }
 

--- a/smelter-core/src/queue.rs
+++ b/smelter-core/src/queue.rs
@@ -161,6 +161,12 @@ impl QueueContext {
             .value()
             .unwrap_or_else(|| self.sync_point.elapsed())
     }
+
+    /// Translate a timestamp relative to the queue start into the queue PTS space
+    /// (relative to `sync_point`). `None` before the queue is started.
+    pub(crate) fn pts_from_start(&self, offset: Duration) -> Option<Duration> {
+        self.start_pts.value().map(|start_pts| start_pts + offset)
+    }
 }
 
 #[derive(Debug)]
@@ -242,6 +248,16 @@ pub struct ScheduledEvent {
     /// Public PTS value (relative to start, not to the sync_point)
     pts: Duration,
     callback: Box<dyn FnOnce() + Send>,
+    late_policy: LateEventPolicy,
+}
+
+/// Defines what happens when an event is scheduled for a PTS the queue already passed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LateEventPolicy {
+    /// Follow the `run_late_scheduled_events` queue option.
+    Default,
+    /// Run the event anyway, on the next queue tick.
+    AlwaysRun,
 }
 
 impl<T: Clone> Clone for PipelineEvent<T> {
@@ -344,9 +360,18 @@ impl Queue {
         }
     }
 
-    pub fn schedule_event(&self, pts: Duration, callback: Box<dyn FnOnce() + Send>) {
+    pub fn schedule_event(
+        &self,
+        pts: Duration,
+        late_policy: LateEventPolicy,
+        callback: Box<dyn FnOnce() + Send>,
+    ) {
         self.scheduled_event_sender
-            .send(ScheduledEvent { pts, callback })
+            .send(ScheduledEvent {
+                pts,
+                callback,
+                late_policy,
+            })
             .unwrap();
     }
 }
@@ -364,8 +389,12 @@ impl Debug for ScheduledEvent {
 pub(super) struct SharedPts(Arc<RwLock<Option<Duration>>>);
 
 impl SharedPts {
+    /// Monotonic, PTS never goes back (e.g. when a late scheduled event is handled).
     fn update(&self, pts: Duration) {
-        *self.0.write().unwrap() = Some(pts);
+        let mut guard = self.0.write().unwrap();
+        if guard.is_none_or(|current| pts > current) {
+            *guard = Some(pts);
+        }
     }
 
     fn value(&self) -> Option<Duration> {

--- a/smelter-core/src/queue/queue_thread.rs
+++ b/smelter-core/src/queue/queue_thread.rs
@@ -9,7 +9,7 @@ use std::{
 use crossbeam_channel::{Receiver, Sender, select, tick};
 use tracing::{debug, info, info_span, trace, warn};
 
-use super::{Queue, QueueAudioOutput, QueueVideoOutput, ScheduledEvent};
+use super::{LateEventPolicy, Queue, QueueAudioOutput, QueueVideoOutput, ScheduledEvent};
 
 pub(super) struct QueueThread {
     queue: Arc<Queue>,
@@ -206,15 +206,21 @@ impl QueueThreadAfterStart {
         let new_event_pts = scheduled_event.pts + self.queue_start_pts;
 
         let is_future_event = new_event_pts >= min_pts;
+        let run_late = match scheduled_event.late_policy {
+            LateEventPolicy::AlwaysRun => true,
+            LateEventPolicy::Default => self.queue.run_late_scheduled_events,
+        };
+
         if !is_future_event {
-            tracing::warn!(
+            warn!(
                 ?new_event_pts,
                 ?min_pts,
+                ?run_late,
                 "Scheduled event received too late"
             )
         }
 
-        if self.queue.run_late_scheduled_events || is_future_event {
+        if run_late || is_future_event {
             match self.scheduled_events.get_mut(&scheduled_event.pts) {
                 Some(events) => {
                     events.push(scheduled_event.callback);

--- a/src/routes/register_request.rs
+++ b/src/routes/register_request.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, State};
 use glyphon::fontdb::Source;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use smelter_core::{InputInitInfo, Pipeline, protocols::Port};
+use smelter_core::{InputInitInfo, Pipeline, RegisterOutputOptions, protocols::Port};
 use utoipa::ToSchema;
 
 use crate::{
@@ -145,31 +145,17 @@ pub async fn handle_output(
 ) -> Result<Response, ApiError> {
     let api = api.clone();
     tokio::task::spawn_blocking(move || {
-        let response = match request {
-            RegisterOutput::RtpStream(rtp) => {
-                Pipeline::register_output(&api.pipeline()?, output_id.into(), rtp.try_into()?)?
-            }
-            RegisterOutput::Mp4(mp4) => {
-                Pipeline::register_output(&api.pipeline()?, output_id.into(), mp4.try_into()?)?
-            }
-            RegisterOutput::WhipClient(whip) => {
-                Pipeline::register_output(&api.pipeline()?, output_id.into(), whip.try_into()?)?
-            }
-            RegisterOutput::WhepServer(whep) => {
-                Pipeline::register_output(&api.pipeline()?, output_id.into(), whep.try_into()?)?
-            }
-            RegisterOutput::RtmpClient(rtmp) => {
-                Pipeline::register_output(&api.pipeline()?, output_id.into(), rtmp.try_into()?)?
-            }
-            RegisterOutput::Hls(hls) => {
-                Pipeline::register_output(&api.pipeline()?, output_id.into(), hls.try_into()?)?
-            }
-            RegisterOutput::MoqClient(moq_client) => Pipeline::register_output(
-                &api.pipeline()?,
-                output_id.into(),
-                moq_client.try_into()?,
-            )?,
+        let options: RegisterOutputOptions = match request {
+            RegisterOutput::RtpStream(rtp) => rtp.try_into()?,
+            RegisterOutput::Mp4(mp4) => mp4.try_into()?,
+            RegisterOutput::WhipClient(whip) => whip.try_into()?,
+            RegisterOutput::WhepServer(whep) => whep.try_into()?,
+            RegisterOutput::RtmpClient(rtmp) => rtmp.try_into()?,
+            RegisterOutput::Hls(hls) => hls.try_into()?,
+            RegisterOutput::MoqClient(moq_client) => moq_client.try_into()?,
         };
+
+        let response = Pipeline::register_output(&api.pipeline()?, output_id.into(), options)?;
         match response {
             Some(Port(port)) => Ok(Response::RegisteredPort { port: Some(port) }),
             None => Ok(Response::Ok {}),

--- a/src/routes/unregister_request.rs
+++ b/src/routes/unregister_request.rs
@@ -2,7 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use axum::extract::{Path, State};
 use serde::{Deserialize, Serialize};
-use smelter_core::Pipeline;
+use smelter_core::{LateEventPolicy, Pipeline};
 use smelter_render::{RegistryType, error::ErrorStack};
 use tracing::error;
 use utoipa::ToSchema;
@@ -58,15 +58,20 @@ pub async fn handle_input(
     match request.schedule_time_ms {
         Some(schedule_time_ms) => {
             let schedule_time = Duration::from_secs_f64(schedule_time_ms / 1000.0);
-            Pipeline::schedule_event(&api.pipeline()?, schedule_time, move |pipeline| {
-                if let Err(err) = pipeline.unregister_input(&input_id.into()) {
-                    error!(
-                        "Error while running scheduled input unregister for pts {}ms: {}",
-                        schedule_time.as_millis(),
-                        ErrorStack::new(&err).into_string()
-                    )
-                }
-            });
+            Pipeline::schedule_event(
+                &api.pipeline()?,
+                schedule_time,
+                LateEventPolicy::Default,
+                move |pipeline| {
+                    if let Err(err) = pipeline.unregister_input(&input_id.into()) {
+                        error!(
+                            "Error while running scheduled input unregister for pts {}ms: {}",
+                            schedule_time.as_millis(),
+                            ErrorStack::new(&err).into_string()
+                        )
+                    }
+                },
+            );
         }
         None => {
             api.pipeline()?
@@ -99,15 +104,20 @@ pub async fn handle_output(
     match request.schedule_time_ms {
         Some(schedule_time_ms) => {
             let schedule_time = Duration::from_secs_f64(schedule_time_ms / 1000.0);
-            Pipeline::schedule_event(&api.pipeline()?, schedule_time, move |pipeline| {
-                if let Err(err) = pipeline.unregister_output(&output_id.into()) {
-                    error!(
-                        "Error while running scheduled output unregister for pts {}ms: {}",
-                        schedule_time.as_millis(),
-                        ErrorStack::new(&err).into_string()
-                    )
-                }
-            });
+            Pipeline::schedule_event(
+                &api.pipeline()?,
+                schedule_time,
+                LateEventPolicy::Default,
+                move |pipeline| {
+                    if let Err(err) = pipeline.unregister_output(&output_id.into()) {
+                        error!(
+                            "Error while running scheduled output unregister for pts {}ms: {}",
+                            schedule_time.as_millis(),
+                            ErrorStack::new(&err).into_string()
+                        )
+                    }
+                },
+            );
         }
         None => {
             api.pipeline()?
@@ -140,17 +150,22 @@ pub async fn handle_shader(
     match request.schedule_time_ms {
         Some(schedule_time_ms) => {
             let schedule_time = Duration::from_secs_f64(schedule_time_ms / 1000.0);
-            Pipeline::schedule_event(&api.pipeline()?, schedule_time, move |pipeline| {
-                if let Err(err) =
-                    pipeline.unregister_renderer(&shader_id.into(), RegistryType::Shader)
-                {
-                    error!(
-                        "Error while running scheduled shader unregister for pts {}ms: {}",
-                        schedule_time.as_millis(),
-                        ErrorStack::new(&err).into_string()
-                    )
-                }
-            });
+            Pipeline::schedule_event(
+                &api.pipeline()?,
+                schedule_time,
+                LateEventPolicy::Default,
+                move |pipeline| {
+                    if let Err(err) =
+                        pipeline.unregister_renderer(&shader_id.into(), RegistryType::Shader)
+                    {
+                        error!(
+                            "Error while running scheduled shader unregister for pts {}ms: {}",
+                            schedule_time.as_millis(),
+                            ErrorStack::new(&err).into_string()
+                        )
+                    }
+                },
+            );
         }
         None => {
             api.pipeline()?
@@ -183,17 +198,22 @@ pub async fn handle_web_renderer(
     match request.schedule_time_ms {
         Some(schedule_time_ms) => {
             let schedule_time = Duration::from_secs_f64(schedule_time_ms / 1000.0);
-            Pipeline::schedule_event(&api.pipeline()?, schedule_time, move |pipeline| {
-                if let Err(err) =
-                    pipeline.unregister_renderer(&instance_id.into(), RegistryType::WebRenderer)
-                {
-                    error!(
-                        "Error while running scheduled web renderer unregister for pts {}ms: {}",
-                        schedule_time.as_millis(),
-                        ErrorStack::new(&err).into_string()
-                    )
-                }
-            });
+            Pipeline::schedule_event(
+                &api.pipeline()?,
+                schedule_time,
+                LateEventPolicy::Default,
+                move |pipeline| {
+                    if let Err(err) =
+                        pipeline.unregister_renderer(&instance_id.into(), RegistryType::WebRenderer)
+                    {
+                        error!(
+                            "Error while running scheduled web renderer unregister for pts {}ms: {}",
+                            schedule_time.as_millis(),
+                            ErrorStack::new(&err).into_string()
+                        )
+                    }
+                },
+            );
         }
         None => {
             api.pipeline()?
@@ -226,17 +246,22 @@ pub async fn handle_image(
     match request.schedule_time_ms {
         Some(schedule_time_ms) => {
             let schedule_time = Duration::from_secs_f64(schedule_time_ms / 1000.0);
-            Pipeline::schedule_event(&api.pipeline()?, schedule_time, move |pipeline| {
-                if let Err(err) =
-                    pipeline.unregister_renderer(&image_id.into(), RegistryType::Image)
-                {
-                    error!(
-                        "Error while running scheduled image unregister for pts {}ms: {}",
-                        schedule_time.as_millis(),
-                        ErrorStack::new(&err).into_string()
-                    )
-                }
-            });
+            Pipeline::schedule_event(
+                &api.pipeline()?,
+                schedule_time,
+                LateEventPolicy::Default,
+                move |pipeline| {
+                    if let Err(err) =
+                        pipeline.unregister_renderer(&image_id.into(), RegistryType::Image)
+                    {
+                        error!(
+                            "Error while running scheduled image unregister for pts {}ms: {}",
+                            schedule_time.as_millis(),
+                            ErrorStack::new(&err).into_string()
+                        )
+                    }
+                },
+            );
         }
         None => {
             api.pipeline()?

--- a/src/routes/update_output.rs
+++ b/src/routes/update_output.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use axum::extract::{Path, State};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use smelter_core::Pipeline;
+use smelter_core::{LateEventPolicy, Pipeline};
 use smelter_render::error::ErrorStack;
 use tracing::error;
 use utoipa::ToSchema;
@@ -52,15 +52,20 @@ pub async fn handle_output_update(
     match request.schedule_time_ms {
         Some(schedule_time_ms) => {
             let schedule_time = Duration::from_secs_f64(schedule_time_ms / 1000.0);
-            Pipeline::schedule_event(&api.pipeline()?, schedule_time, move |pipeline| {
-                if let Err(err) = pipeline.update_output(output_id, scene, audio) {
-                    error!(
-                        "Error while running scheduled output update for pts {}ms: {}",
-                        schedule_time.as_millis(),
-                        ErrorStack::new(&err).into_string()
-                    )
-                }
-            });
+            Pipeline::schedule_event(
+                &api.pipeline()?,
+                schedule_time,
+                LateEventPolicy::Default,
+                move |pipeline| {
+                    if let Err(err) = pipeline.update_output(output_id, scene, audio) {
+                        error!(
+                            "Error while running scheduled output update for pts {}ms: {}",
+                            schedule_time.as_millis(),
+                            ErrorStack::new(&err).into_string()
+                        )
+                    }
+                },
+            );
         }
         None => api
             .pipeline()?

--- a/tools/schemas/openapi_specification.json
+++ b/tools/schemas/openapi_specification.json
@@ -1732,6 +1732,14 @@
             "propertyNames": {
               "type": "string"
             }
+          },
+          "start_at_ms": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "Time in milliseconds when this output should start producing data. Value `0` represents\ntime of the start request. Output is always created when this request is handled (e.g.\nplaylist is created), only the moment it starts receiving frames/samples is delayed."
           }
         },
         "additionalProperties": false
@@ -3250,6 +3258,14 @@
             "propertyNames": {
               "type": "string"
             }
+          },
+          "start_at_ms": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double",
+            "description": "Time in milliseconds when this output should start producing data. Value `0` represents\ntime of the start request. Output is always created when this request is handled (e.g.\nfile is created), only the moment it starts receiving frames/samples is delayed."
           }
         },
         "additionalProperties": false

--- a/ts/smelter-core/src/api/output/hls.ts
+++ b/ts/smelter-core/src/api/output/hls.ts
@@ -13,6 +13,7 @@ export function intoRegisterHlsOutput(
     video: output.video && initial.video && intoOutputHlsVideoOptions(output.video, initial.video),
     audio: output.audio && initial.audio && intoOutputHlsAudioOptions(output.audio, initial.audio),
     ffmpeg_options: output.ffmpegOptions,
+    start_at_ms: output.startAtMs,
   };
 }
 

--- a/ts/smelter-core/src/api/output/mp4.ts
+++ b/ts/smelter-core/src/api/output/mp4.ts
@@ -12,6 +12,7 @@ export function intoRegisterMp4Output(
     video: output.video && initial.video && intoOutputMp4VideoOptions(output.video, initial.video),
     audio: output.audio && initial.audio && intoOutputMp4AudioOptions(output.audio, initial.audio),
     ffmpeg_options: output.ffmpegOptions,
+    start_at_ms: output.startAtMs,
   };
 }
 

--- a/ts/smelter/src/api.generated.ts
+++ b/ts/smelter/src/api.generated.ts
@@ -416,6 +416,10 @@ export type RegisterOutput =
       ffmpeg_options?: {
         [k: string]: string;
       } | null;
+      /**
+       * Time in milliseconds when this output should start producing data. Value `0` represents time of the start request. Output is always created when this request is handled (e.g. file is created), only the moment it starts receiving frames/samples is delayed.
+       */
+      start_at_ms?: number | null;
     }
   | {
       type: "whip_client";
@@ -472,6 +476,10 @@ export type RegisterOutput =
       ffmpeg_options?: {
         [k: string]: string;
       } | null;
+      /**
+       * Time in milliseconds when this output should start producing data. Value `0` represents time of the start request. Output is always created when this request is handled (e.g. playlist is created), only the moment it starts receiving frames/samples is delayed.
+       */
+      start_at_ms?: number | null;
     };
 export type InputId = string;
 export type RtpVideoEncoderOptions =

--- a/ts/smelter/src/types/output.ts
+++ b/ts/smelter/src/types/output.ts
@@ -56,6 +56,12 @@ export type RegisterMp4Output = {
    * Raw FFmpeg muxer options. See [docs](https://ffmpeg.org/ffmpeg-formats.html) for more.
    */
   ffmpegOptions?: Record<string, string>;
+  /**
+   * Time in milliseconds when this output should start producing data. Value `0` represents
+   * time of the start request. Output is always created when this request is handled
+   * (e.g. file is created), only the moment it starts receiving frames/samples is delayed.
+   */
+  startAtMs?: number | null;
 };
 
 export type RegisterHlsOutput = {
@@ -81,6 +87,12 @@ export type RegisterHlsOutput = {
    * Note: keys here may override defaults, including `hls_list_size` derived from `maxPlaylistSize`.
    */
   ffmpegOptions?: Record<string, string>;
+  /**
+   * Time in milliseconds when this output should start producing data. Value `0` represents
+   * time of the start request. Output is always created when this request is handled
+   * (e.g. playlist is created), only the moment it starts receiving frames/samples is delayed.
+   */
+  startAtMs?: number | null;
 };
 
 export type RegisterWhipClientOutput = {


### PR DESCRIPTION
https://github.com/smelter-labs/smelter-snapshot-tests/pull/97

## What

Adds `start_at_ms` to MP4 and HLS output registration — the output is created when the register request is handled (file/playlist on disk, encoders up), but only starts receiving frames and samples once the queue reaches the given time. Not supported on live-connection protocols.

## Core change

Output registration is split into **create** and **start**. `register_pipeline_output` builds and inserts the output; `start_output` connects it to the renderer and audio mixer. Without `start_at_ms` the two happen back to back, otherwise the start becomes a scheduled queue event.

Outputs therefore have a pending state now: a scene update on a pending output is stored as its initial scene instead of going to the renderer, and its scene is validated at start time rather than during the register request.

MP4/HLS output timestamps are no longer anchored on the first chunk that arrives — the anchor is `start_at` when set, otherwise the lowest PTS across the first chunk of each track.