### PR TITLE
Filter decode_only frames by pts values

### DIFF
--- a/smelter-core/src/pipeline/decoder.rs
+++ b/smelter-core/src/pipeline/decoder.rs
@@ -9,9 +9,11 @@ use crate::prelude::*;
 pub(super) mod decoder_thread_audio;
 pub(super) mod decoder_thread_video;
 
+mod decode_only_filter;
 mod dynamic_stream;
 mod static_stream;
 
+use decode_only_filter::DecodeOnlyFilter;
 pub(super) use dynamic_stream::{
     DynamicVideoDecoderStream, KeyframeRequestSender, VideoDecoderMapping,
 };

--- a/smelter-core/src/pipeline/decoder/decode_only_filter.rs
+++ b/smelter-core/src/pipeline/decoder/decode_only_filter.rs
@@ -1,0 +1,79 @@
+use std::time::Duration;
+
+use crate::pipeline::decoder::EncodedInputEvent;
+
+/// Tracks which decoded frames/samples came from decode-only chunks.
+///
+/// Decoders buffer and reorder, so frames from a decode-only chunk may come out
+/// of a later `decode` call. Track pts ranges instead:
+/// - Open range on first decode_only chunk
+/// - Close range on first !decode_only chunk
+/// - Drop only output inside a range
+///
+/// With non-monotonic PTS (B-frames) a chunk of the boundary GOP can arrive
+/// after the range was opened/closed with a smaller PTS, so bounds move down
+/// after the fact.
+#[derive(Default)]
+pub(crate) struct DecodeOnlyFilter {
+    /// Pts ranges `[start, end)` that must not be presented; an open range
+    /// (`end` is `None`) has not seen a presentable chunk yet.
+    ranges: Vec<(Duration, Option<Duration>)>,
+    /// Ranges describe a timeline that ended; the next chunk starts over.
+    reset_on_next_chunk: bool,
+}
+
+impl DecodeOnlyFilter {
+    /// Call before passing the event to the decoder.
+    pub fn on_event(&mut self, event: &EncodedInputEvent) {
+        match event {
+            EncodedInputEvent::Chunk(chunk) => {
+                if self.reset_on_next_chunk {
+                    self.ranges.clear();
+                    self.reset_on_next_chunk = false;
+                }
+                match (chunk.decode_only, self.ranges.last_mut()) {
+                    // No ranges so always start new
+                    (true, None) => self.ranges.push((chunk.pts, None)),
+
+                    // Last range is closed, and PTS is outside of that range
+                    (true, Some((_start, Some(end)))) if chunk.pts >= *end => {
+                        self.ranges.push((chunk.pts, None))
+                    }
+
+                    // Either inside last range or even before
+                    (true, Some((start, _end))) => {
+                        *start = Duration::min(*start, chunk.pts);
+                    }
+
+                    // modify existing range even if closed if current PTS is smaller
+                    (false, Some((_, end))) => {
+                        *end = Some(Duration::min(end.unwrap_or(Duration::MAX), chunk.pts));
+                    }
+
+                    (false, None) => {}
+                }
+            }
+            EncodedInputEvent::Discontinuity => {
+                // Everything still buffered belongs to the old timeline and
+                // nothing presentable follows it there.
+                if let Some((_, end @ None)) = self.ranges.last_mut() {
+                    *end = Some(Duration::MAX);
+                }
+                self.reset_on_next_chunk = true;
+            }
+            EncodedInputEvent::LostData | EncodedInputEvent::AuDelimiter => {}
+        }
+    }
+
+    /// Call for every frame/sample batch the decoder returns, in the order
+    /// it was returned.
+    pub fn should_drop(&mut self, pts: Duration) -> bool {
+        // Output leaves the decoder in presentation order, so closed ranges
+        // ending at or before this pts can never match again.
+        self.ranges
+            .retain(|(_, end)| end.is_none_or(|end| end > pts));
+        self.ranges
+            .iter()
+            .any(|(start, end)| *start <= pts && end.is_none_or(|end| pts < end))
+    }
+}

--- a/smelter-core/src/pipeline/decoder/dynamic_stream.rs
+++ b/smelter-core/src/pipeline/decoder/dynamic_stream.rs
@@ -4,8 +4,9 @@ use smelter_render::{Frame, error::ErrorStack};
 use tracing::error;
 
 use crate::pipeline::decoder::{
-    EncodedInputEvent, VideoDecoder, VideoDecoderInstance, ffmpeg_h264::FfmpegH264Decoder,
-    ffmpeg_vp8::FfmpegVp8Decoder, ffmpeg_vp9::FfmpegVp9Decoder, vulkan_h264::VulkanH264Decoder,
+    DecodeOnlyFilter, EncodedInputEvent, VideoDecoder, VideoDecoderInstance,
+    ffmpeg_h264::FfmpegH264Decoder, ffmpeg_vp8::FfmpegVp8Decoder, ffmpeg_vp9::FfmpegVp9Decoder,
+    vulkan_h264::VulkanH264Decoder,
 };
 
 use crate::prelude::*;
@@ -47,6 +48,7 @@ where
 {
     ctx: Arc<PipelineCtx>,
     decoder: Option<Box<dyn VideoDecoderInstance>>,
+    decode_only_filter: DecodeOnlyFilter,
     last_chunk_kind: Option<MediaKind>,
     source: Source,
     decoders_info: VideoDecoderMapping,
@@ -66,6 +68,7 @@ where
         Self {
             ctx,
             decoder: None,
+            decode_only_filter: DecodeOnlyFilter::default(),
             last_chunk_kind: None,
             source,
             decoders_info,
@@ -144,16 +147,20 @@ where
                     self.ensure_decoder(chunk.kind);
                 }
                 let decoder = self.decoder.as_mut()?;
-                Some(decoder.decode(event))
+                self.decode_only_filter.on_event(&event);
+                let mut frames = decoder.decode(event);
+                frames.retain(|frame| !self.decode_only_filter.should_drop(frame.pts));
+                Some(frames)
             }
             Some(PipelineEvent::EOS) | None => {
-                let chunks = self
+                let mut frames = self
                     .decoder
                     .as_mut()
                     .map(|decoder| decoder.flush())
                     .unwrap_or_default();
-                match chunks.is_empty() {
-                    false => Some(chunks),
+                frames.retain(|frame| !self.decode_only_filter.should_drop(frame.pts));
+                match frames.is_empty() {
+                    false => Some(frames),
                     true => None,
                 }
             }

--- a/smelter-core/src/pipeline/decoder/ffmpeg_h264.rs
+++ b/smelter-core/src/pipeline/decoder/ffmpeg_h264.rs
@@ -65,7 +65,7 @@ impl VideoDecoderInstance for FfmpegH264Decoder {
         trace!(?event, "FFmpeg H264 decoder received an event.");
         let au_chunks = match event {
             EncodedInputEvent::Chunk(chunk) => {
-                self.drop_frames = !chunk.present;
+                self.drop_frames = chunk.decode_only;
                 match self.au_splitter.put_chunk(chunk) {
                     Ok(chunks) => chunks,
                     Err(err) => {

--- a/smelter-core/src/pipeline/decoder/ffmpeg_h264.rs
+++ b/smelter-core/src/pipeline/decoder/ffmpeg_h264.rs
@@ -24,7 +24,6 @@ pub struct FfmpegH264Decoder {
     keyframe_request_sender: Option<KeyframeRequestSender>,
     av_frame: ffmpeg_next::frame::Video,
     au_splitter: H264AuSplitter,
-    drop_frames: bool,
 }
 
 impl VideoDecoder for FfmpegH264Decoder {
@@ -55,7 +54,6 @@ impl VideoDecoder for FfmpegH264Decoder {
             keyframe_request_sender,
             av_frame: ffmpeg_next::frame::Video::empty(),
             au_splitter: H264AuSplitter::default(),
-            drop_frames: false,
         })
     }
 }
@@ -64,19 +62,16 @@ impl VideoDecoderInstance for FfmpegH264Decoder {
     fn decode(&mut self, event: EncodedInputEvent) -> Vec<Frame> {
         trace!(?event, "FFmpeg H264 decoder received an event.");
         let au_chunks = match event {
-            EncodedInputEvent::Chunk(chunk) => {
-                self.drop_frames = chunk.decode_only;
-                match self.au_splitter.put_chunk(chunk) {
-                    Ok(chunks) => chunks,
-                    Err(err) => {
-                        if let Some(s) = self.keyframe_request_sender.as_ref() {
-                            s.send()
-                        }
-                        debug!("H264 AU splitter could not process the chunks: {err}");
-                        return Vec::new();
+            EncodedInputEvent::Chunk(chunk) => match self.au_splitter.put_chunk(chunk) {
+                Ok(chunks) => chunks,
+                Err(err) => {
+                    if let Some(s) = self.keyframe_request_sender.as_ref() {
+                        s.send()
                     }
+                    debug!("H264 AU splitter could not process the chunks: {err}");
+                    return Vec::new();
                 }
-            }
+            },
             EncodedInputEvent::LostData => {
                 self.au_splitter.mark_missing_data();
                 return vec![];
@@ -143,10 +138,7 @@ impl FfmpegH264Decoder {
             match self.decoder.receive_frame(&mut self.av_frame) {
                 Ok(_) => match from_av_frame(&mut self.av_frame, TIME_BASE) {
                     Ok(frame) => {
-                        trace!(pts=?frame.pts, drop_frames=?self.drop_frames, "H264 decoder produced a frame.");
-                        if self.drop_frames {
-                            continue;
-                        }
+                        trace!(pts=?frame.pts, "H264 decoder produced a frame.");
                         frames.push(frame);
                     }
                     Err(err) => {

--- a/smelter-core/src/pipeline/decoder/static_stream.rs
+++ b/smelter-core/src/pipeline/decoder/static_stream.rs
@@ -3,7 +3,7 @@ use tracing::warn;
 
 use smelter_render::{Frame, error::ErrorStack};
 
-use crate::pipeline::decoder::{AudioDecoder, EncodedInputEvent, VideoDecoder};
+use crate::pipeline::decoder::{AudioDecoder, DecodeOnlyFilter, EncodedInputEvent, VideoDecoder};
 
 use crate::prelude::*;
 
@@ -13,6 +13,7 @@ where
     Source: Iterator<Item = PipelineEvent<EncodedInputEvent>>,
 {
     decoder: Decoder,
+    decode_only_filter: DecodeOnlyFilter,
     source: Source,
 }
 
@@ -23,7 +24,11 @@ where
 {
     pub fn new(ctx: Arc<PipelineCtx>, source: Source) -> Result<Self, DecoderInitError> {
         let decoder = Decoder::new(&ctx, None)?;
-        Ok(Self { decoder, source })
+        Ok(Self {
+            decoder,
+            decode_only_filter: DecodeOnlyFilter::default(),
+            source,
+        })
     }
 }
 
@@ -36,11 +41,17 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.source.next() {
-            Some(PipelineEvent::Data(event)) => Some(self.decoder.decode(event)),
+            Some(PipelineEvent::Data(event)) => {
+                self.decode_only_filter.on_event(&event);
+                let mut frames = self.decoder.decode(event);
+                frames.retain(|frame| !self.decode_only_filter.should_drop(frame.pts));
+                Some(frames)
+            }
             Some(PipelineEvent::EOS) | None => {
-                let chunks = self.decoder.flush();
-                match chunks.is_empty() {
-                    false => Some(chunks),
+                let mut frames = self.decoder.flush();
+                frames.retain(|frame| !self.decode_only_filter.should_drop(frame.pts));
+                match frames.is_empty() {
+                    false => Some(frames),
                     true => None,
                 }
             }
@@ -54,6 +65,7 @@ where
     Source: Iterator<Item = PipelineEvent<EncodedInputEvent>>,
 {
     decoder: Decoder,
+    decode_only_filter: DecodeOnlyFilter,
     source: Source,
 }
 
@@ -68,7 +80,11 @@ where
         source: Source,
     ) -> Result<Self, DecoderInitError> {
         let decoder = Decoder::new(&ctx, options)?;
-        Ok(Self { decoder, source })
+        Ok(Self {
+            decoder,
+            decode_only_filter: DecodeOnlyFilter::default(),
+            source,
+        })
     }
 }
 
@@ -81,20 +97,29 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.source.next() {
-            Some(PipelineEvent::Data(event)) => match self.decoder.decode(event) {
-                Ok(chunks) => Some(chunks),
-                Err(err) => {
-                    warn!(
-                        "Audio decoder error: {}",
-                        ErrorStack::new(&err).into_string()
-                    );
-                    Some(vec![])
+            Some(PipelineEvent::Data(event)) => {
+                self.decode_only_filter.on_event(&event);
+                match self.decoder.decode(event) {
+                    Ok(mut samples) => {
+                        samples.retain(|samples| {
+                            !self.decode_only_filter.should_drop(samples.start_pts)
+                        });
+                        Some(samples)
+                    }
+                    Err(err) => {
+                        warn!(
+                            "Audio decoder error: {}",
+                            ErrorStack::new(&err).into_string()
+                        );
+                        Some(vec![])
+                    }
                 }
-            },
+            }
             Some(PipelineEvent::EOS) | None => {
-                let chunks = self.decoder.flush();
-                match chunks.is_empty() {
-                    false => Some(chunks),
+                let mut samples = self.decoder.flush();
+                samples.retain(|samples| !self.decode_only_filter.should_drop(samples.start_pts));
+                match samples.is_empty() {
+                    false => Some(samples),
                     true => None,
                 }
             }

--- a/smelter-core/src/pipeline/decoder/vulkan_h264.rs
+++ b/smelter-core/src/pipeline/decoder/vulkan_h264.rs
@@ -16,7 +16,6 @@ use crate::prelude::*;
 pub struct VulkanH264Decoder {
     decoder: WgpuTexturesDecoder,
     keyframe_request_sender: Option<KeyframeRequestSender>,
-    drop_frames: bool,
 }
 
 impl VideoDecoder for VulkanH264Decoder {
@@ -43,7 +42,6 @@ impl VideoDecoder for VulkanH264Decoder {
         Ok(Self {
             decoder,
             keyframe_request_sender,
-            drop_frames: false,
         })
     }
 }
@@ -54,7 +52,6 @@ impl VideoDecoderInstance for VulkanH264Decoder {
 
         let decoder_event = match &event {
             EncodedInputEvent::Chunk(chunk) => {
-                self.drop_frames = chunk.decode_only;
                 H264DecoderEvent::DecodeChunk(gpu_video::EncodedInputChunk {
                     data: chunk.data.as_ref(),
                     pts: Some(chunk.pts.as_micros() as u64),
@@ -82,20 +79,12 @@ impl VideoDecoderInstance for VulkanH264Decoder {
             }
         };
 
-        match self.drop_frames {
-            true => Vec::new(),
-            false => frames.into_iter().map(from_vk_frame).collect(),
-        }
+        frames.into_iter().map(from_vk_frame).collect()
     }
 
     fn flush(&mut self) -> Vec<Frame> {
         match self.decoder.flush() {
-            Ok(frames) => {
-                if self.drop_frames {
-                    return Vec::new();
-                }
-                frames.into_iter().map(from_vk_frame).collect()
-            }
+            Ok(frames) => frames.into_iter().map(from_vk_frame).collect(),
             Err(err) => {
                 warn!("Failed to flush the decoder: {err}");
                 Vec::new()

--- a/smelter-core/src/pipeline/decoder/vulkan_h264.rs
+++ b/smelter-core/src/pipeline/decoder/vulkan_h264.rs
@@ -54,7 +54,7 @@ impl VideoDecoderInstance for VulkanH264Decoder {
 
         let decoder_event = match &event {
             EncodedInputEvent::Chunk(chunk) => {
-                self.drop_frames = !chunk.present;
+                self.drop_frames = chunk.decode_only;
                 H264DecoderEvent::DecodeChunk(gpu_video::EncodedInputChunk {
                     data: chunk.data.as_ref(),
                     pts: Some(chunk.pts.as_micros() as u64),

--- a/smelter-core/src/pipeline/hls/hls_input.rs
+++ b/smelter-core/src/pipeline/hls/hls_input.rs
@@ -373,7 +373,7 @@ impl HlsPacket {
             pts: self.pts(),
             dts: self.packet.dts().map(|dts| self.timestamp(dts)),
             kind,
-            present: !self.decode_only,
+            decode_only: self.decode_only,
         }
     }
 }

--- a/smelter-core/src/pipeline/moq/input/connection.rs
+++ b/smelter-core/src/pipeline/moq/input/connection.rs
@@ -265,7 +265,7 @@ async fn run_video_track(
             pts: raw_pts,
             dts: None,
             kind: MediaKind::Video(video.codec),
-            present: true,
+            decode_only: false,
         };
 
         let channel_closed = aligner
@@ -348,7 +348,7 @@ async fn run_audio_track(
             pts: raw_pts,
             dts: None,
             kind: MediaKind::Audio(audio.codec),
-            present: true,
+            decode_only: false,
         };
 
         let channel_closed = aligner

--- a/smelter-core/src/pipeline/mp4/reader.rs
+++ b/smelter-core/src/pipeline/mp4/reader.rs
@@ -337,7 +337,7 @@ impl<Reader: Read + Seek + Send + 'static> TrackChunks<'_, Reader> {
         // sample before the seek point so the decoder can build up its reference
         // frames. Samples before `present_from_sample` are only needed for decoding
         // and should not be presented.
-        let present = sample_index >= self.present_from_index;
+        let decode_only = sample_index < self.present_from_index;
 
         let chunk = EncodedInputChunk {
             data: sample.bytes,
@@ -347,7 +347,7 @@ impl<Reader: Read + Seek + Send + 'static> TrackChunks<'_, Reader> {
                 DecoderOptions::H264(_) => MediaKind::Video(VideoCodec::H264),
                 DecoderOptions::Aac(_) => MediaKind::Audio(AudioCodec::Aac),
             },
-            present,
+            decode_only,
         };
         (chunk, sample_duration)
     }

--- a/smelter-core/src/pipeline/rtmp/rtmp_input/connection.rs
+++ b/smelter-core/src/pipeline/rtmp/rtmp_input/connection.rs
@@ -206,7 +206,7 @@ impl RtmpConnectionState {
             pts: video.pts,
             dts: Some(video.dts),
             kind: MediaKind::Video(video.codec.into()),
-            present: true,
+            decode_only: false,
         };
 
         track_sync
@@ -226,7 +226,7 @@ impl RtmpConnectionState {
             pts: audio.pts,
             dts: None,
             kind: MediaKind::Audio(audio.codec.into()),
-            present: true,
+            decode_only: false,
         };
 
         track_sync

--- a/smelter-core/src/pipeline/rtp/depayloader.rs
+++ b/smelter-core/src/pipeline/rtp/depayloader.rs
@@ -116,7 +116,7 @@ impl<T: Depacketizer + Default + 'static> Depayloader for BufferedDepayloader<T>
             pts: packet.timestamp,
             dts: None,
             kind: self.kind,
-            present: true,
+            decode_only: false,
         });
 
         trace!(chunk=?new_chunk, "RTP depayloader produced a new chunk");
@@ -154,7 +154,7 @@ impl<T: Depacketizer + Default + 'static> Depayloader for SimpleDepayloader<T> {
             pts: packet.timestamp,
             dts: None,
             kind: self.kind,
-            present: true,
+            decode_only: false,
         });
 
         if packet.packet.header.marker {

--- a/smelter-core/src/pipeline/rtp/depayloader/aac_depayloader.rs
+++ b/smelter-core/src/pipeline/rtp/depayloader/aac_depayloader.rs
@@ -94,7 +94,7 @@ impl Depayloader for AacDepayloader {
                 data: payload,
                 dts: None,
                 kind: MediaKind::Audio(AudioCodec::Aac),
-                present: true,
+                decode_only: false,
             };
             trace!(?chunk, "RTP AAC depayloader produced a new chunk");
             chunks.push(EncodedInputEvent::Chunk(chunk));

--- a/smelter-core/src/pipeline/utils/h264_au_splitter.rs
+++ b/smelter-core/src/pipeline/utils/h264_au_splitter.rs
@@ -28,18 +28,18 @@ impl H264AuSplitter {
             .parser
             .parse(&chunk.data, Some(chunk.pts.as_micros() as u64))?;
 
-        self.process_au(access_units, chunk.present)
+        self.process_au(access_units, chunk.decode_only)
     }
 
     pub fn flush(&mut self) -> Result<Vec<EncodedInputChunk>, AuSplitterError> {
         let access_units = self.parser.flush()?;
-        self.process_au(access_units, true)
+        self.process_au(access_units, false)
     }
 
     fn process_au(
         &mut self,
         access_units: Vec<AccessUnit>,
-        present: bool,
+        decode_only: bool,
     ) -> Result<Vec<EncodedInputChunk>, AuSplitterError> {
         let mut chunks = Vec::new();
         for au in access_units {
@@ -63,7 +63,7 @@ impl H264AuSplitter {
                 pts: Duration::from_micros(pts),
                 dts: None,
                 kind: MediaKind::Video(VideoCodec::H264),
-                present,
+                decode_only,
             });
         }
 

--- a/smelter-core/src/pipeline/utils/input_sync/item.rs
+++ b/smelter-core/src/pipeline/utils/input_sync/item.rs
@@ -42,6 +42,6 @@ impl InputSyncItem for EncodedInputChunk {
     }
 
     fn mark_decode_only(&mut self) {
-        self.present = false;
+        self.decode_only = true;
     }
 }

--- a/smelter-core/src/protocols/channel/encoded_input.rs
+++ b/smelter-core/src/protocols/channel/encoded_input.rs
@@ -11,8 +11,8 @@ pub struct EncodedInputChunk {
 
     /// Sometimes we need to send data to the decoder, so the next chunks can
     /// be decoded correctly, but resulting frames should not be sent to the queue.
-    /// In those cases this field should be set to false.
-    pub present: bool,
+    /// In those cases this field should be set to true.
+    pub decode_only: bool,
 }
 
 impl fmt::Debug for EncodedInputChunk {
@@ -24,7 +24,7 @@ impl fmt::Debug for EncodedInputChunk {
             .field("pts", &self.pts)
             .field("dts", &self.dts)
             .field("kind", &self.kind)
-            .field("present", &self.present)
+            .field("decode_only", &self.decode_only)
             .finish()
     }
 }


### PR DESCRIPTION
- Rename field (+ invert bool value)
- Extract logic in a decoder-independent way; up until  now, only h264 supported it
- Old approach: set a flag when receiving chunks that should be dropped, and drop frames that the decoder produced immediately after
- New approach: remember PTS ranges that should be dropped, and check if frame is in that range