### PR TITLE
Mp4 input - ensure that frame for pts=0 is not `decode_only`

### DIFF
--- a/smelter-core/src/pipeline/mp4/reader.rs
+++ b/smelter-core/src/pipeline/mp4/reader.rs
@@ -327,9 +327,9 @@ impl<Reader: Read + Seek + Send + 'static> TrackChunks<'_, Reader> {
         // sample before the seek point so the decoder can build up its reference
         // frames.
         //
-        // There needs to at least one chunk which PTS <= 0, for most mp4 the first frame
-        // will have exactly 0, pts but if not we want to avoid empty frame at the start,
-        // especially when looping
+        // There needs to be at least one chunk whose PTS <= 0. For most MP4s the first frame
+        // has exactly 0 PTS, but if not we want to avoid an empty frame at the start,
+        // especially when looping.
         let decode_only = pts + sample_duration <= Timestamp::ZERO;
 
         let chunk = EncodedInputChunk {

--- a/smelter-core/src/pipeline/mp4/reader.rs
+++ b/smelter-core/src/pipeline/mp4/reader.rs
@@ -325,9 +325,12 @@ impl<Reader: Read + Seek + Send + 'static> TrackChunks<'_, Reader> {
 
         // When seeking in video, we start reading from the nearest sync (keyframe)
         // sample before the seek point so the decoder can build up its reference
-        // frames. Samples presented before the seek point are only needed for
-        // decoding and should not be presented.
-        let decode_only = pts.is_negative();
+        // frames.
+        //
+        // There needs to at least one chunk which PTS <= 0, for most mp4 the first frame
+        // will have exactly 0, pts but if not we want to avoid empty frame at the start,
+        // especially when looping
+        let decode_only = pts + sample_duration <= Timestamp::ZERO;
 
         let chunk = EncodedInputChunk {
             data: sample.bytes,


### PR DESCRIPTION
If `elst` box has a non-zero media stream, the first frame PTS may not be exactly zero. Our queue always takes older frames, which might lead to missing the first frame for mp4s like this (especially problematic for looping)

If we send at least one chunk where pts <= 0 with decode_only false, we guarantee at most one negative pts frame in the queue (if pts hits exactly zero, there should be no negative PTS values)